### PR TITLE
tenant-controller: add namespace/rbac sync on update of tenant

### DIFF
--- a/poc/README.md
+++ b/poc/README.md
@@ -54,3 +54,11 @@ devtk build                               # build all binaries from all projects
 devtk build tenants-ctl                   # build the specified binary
 devtk build tenant-controller/tenants-ctl # build the specified binary within project explicitly specified
 ```
+
+#### Pack Container Image
+
+```
+devtk pack                              # pack all container images from all projects
+devtk pack tenants                      # pack the specified container image
+devtk pack tenant-controller/tenants    # pack the specified container image within project explicitly specified
+```

--- a/poc/tenant-controller/data/manifests/rbac.yaml
+++ b/poc/tenant-controller/data/manifests/rbac.yaml
@@ -11,7 +11,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
-  verbs: ["get", "list", "watch", "create", "update", "patch"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["create"]


### PR DESCRIPTION
Refactor the code and add the functionality to:

- synchronize namespaces when Tenant object is updated, including namespace deletion/creation;
- synchronize RBAC inside namespaces when Tenant object is updated, for tenant admins;
- add OwnerReferences to be managed by garbage collector.