### PR TITLE
Prevent cycles in validating webhook

### DIFF
--- a/incubator/hnc/cmd/manager/main.go
+++ b/incubator/hnc/cmd/manager/main.go
@@ -31,6 +31,7 @@ import (
 
 	tenancy "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/controllers"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/forest"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/validators"
 )
 
@@ -74,7 +75,8 @@ func main() {
 	}
 
 	// Create all reconciling controllers
-	if err := controllers.Create(mgr); err != nil {
+	f := forest.NewForest()
+	if err := controllers.Create(mgr, f); err != nil {
 		setupLog.Error(err, "cannot create controllers")
 		os.Exit(1)
 	}
@@ -83,7 +85,8 @@ func main() {
 	if !novalidation {
 		setupLog.Info("Registering validating webhook (won't work when running locally; use --novalidation)")
 		mgr.GetWebhookServer().Register(validators.HierarchyServingPath, &webhook.Admission{Handler: &validators.Hierarchy{
-			Log: ctrl.Log.WithName("validators").WithName("Hierarchy"),
+			Log:    ctrl.Log.WithName("validators").WithName("Hierarchy"),
+			Forest: f,
 		}})
 	}
 

--- a/incubator/hnc/kind-deploy
+++ b/incubator/hnc/kind-deploy
@@ -1,6 +1,6 @@
 #!/bin/bash
-set -e
 kubectl -n hnc-system delete deployment hnc-controller-manager
+set -e
 # The tag is `kind-local`, not `latest`, since KIND always attempts to re-pull an
 # image with the `latest` tag and this won't work when we're testing locally.
 export IMG=controller:kind-local

--- a/incubator/hnc/pkg/controllers/setup.go
+++ b/incubator/hnc/pkg/controllers/setup.go
@@ -15,9 +15,7 @@ import (
 // configuration object.
 //
 // This function is called both from main.go as well as from the integ tests.
-func Create(mgr ctrl.Manager) error {
-	f := forest.NewForest()
-
+func Create(mgr ctrl.Manager, f *forest.Forest) error {
 	// Create all object reconcillers
 	gvks := []schema.GroupVersionKind{
 		{Group: "", Version: "v1", Kind: "Secret"},

--- a/incubator/hnc/pkg/controllers/suite_test.go
+++ b/incubator/hnc/pkg/controllers/suite_test.go
@@ -34,6 +34,7 @@ import (
 
 	tenancy "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/controllers"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/forest"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -82,7 +83,7 @@ var _ = BeforeSuite(func(done Done) {
 		Scheme: scheme.Scheme,
 	})
 	Expect(err).ToNot(HaveOccurred())
-	err = controllers.Create(k8sManager)
+	err = controllers.Create(k8sManager, forest.NewForest())
 	Expect(err).ToNot(HaveOccurred())
 
 	k8sClient = k8sManager.GetClient()

--- a/incubator/hnc/pkg/validators/hierarchy.go
+++ b/incubator/hnc/pkg/validators/hierarchy.go
@@ -2,13 +2,17 @@ package validators
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/go-logr/logr"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	tenancy "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/forest"
 )
 
 const (
@@ -17,24 +21,77 @@ const (
 	HierarchyServingPath = "/validate-hnc-x-k8s-io-v1alpha1-hierarchies"
 )
 
+// Note: the validating webhook FAILS CLOSED. This means that if the webhook goes down, all further
+// changes to the hierarchy are forbidden. However, new objects will still be propagated according
+// to the existing hierarchy (unless the reconciler is down too).
+//
 // +kubebuilder:webhook:path=/validate-hnc-x-k8s-io-v1alpha1-hierarchies,mutating=false,failurePolicy=fail,groups="hnc.x-k8s.io",resources=hierarchies,verbs=create;update,versions=v1alpha1,name=hierarchies.hnc.x-k8s.io
 
 type Hierarchy struct {
 	Log     logr.Logger
+	Forest  *forest.Forest
 	client  client.Client
 	decoder *admission.Decoder
 }
 
 func (v *Hierarchy) Handle(ctx context.Context, req admission.Request) admission.Response {
-	log := v.Log.WithValues("namespace", req.Namespace)
-	log.Info("Validating")
-	hier := &tenancy.Hierarchy{}
-	err := v.decoder.Decode(req, hier)
+	log := v.Log.WithValues("ns", req.Namespace)
+
+	if isHNCServiceAccount(req.AdmissionRequest.UserInfo) {
+		log.Info("Allowed change by HNC SA")
+		return admission.Allowed("Change by HNC SA")
+	}
+
+	inst := &tenancy.Hierarchy{}
+	err := v.decoder.Decode(req, inst)
 	if err != nil {
+		log.Error(err, "Couldn't decode request")
 		return admission.Errored(http.StatusBadRequest, err)
 	}
-	log.Info("Checking", "contents", hier)
-	return admission.Allowed("hey ho")
+
+	return v.handle(ctx, log, inst)
+}
+
+// handle implements the non-webhook-y businesss logic of this validator, allowing it to be more
+// easily unit tested (ie without constructing an admission.Request, setting up user infos, etc).
+func (v *Hierarchy) handle(ctx context.Context, log logr.Logger, inst *tenancy.Hierarchy) admission.Response {
+	nnm := inst.ObjectMeta.Namespace
+	pnm := inst.Spec.Parent
+	if pnm == "" {
+		log.Info("Allowed", "parent", "<none>")
+		return admission.Allowed("No parent set")
+	}
+
+	v.Forest.Lock()
+	defer v.Forest.Unlock()
+	ns := v.Forest.Get(nnm)
+	pns := v.Forest.Get(pnm)
+	if !pns.Exists() {
+		// TODO: only allow if sufficient privileges
+		log.Info("Allowed missing", "parent", pnm)
+		return admission.Allowed("Parent does not exist yet")
+	}
+	if reason := ns.CanSetParent(pns); reason != "" {
+		log.Info("Rejected", "parent", pnm, "reason", reason)
+		return admission.Denied("Illegal parent: " + reason)
+	}
+	log.Info("Allowed", "parent", pnm)
+	return admission.Allowed("Parent is legal")
+}
+
+// isHNCServiceAccount is inspired by isGKServiceAccount from open-policy-agent/gatekeeper.
+func isHNCServiceAccount(user authenticationv1.UserInfo) bool {
+	ns, found := os.LookupEnv("POD_NAMESPACE")
+	if !found {
+		ns = "hnc-system"
+	}
+	saGroup := fmt.Sprintf("system:serviceaccounts:%s", ns)
+	for _, g := range user.Groups {
+		if g == saGroup {
+			return true
+		}
+	}
+	return false
 }
 
 func (v *Hierarchy) InjectClient(c client.Client) error {

--- a/incubator/hnc/pkg/validators/hierarchy_test.go
+++ b/incubator/hnc/pkg/validators/hierarchy_test.go
@@ -1,0 +1,55 @@
+package validators
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/forest"
+)
+
+func TestHierarchy(t *testing.T) {
+	f := forest.NewForest()
+	foo := f.Get("foo")
+	bar := f.Get("bar")
+	baz := f.Get("baz")
+	foo.SetExists()
+	bar.SetExists()
+	baz.SetExists()
+	bar.SetParent(foo)
+	h := &Hierarchy{Forest: f}
+	l := zap.Logger(false)
+
+	tests := []struct {
+		name string
+		nnm  string
+		pnm  string
+		fail bool
+	}{
+		{name: "ok", nnm: "foo", pnm: "baz"},
+		{name: "missing parent", nnm: "foo", pnm: "brumpf"},
+		{name: "self-cycle", nnm: "foo", pnm: "foo", fail: true},
+		{name: "other cycle", nnm: "foo", pnm: "bar", fail: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup
+			g := NewGomegaWithT(t)
+			hier := &api.Hierarchy{Spec: api.HierarchySpec{Parent: tc.pnm}}
+			hier.ObjectMeta.Name = api.Singleton
+			hier.ObjectMeta.Namespace = tc.nnm
+
+			// Test
+			got := h.handle(context.Background(), l, hier)
+
+			// Report
+			reason := got.AdmissionResponse.Result.Reason
+			code := got.AdmissionResponse.Result.Code
+			t.Logf("Got reason %q, code %d", reason, code)
+			g.Expect(got.AdmissionResponse.Allowed).ShouldNot(Equal(tc.fail))
+		})
+	}
+}


### PR DESCRIPTION
This is the first nontrivial validating webhook. It determines if a
change would cause an error condition due to the structure of the
hierarchy and, if so, returns the error.

Tested: manually plus new unit tests