### PR TITLE
Add watcher for tenantAdminNamespace

### DIFF
--- a/tenant/pkg/controller/tenant/tenant_controller.go
+++ b/tenant/pkg/controller/tenant/tenant_controller.go
@@ -65,6 +65,14 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	if err != nil {
 		return err
 	}
+
+	// Watch for changes to namespaces
+	err = c.Watch(&source.Kind{Type: &corev1.Namespace{}}, &handler.EnqueueRequestForOwner{
+		OwnerType: &tenancyv1alpha1.Tenant{},
+	})
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/tenant/pkg/controller/tenant/tenant_controller_test.go
+++ b/tenant/pkg/controller/tenant/tenant_controller_test.go
@@ -80,6 +80,10 @@ func TestReconcile(t *testing.T) {
 	g.Eventually(func() error { return c.Get(context.TODO(), nskey, adminNs) }, timeout).
 		Should(gomega.Succeed())
 
+	// Delete the namespace and expect reconcile to be called to create the namespace again
 	g.Expect(c.Delete(context.TODO(), adminNs)).NotTo(gomega.HaveOccurred())
+	g.Eventually(requests, timeout).Should(gomega.Receive(gomega.Equal(expectedRequest)))
+	g.Eventually(func() error { return c.Get(context.TODO(), nskey, adminNs) }, timeout).
+		Should(gomega.Succeed())
 
 }


### PR DESCRIPTION
This change adds watcher for tenantAdminNamespace. As a result, if tenantAdminNamespace is deleted for some reason, the tenant controller will create a new one with the same name.