### PR TITLE
Support optional Name in TenantNamespaceSpec

### DIFF
--- a/tenant/config/crds/tenancy_v1alpha1_tenantnamespace.yaml
+++ b/tenant/config/crds/tenancy_v1alpha1_tenantnamespace.yaml
@@ -29,9 +29,9 @@ spec:
         spec:
           properties:
             name:
+              description: Name of the tenant namespace. If not specified, TenantNamespace
+                CR name will be used.
               type: string
-          required:
-          - name
           type: object
         status:
           type: object

--- a/tenant/pkg/apis/tenancy/v1alpha1/tenantnamespace_types.go
+++ b/tenant/pkg/apis/tenancy/v1alpha1/tenantnamespace_types.go
@@ -22,7 +22,10 @@ import (
 
 // TenantNamespaceSpec defines the desired state of TenantNamespace
 type TenantNamespaceSpec struct {
-	Name string `json:"name"`
+	// Name of the tenant namespace. If not specified, TenantNamespace CR
+	// name will be used.
+	// +optional
+	Name string `json:"name,omitempty"`
 }
 
 // TenantNamespaceStatus defines the observed state of TenantNamespace

--- a/tenant/pkg/controller/tenantnamespace/tenantnamespace_controller.go
+++ b/tenant/pkg/controller/tenantnamespace/tenantnamespace_controller.go
@@ -82,6 +82,9 @@ type ReconcileTenantNamespace struct {
 // Find the tenant namespace name based on prefix requirement
 func (r *ReconcileTenantNamespace) getNamespaceName(prefix bool, instance *tenancyv1alpha1.TenantNamespace) string {
 	name := instance.Spec.Name
+	if name == "" {
+		name = instance.Name
+	}
 	if prefix {
 		name = instance.Namespace + "-" + name
 	}


### PR DESCRIPTION
This change makes Name as an optional field in TenantNamespaceSpec.
Two unit tests are added and test code is refactored. 
