### PR TITLE
Add validation admission checks for TenantNamespace - Part I

### DIFF
--- a/tenant/pkg/webhook/default_server/tenantnamespace/validating/tenantnamespace_create_update_handler.go
+++ b/tenant/pkg/webhook/default_server/tenantnamespace/validating/tenantnamespace_create_update_handler.go
@@ -48,7 +48,7 @@ type TenantNamespaceCreateUpdateHandler struct {
 }
 
 func (h *TenantNamespaceCreateUpdateHandler) validateTenantNamespaceUpdate(obj *tenancyv1alpha1.TenantNamespace, oldobj *tenancyv1alpha1.TenantNamespace) field.ErrorList {
-	allErrs := apivalidation.ValidateObjectMetaUpdate(&obj.ObjectMeta, &oldobj.ObjectMeta, field.NewPath("metadata"))
+	allErrs := field.ErrorList{}
 	if obj.Spec.Name != oldobj.Spec.Name {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec").Child("name"), fmt.Sprintf("cannot modify the name field in spec after initial creation (attempting to change from %s to %s)", oldobj.Spec.Name, obj.Spec.Name)))
 	}

--- a/tenant/pkg/webhook/default_server/tenantnamespace/validating/tenantnamespace_create_update_handler.go
+++ b/tenant/pkg/webhook/default_server/tenantnamespace/validating/tenantnamespace_create_update_handler.go
@@ -21,6 +21,10 @@ import (
 	"net/http"
 
 	tenancyv1alpha1 "github.com/multi-tenancy/tenant/pkg/apis/tenancy/v1alpha1"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
@@ -36,19 +40,45 @@ func init() {
 
 // TenantNamespaceCreateUpdateHandler handles TenantNamespace
 type TenantNamespaceCreateUpdateHandler struct {
-	// To use the client, you need to do the following:
-	// - uncomment it
-	// - import sigs.k8s.io/controller-runtime/pkg/client
-	// - uncomment the InjectClient method at the bottom of this file.
-	// Client  client.Client
+	Client client.Client
 
 	// Decoder decodes objects
 	Decoder types.Decoder
 }
 
-func (h *TenantNamespaceCreateUpdateHandler) validatingTenantNamespaceFn(ctx context.Context, obj *tenancyv1alpha1.TenantNamespace) (bool, string, error) {
-	// TODO(user): implement your admission logic
-	return true, "allowed to be admitted", nil
+func (h *TenantNamespaceCreateUpdateHandler) validateTenantNamespaceUpdate(obj *tenancyv1alpha1.TenantNamespace, oldobj *tenancyv1alpha1.TenantNamespace) field.ErrorList {
+	allErrs := apivalidation.ValidateObjectMetaUpdate(&obj.ObjectMeta, &oldobj.ObjectMeta, field.NewPath("metadata"))
+	if obj.Spec.Name != oldobj.Spec.Name {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec").Child("name"), "update to name field in spec is forbiddern"))
+	}
+	return allErrs
+}
+
+func validateTenantNamespaceName(name string, prefix bool) []string {
+	// We don't have name requirement for now
+	return nil
+}
+func (h *TenantNamespaceCreateUpdateHandler) validateTenantNamespaceCreate(obj *tenancyv1alpha1.TenantNamespace) field.ErrorList {
+	path := field.NewPath("metadata")
+	allErrs := apivalidation.ValidateObjectMeta(&obj.ObjectMeta, true, validateTenantNamespaceName, path)
+
+	// Fetch tenant list
+	tenantList := &tenancyv1alpha1.TenantList{}
+	err := h.Client.List(context.TODO(), &client.ListOptions{}, tenantList)
+	if err != nil {
+		allErrs = append(allErrs, field.Invalid(path.Child("Namespace"), obj.Namespace, "cannot validate namespace because cannot get tenant list"))
+	}
+	foundTenant := false
+	for _, each := range tenantList.Items {
+		if each.Spec.TenantAdminNamespaceName == obj.Namespace {
+			foundTenant = true
+			break
+		}
+	}
+	if !foundTenant {
+		allErrs = append(allErrs, field.Invalid(path.Child("Namespace"), obj.Namespace, "namespace has to be a tenant admin namespace"))
+	}
+	return allErrs
 }
 
 var _ admission.Handler = &TenantNamespaceCreateUpdateHandler{}
@@ -61,21 +91,32 @@ func (h *TenantNamespaceCreateUpdateHandler) Handle(ctx context.Context, req typ
 	if err != nil {
 		return admission.ErrorResponse(http.StatusBadRequest, err)
 	}
-
-	allowed, reason, err := h.validatingTenantNamespaceFn(ctx, obj)
-	if err != nil {
-		return admission.ErrorResponse(http.StatusInternalServerError, err)
+	switch req.AdmissionRequest.Operation {
+	case admissionv1beta1.Create:
+		if createErrorList := h.validateTenantNamespaceCreate(obj); len(createErrorList) > 0 {
+			return admission.ErrorResponse(http.StatusUnprocessableEntity, createErrorList.ToAggregate())
+		}
+	case admissionv1beta1.Update:
+		oldobj := &tenancyv1alpha1.TenantNamespace{}
+		if err := h.Decoder.Decode(types.Request{
+			AdmissionRequest: &admissionv1beta1.AdmissionRequest{Object: req.AdmissionRequest.OldObject},
+		}, oldobj); err != nil {
+			return admission.ErrorResponse(http.StatusBadRequest, err)
+		}
+		if updateErrorList := h.validateTenantNamespaceUpdate(obj, oldobj); len(updateErrorList) > 0 {
+			return admission.ErrorResponse(http.StatusInternalServerError, updateErrorList.ToAggregate())
+		}
 	}
-	return admission.ValidationResponse(allowed, reason)
+	return admission.ValidationResponse(true, "")
 }
 
-//var _ inject.Client = &TenantNamespaceCreateUpdateHandler{}
-//
-//// InjectClient injects the client into the TenantNamespaceCreateUpdateHandler
-//func (h *TenantNamespaceCreateUpdateHandler) InjectClient(c client.Client) error {
-//	h.Client = c
-//	return nil
-//}
+var _ inject.Client = &TenantNamespaceCreateUpdateHandler{}
+
+// InjectClient injects the client into the TenantNamespaceCreateUpdateHandler
+func (h *TenantNamespaceCreateUpdateHandler) InjectClient(c client.Client) error {
+	h.Client = c
+	return nil
+}
 
 var _ inject.Decoder = &TenantNamespaceCreateUpdateHandler{}
 


### PR DESCRIPTION
This change adds a few validation admission checks for TenantNamespace CR. 

OnCreation: TenantNamespace CR's namespace needs to be a tenantadminnamespace.
OnUpdate: TenantNamespace CR's `spec.name` cannot be changed. 