### PR TITLE
Add scaffolding code for TenantNameSpace CRD Webhook

### DIFF
--- a/tenant/config/manager/all_in_one.yaml
+++ b/tenant/config/manager/all_in_one.yaml
@@ -6,6 +6,37 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: tenant-system
 ---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    alpha.admissionwebhook.cert-manager.io: "true"
+  creationTimestamp: null
+  name: tenant-validating-webhook-cfg
+webhooks:
+- clientConfig:
+    caBundle: XG4=
+    service:
+      name: webhook-server-service
+      namespace: tenant-system
+      path: /validating-create-update-tenantnamespace
+  failurePolicy: Fail
+  name: validating-create-update-tenantnamespace.x-k8s.io
+  namespaceSelector:
+    matchExpressions:
+    - key: control-plane
+      operator: DoesNotExist
+  rules:
+  - apiGroups:
+    - tenancy
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - tenantnamespaces
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/tenant/config/manager/all_in_one.yaml
+++ b/tenant/config/manager/all_in_one.yaml
@@ -81,7 +81,7 @@ spec:
       containers:
       - command:
         - /manager
-        image: vrgf2003/tenant:latest
+        image: tenant-controller:latest
         imagePullPolicy: Always
         name: manager
         env:

--- a/tenant/config/manager/manager.yaml
+++ b/tenant/config/manager/manager.yaml
@@ -50,7 +50,7 @@ spec:
       containers:
       - command:
         - /manager
-        image: vrgf2003/tenant:latest
+        image: tenant-controller:latest
         imagePullPolicy: Always
         name: manager
         env:

--- a/tenant/config/rbac/rbac_role_binding.yaml
+++ b/tenant/config/rbac/rbac_role_binding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: system
+  namespace: tenant-system

--- a/tenant/config/samples/tenancy_v1alpha1_tenantnamespace.yaml
+++ b/tenant/config/samples/tenancy_v1alpha1_tenantnamespace.yaml
@@ -6,4 +6,4 @@ metadata:
   name: tenantnamespace-sample
 spec:
   # Add fields here
-  foo: bar
+  name: t1-ns1

--- a/tenant/config/webhook/webhookmanifests.yaml
+++ b/tenant/config/webhook/webhookmanifests.yaml
@@ -1,0 +1,30 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    alpha.admissionwebhook.cert-manager.io: "true"
+  creationTimestamp: null
+  name: tenant-validating-webhook-cfg
+webhooks:
+- clientConfig:
+    caBundle: XG4=
+    service:
+      name: webhook-service
+      namespace: tenant-system
+      path: /validating-create-update-tenantnamespace
+  failurePolicy: Fail
+  name: validating-create-update-tenantnamespace.x-k8s.io
+  namespaceSelector:
+    matchExpressions:
+    - key: control-plane
+      operator: DoesNotExist
+  rules:
+  - apiGroups:
+    - tenancy
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - tenantnamespaces

--- a/tenant/pkg/apis/tenancy/v1alpha1/tenantnamespace_types.go
+++ b/tenant/pkg/apis/tenancy/v1alpha1/tenantnamespace_types.go
@@ -53,6 +53,11 @@ type TenantNamespaceList struct {
 	Items           []TenantNamespace `json:"items"`
 }
 
+// +kubebuilder:webhook:groups=tenancy,versions=v1alpha1,resources=tenantnamespaces,verbs=create;update
+// +kubebuilder:webhook:name=validating-create-update-tenantnamespace.x-k8s.io
+// +kubebuilder:webhook:path=/validating-create-update-tenantnamespace
+// +kubebuilder:webhook:type=validating,failure-policy=fail
+
 func init() {
 	SchemeBuilder.Register(&TenantNamespace{}, &TenantNamespaceList{})
 }

--- a/tenant/pkg/webhook/add_default_server.go
+++ b/tenant/pkg/webhook/add_default_server.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	server "github.com/multi-tenancy/tenant/pkg/webhook/default_server"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create webhook servers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, server.Add)
+}

--- a/tenant/pkg/webhook/default_server/add_validating_tenantnamespace.go
+++ b/tenant/pkg/webhook/default_server/add_validating_tenantnamespace.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultserver
+
+import (
+	"fmt"
+
+	"github.com/multi-tenancy/tenant/pkg/webhook/default_server/tenantnamespace/validating"
+)
+
+func init() {
+	for k, v := range validating.Builders {
+		_, found := builderMap[k]
+		if found {
+			log.V(1).Info(fmt.Sprintf(
+				"conflicting webhook builder names in builder map: %v", k))
+		}
+		builderMap[k] = v
+	}
+	for k, v := range validating.HandlerMap {
+		_, found := HandlerMap[k]
+		if found {
+			log.V(1).Info(fmt.Sprintf(
+				"conflicting webhook builder names in handler map: %v", k))
+		}
+		_, found = builderMap[k]
+		if !found {
+			log.V(1).Info(fmt.Sprintf(
+				"can't find webhook builder name %q in builder map", k))
+			continue
+		}
+		HandlerMap[k] = v
+	}
+}

--- a/tenant/pkg/webhook/default_server/server.go
+++ b/tenant/pkg/webhook/default_server/server.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultserver
+
+import (
+	"fmt"
+	"os"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+)
+
+var (
+	log        = logf.Log.WithName("default_server")
+	builderMap = map[string]*builder.WebhookBuilder{}
+	// HandlerMap contains all admission webhook handlers.
+	HandlerMap = map[string][]admission.Handler{}
+)
+
+// Add adds itself to the manager
+func Add(mgr manager.Manager) error {
+	ns := os.Getenv("POD_NAMESPACE")
+	if len(ns) == 0 {
+		ns = "default"
+	}
+	secretName := os.Getenv("SECRET_NAME")
+	if len(secretName) == 0 {
+		secretName = "webhook-server-secret"
+	}
+
+	svr, err := webhook.NewServer("foo-admission-server", mgr, webhook.ServerOptions{
+		// TODO(user): change the configuration of ServerOptions based on your need.
+		Port:    9876,
+		CertDir: "/tmp/cert",
+		BootstrapOptions: &webhook.BootstrapOptions{
+			Secret: &types.NamespacedName{
+				Namespace: ns,
+				Name:      secretName,
+			},
+
+			Service: &webhook.Service{
+				Namespace: ns,
+				Name:      "webhook-server-service",
+				// Selectors should select the pods that runs this webhook server.
+				Selectors: map[string]string{
+					"control-plane": "controller-manager",
+				},
+			},
+			ValidatingWebhookConfigName: "tenant-validating-webhook-cfg",
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	var webhooks []webhook.Webhook
+	for k, builder := range builderMap {
+		handlers, ok := HandlerMap[k]
+		if !ok {
+			log.V(1).Info(fmt.Sprintf("can't find handlers for builder: %v", k))
+			handlers = []admission.Handler{}
+		}
+		wh, err := builder.
+			Handlers(handlers...).
+			WithManager(mgr).
+			Build()
+		if err != nil {
+			return err
+		}
+		webhooks = append(webhooks, wh)
+	}
+
+	return svr.Register(webhooks...)
+}

--- a/tenant/pkg/webhook/default_server/tenantnamespace/validating/create_update_webhook.go
+++ b/tenant/pkg/webhook/default_server/tenantnamespace/validating/create_update_webhook.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validating
+
+import (
+	tenancyv1alpha1 "github.com/multi-tenancy/tenant/pkg/apis/tenancy/v1alpha1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+)
+
+func init() {
+	builderName := "validating-create-update-tenantnamespace"
+	Builders[builderName] = builder.
+		NewWebhookBuilder().
+		Name(builderName+".x-k8s.io").
+		Path("/"+builderName).
+		Validating().
+		Operations(admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update).
+		FailurePolicy(admissionregistrationv1beta1.Fail).
+		ForType(&tenancyv1alpha1.TenantNamespace{})
+}

--- a/tenant/pkg/webhook/default_server/tenantnamespace/validating/tenantnamespace_create_update_handler.go
+++ b/tenant/pkg/webhook/default_server/tenantnamespace/validating/tenantnamespace_create_update_handler.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validating
+
+import (
+	"context"
+	"net/http"
+
+	tenancyv1alpha1 "github.com/multi-tenancy/tenant/pkg/apis/tenancy/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+)
+
+func init() {
+	webhookName := "validating-create-update-tenantnamespace"
+	if HandlerMap[webhookName] == nil {
+		HandlerMap[webhookName] = []admission.Handler{}
+	}
+	HandlerMap[webhookName] = append(HandlerMap[webhookName], &TenantNamespaceCreateUpdateHandler{})
+}
+
+// TenantNamespaceCreateUpdateHandler handles TenantNamespace
+type TenantNamespaceCreateUpdateHandler struct {
+	// To use the client, you need to do the following:
+	// - uncomment it
+	// - import sigs.k8s.io/controller-runtime/pkg/client
+	// - uncomment the InjectClient method at the bottom of this file.
+	// Client  client.Client
+
+	// Decoder decodes objects
+	Decoder types.Decoder
+}
+
+func (h *TenantNamespaceCreateUpdateHandler) validatingTenantNamespaceFn(ctx context.Context, obj *tenancyv1alpha1.TenantNamespace) (bool, string, error) {
+	// TODO(user): implement your admission logic
+	return true, "allowed to be admitted", nil
+}
+
+var _ admission.Handler = &TenantNamespaceCreateUpdateHandler{}
+
+// Handle handles admission requests.
+func (h *TenantNamespaceCreateUpdateHandler) Handle(ctx context.Context, req types.Request) types.Response {
+	obj := &tenancyv1alpha1.TenantNamespace{}
+
+	err := h.Decoder.Decode(req, obj)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusBadRequest, err)
+	}
+
+	allowed, reason, err := h.validatingTenantNamespaceFn(ctx, obj)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusInternalServerError, err)
+	}
+	return admission.ValidationResponse(allowed, reason)
+}
+
+//var _ inject.Client = &TenantNamespaceCreateUpdateHandler{}
+//
+//// InjectClient injects the client into the TenantNamespaceCreateUpdateHandler
+//func (h *TenantNamespaceCreateUpdateHandler) InjectClient(c client.Client) error {
+//	h.Client = c
+//	return nil
+//}
+
+var _ inject.Decoder = &TenantNamespaceCreateUpdateHandler{}
+
+// InjectDecoder injects the decoder into the TenantNamespaceCreateUpdateHandler
+func (h *TenantNamespaceCreateUpdateHandler) InjectDecoder(d types.Decoder) error {
+	h.Decoder = d
+	return nil
+}

--- a/tenant/pkg/webhook/default_server/tenantnamespace/validating/webhooks.go
+++ b/tenant/pkg/webhook/default_server/tenantnamespace/validating/webhooks.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validating
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+)
+
+var (
+	// Builders contain admission webhook builders
+	Builders = map[string]*builder.WebhookBuilder{}
+	// HandlerMap contains admission webhook handlers
+	HandlerMap = map[string][]admission.Handler{}
+)


### PR DESCRIPTION
This change adds kubebuilder scaffold codes for TenantNamespace CRD webhook. i.e., codes generated by following cmd

kubebuilder alpha webhook --group tenancy --version v1alpha1 --kind TenantNamespace --type=validating --operations=create,update 

In addition, I change controller manager namespace to tenant-system and 
add an all_in_one.yaml for easy installation. 
The image name will be changed later once we have a formal docker hub account. 