### PR TITLE
apply namespace template into tenant namespaces

### DIFF
--- a/poc/tenant-controller/data/manifests/sample-nstemplate.yaml
+++ b/poc/tenant-controller/data/manifests/sample-nstemplate.yaml
@@ -2,7 +2,7 @@
 apiVersion: tenants.k8s.io/v1alpha1
 kind: NamespaceTemplate
 metadata:
-  name: sample1
+  name: restricted
 spec:
   templates:
   - apiVersion: rbac.authorization.k8s.io/v1

--- a/poc/tenant-controller/data/manifests/sample-tenant.yaml
+++ b/poc/tenant-controller/data/manifests/sample-tenant.yaml
@@ -2,12 +2,10 @@
 apiVersion: tenants.k8s.io/v1alpha1
 kind: Tenant
 metadata:
-  name: sample-tenant-a 
+  name: tenant-a 
 spec:
   namespaces:
-      - name: sample-tenant-a-ns-1
-        template: dummy
-      - name: sample-tenant-a-ns-2
-        template: dummy
-
+      - name: ns-1
+      - name: ns-2
+        template: restricted
 

--- a/poc/tenant-controller/go.sum
+++ b/poc/tenant-controller/go.sum
@@ -189,6 +189,7 @@ k8s.io/apimachinery v0.0.0-20181127025237-2b1284ed4c93 h1:tT6oQBi0qwLbbZSfDkdIsb
 k8s.io/apimachinery v0.0.0-20181127025237-2b1284ed4c93/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
 k8s.io/apimachinery v0.0.0-20190402215020-10bf64c7018d h1:2NbCIw30UqwxPyU1HFb8Y0YPX3VJsJt82fuFrSgTrx8=
 k8s.io/apimachinery v0.0.0-20190415132420-07d458fe0356 h1:IneIG23feOS594nIIsJVRUHK50ALz/g0/Co/3iML7RI=
+k8s.io/apimachinery v0.0.0-20190416092415-3370b4aef5d6 h1:kD21h6tGK/yzgTxdmtEbxHgYIiCIAdQ04nLmP+axsEM=
 k8s.io/client-go v10.0.0+incompatible h1:F1IqCqw7oMBzDkqlcBymRq1450wD0eNqLE9jzUrIi34=
 k8s.io/client-go v10.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/klog v0.2.0 h1:0ElL0OHzF3N+OhoJTL0uca20SxtYt4X4+bzHeqrB83c=

--- a/poc/tenant-controller/pkg/controllers/tenants/kubectl.go
+++ b/poc/tenant-controller/pkg/controllers/tenants/kubectl.go
@@ -17,7 +17,6 @@ import (
 	"os/exec"
 
 	"github.com/golang/glog"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8srt "k8s.io/apimachinery/pkg/runtime"
 	json "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -40,10 +39,7 @@ func newKubeCtl() *kubectlHelper {
 func (k *kubectlHelper) addObjects(objs ...k8srt.Object) *kubectlHelper {
 	s := json.NewSerializer(json.DefaultMetaFactory, scheme.Scheme, scheme.Scheme, true)
 	for _, obj := range objs {
-		copied := obj.DeepCopyObject()
-		// clear namespace as it will be set on kubectl command line.
-		copied.(metav1.Object).SetNamespace("")
-		if err := s.Encode(copied, &k.buf); err != nil {
+		if err := s.Encode(obj, &k.buf); err != nil {
 			panic(err)
 		}
 	}


### PR DESCRIPTION
A simple implementation for applying policy objects defined in NamespaceTemplate into tenant namespaces:

- The NamespaceTemplate must exist if it's referenced by the Tenant, otherwise creating Tenant will fail;
- NamespaceTemplate is only applied when Tenant is created or updated;
- Updates on NamespaceTemplate won't be applied to Tenant namespaces which are already created.

Behavior changes since last commit:

-  The tenant namespace name is constructed with tenant name as prefix, e.g. `tenant-a` puts `ns-1` in Tenant CR, the final namespace name will be `tenant-a-ns-1`.
