### PR TITLE
Add Name field in TenantNamespace CRD

### DIFF
--- a/tenant/config/crds/tenancy_v1alpha1_tenantnamespace.yaml
+++ b/tenant/config/crds/tenancy_v1alpha1_tenantnamespace.yaml
@@ -27,6 +27,11 @@ spec:
         metadata:
           type: object
         spec:
+          properties:
+            name:
+              type: string
+          required:
+          - name
           type: object
         status:
           type: object

--- a/tenant/config/rbac/rbac_role.yaml
+++ b/tenant/config/rbac/rbac_role.yaml
@@ -34,6 +34,15 @@ rules:
   - update
   - patch
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
   - tenancy.x-k8s.io
   resources:
   - tenantnamespaces

--- a/tenant/pkg/apis/tenancy/v1alpha1/tenantnamespace_types.go
+++ b/tenant/pkg/apis/tenancy/v1alpha1/tenantnamespace_types.go
@@ -20,13 +20,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // TenantNamespaceSpec defines the desired state of TenantNamespace
 type TenantNamespaceSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
+	Name string `json:"name"`
 }
 
 // TenantNamespaceStatus defines the observed state of TenantNamespace


### PR DESCRIPTION
This change adds Name field in TenantNamespace CRD plus corresponding controller code for reconciling the tenant namespace CR. A few notes:

1) Controller will add OwnerReference to TenantNamespace CR for the newly created tenant namespace; 
2) Controller will add OwnerReference to TenantNamespace CR for existing namespace if the name matches instead of reporting error (not in this change);
3) One namespace can only be owned by one TenantNamespace CR. An admission Webhook will be added later to guarantee this;
4) Controller will not add prefix to the namespace name. It is up to user to resolve any naming conflict. 
5) TenantNamespace CR's namespace has be one tenant admin namespace. An admission Webhook will be added later to guarantee this;