### PR TITLE
Add RequireNamespacePrefix field in Tenant CRD

### DIFF
--- a/tenant/config/crds/tenancy_v1alpha1_tenant.yaml
+++ b/tenant/config/crds/tenancy_v1alpha1_tenant.yaml
@@ -28,6 +28,11 @@ spec:
           type: object
         spec:
           properties:
+            requireNamespacePrefix:
+              description: If set to True, all the namespaces belong to the tenant
+                are requried to have TenantAdminNamespaceName as name prefix. By default,
+                namespace prefix is not required.
+              type: boolean
             tenantAdminNamespaceName:
               description: The name of tenant administration namespace, which is used
                 to create all tenant related policy objects and custom resources.

--- a/tenant/config/default/manager_patch.yaml
+++ b/tenant/config/default/manager_patch.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: controller-manager
+spec:
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 9876
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/cert
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-secret

--- a/tenant/config/rbac/rbac_role_binding.yaml
+++ b/tenant/config/rbac/rbac_role_binding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: tenant-system
+  namespace: system

--- a/tenant/config/webhook/webhookmanifests.yaml
+++ b/tenant/config/webhook/webhookmanifests.yaml
@@ -28,3 +28,20 @@ webhooks:
     - UPDATE
     resources:
     - tenantnamespaces
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    alpha.service.cert-manager.io/serving-cert-secret-name: webhook-server-secret
+  creationTimestamp: null
+  name: webhook-service
+  namespace: tenant-system
+spec:
+  ports:
+  - port: 443
+    targetPort: 9876
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/tenant/pkg/apis/tenancy/v1alpha1/tenant_types.go
+++ b/tenant/pkg/apis/tenancy/v1alpha1/tenant_types.go
@@ -29,6 +29,11 @@ type TenantSpec struct {
 	// all tenant related policy objects and custom resources.
 	// +optional
 	TenantAdminNamespaceName string `json:"tenantAdminNamespaceName,omitempty"`
+	// If set to True, all the namespaces belong to the tenant are requried to
+	// have TenantAdminNamespaceName as name prefix. By default, namespace prefix
+	// is not required.
+	// +optional
+	RequireNamespacePrefix bool `json:"requireNamespacePrefix,omitempty"`
 }
 
 // TenantStatus defines the observed state of Tenant

--- a/tenant/pkg/webhook/webhook.go
+++ b/tenant/pkg/webhook/webhook.go
@@ -35,3 +35,9 @@ func AddToManager(m manager.Manager) error {
 	}
 	return nil
 }
+
+// +kubebuilder:webhook:port=9876,cert-dir=/tmp/cert
+// +kubebuilder:webhook:service=tenant-system:webhook-service,selector=control-plane:controller-manager
+// +kubebuilder:webhook:secret=tenant-system:webhook-server-secret
+// +kubebuilder:webhook:mutating-webhook-config-name=tenant-mutating-webhook-cfg
+// +kubebuilder:webhook:validating-webhook-config-name=tenant-validating-webhook-cfg


### PR DESCRIPTION
This change simply adds a new field in Tenant CRD. This field will be checked by TenantNamespaceCRD later. 

This change also adds all the missing autogenerated webhook code. 
For now, "config/manager/all_in_one.yaml" is going to be the maintained yaml file for installing the controller manager. It contains all small fixes (such as namespace name). 