### PR TITLE
Fix a small bug

### DIFF
--- a/tenant/pkg/controller/tenantnamespace/tenantnamespace_controller.go
+++ b/tenant/pkg/controller/tenantnamespace/tenantnamespace_controller.go
@@ -103,8 +103,8 @@ func (r *ReconcileTenantNamespace) updateNamespace(ns *corev1.Namespace, tenantA
 		nsClone.OwnerReferences = append(nsClone.OwnerReferences, *ownerRef)
 		if nsClone.Annotations == nil {
 			nsClone.Annotations = make(map[string]string)
-			nsClone.Annotations[TenantAdminNamespaceAnnotation] = *tenantAdminNamespaceName
 		}
+		nsClone.Annotations[TenantAdminNamespaceAnnotation] = *tenantAdminNamespaceName
 		updateErr := r.Update(context.TODO(), nsClone)
 		if updateErr == nil {
 			return nil


### PR DESCRIPTION
This change fixes a problem such that if namespace has other annotations, the TenantAdminNamespaceAnnotation will not be added.