### PR TITLE
Add scaffolding code for Tenant CRD webhook

### DIFF
--- a/tenant/pkg/webhook/default_server/add_validating_tenant.go
+++ b/tenant/pkg/webhook/default_server/add_validating_tenant.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultserver
+
+import (
+	"fmt"
+
+	"github.com/multi-tenancy/tenant/pkg/webhook/default_server/tenant/validating"
+)
+
+func init() {
+	for k, v := range validating.Builders {
+		_, found := builderMap[k]
+		if found {
+			log.V(1).Info(fmt.Sprintf(
+				"conflicting webhook builder names in builder map: %v", k))
+		}
+		builderMap[k] = v
+	}
+	for k, v := range validating.HandlerMap {
+		_, found := HandlerMap[k]
+		if found {
+			log.V(1).Info(fmt.Sprintf(
+				"conflicting webhook builder names in handler map: %v", k))
+		}
+		_, found = builderMap[k]
+		if !found {
+			log.V(1).Info(fmt.Sprintf(
+				"can't find webhook builder name %q in builder map", k))
+			continue
+		}
+		HandlerMap[k] = v
+	}
+}

--- a/tenant/pkg/webhook/default_server/tenant/validating/create_update_webhook.go
+++ b/tenant/pkg/webhook/default_server/tenant/validating/create_update_webhook.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validating
+
+import (
+	tenancyv1alpha1 "github.com/multi-tenancy/tenant/pkg/apis/tenancy/v1alpha1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+)
+
+func init() {
+	builderName := "validating-create-update-tenant"
+	Builders[builderName] = builder.
+		NewWebhookBuilder().
+		Name(builderName+".x-k8s.io").
+		Path("/"+builderName).
+		Validating().
+		Operations(admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update).
+		FailurePolicy(admissionregistrationv1beta1.Fail).
+		ForType(&tenancyv1alpha1.Tenant{})
+}

--- a/tenant/pkg/webhook/default_server/tenant/validating/tenant_create_update_handler.go
+++ b/tenant/pkg/webhook/default_server/tenant/validating/tenant_create_update_handler.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validating
+
+import (
+	"context"
+	"net/http"
+
+	tenancyv1alpha1 "github.com/multi-tenancy/tenant/pkg/apis/tenancy/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+)
+
+func init() {
+	webhookName := "validating-create-update-tenant"
+	if HandlerMap[webhookName] == nil {
+		HandlerMap[webhookName] = []admission.Handler{}
+	}
+	HandlerMap[webhookName] = append(HandlerMap[webhookName], &TenantCreateUpdateHandler{})
+}
+
+// TenantCreateUpdateHandler handles Tenant
+type TenantCreateUpdateHandler struct {
+	// To use the client, you need to do the following:
+	// - uncomment it
+	// - import sigs.k8s.io/controller-runtime/pkg/client
+	// - uncomment the InjectClient method at the bottom of this file.
+	// Client  client.Client
+
+	// Decoder decodes objects
+	Decoder types.Decoder
+}
+
+func (h *TenantCreateUpdateHandler) validatingTenantFn(ctx context.Context, obj *tenancyv1alpha1.Tenant) (bool, string, error) {
+	// TODO(user): implement your admission logic
+	return true, "allowed to be admitted", nil
+}
+
+var _ admission.Handler = &TenantCreateUpdateHandler{}
+
+// Handle handles admission requests.
+func (h *TenantCreateUpdateHandler) Handle(ctx context.Context, req types.Request) types.Response {
+	obj := &tenancyv1alpha1.Tenant{}
+
+	err := h.Decoder.Decode(req, obj)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusBadRequest, err)
+	}
+
+	allowed, reason, err := h.validatingTenantFn(ctx, obj)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusInternalServerError, err)
+	}
+	return admission.ValidationResponse(allowed, reason)
+}
+
+//var _ inject.Client = &TenantCreateUpdateHandler{}
+//
+//// InjectClient injects the client into the TenantCreateUpdateHandler
+//func (h *TenantCreateUpdateHandler) InjectClient(c client.Client) error {
+//	h.Client = c
+//	return nil
+//}
+
+var _ inject.Decoder = &TenantCreateUpdateHandler{}
+
+// InjectDecoder injects the decoder into the TenantCreateUpdateHandler
+func (h *TenantCreateUpdateHandler) InjectDecoder(d types.Decoder) error {
+	h.Decoder = d
+	return nil
+}

--- a/tenant/pkg/webhook/default_server/tenant/validating/webhooks.go
+++ b/tenant/pkg/webhook/default_server/tenant/validating/webhooks.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validating
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+)
+
+var (
+	// Builders contain admission webhook builders
+	Builders = map[string]*builder.WebhookBuilder{}
+	// HandlerMap contains admission webhook handlers
+	HandlerMap = map[string][]admission.Handler{}
+)


### PR DESCRIPTION
This change adds file generated by the following cmd:

kubebuilder alpha webhook --group tenancy --version v1alpha1 --kind Tenant --type=validating --operations=create,update