### PR TITLE
Add namespace name validity check  for TenantNamespace CR

### DIFF
--- a/tenant/pkg/controller/tenantnamespace/tenantnamespace_controller.go
+++ b/tenant/pkg/controller/tenantnamespace/tenantnamespace_controller.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	tenancyv1alpha1 "github.com/multi-tenancy/tenant/pkg/apis/tenancy/v1alpha1"
-	"github.com/multi-tenancy/tenant/pkg/util"
+	tenantutil "github.com/multi-tenancy/tenant/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -159,7 +159,7 @@ func (r *ReconcileTenantNamespace) Reconcile(request reconcile.Request) (reconci
 	}
 
 	// In case namespace already exists
-	tenantNsName := util.GetTenantNamespaceName(requireNamespacePrefix, instance)
+	tenantNsName := tenantutil.GetTenantNamespaceName(requireNamespacePrefix, instance)
 	expectedOwnerRef := metav1.OwnerReference{
 		APIVersion: tenancyv1alpha1.SchemeGroupVersion.String(),
 		Kind:       "TenantNamespace",

--- a/tenant/pkg/controller/tenantnamespace/tenantnamespace_controller.go
+++ b/tenant/pkg/controller/tenantnamespace/tenantnamespace_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	tenancyv1alpha1 "github.com/multi-tenancy/tenant/pkg/apis/tenancy/v1alpha1"
+	"github.com/multi-tenancy/tenant/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -82,18 +83,6 @@ var _ reconcile.Reconciler = &ReconcileTenantNamespace{}
 type ReconcileTenantNamespace struct {
 	client.Client
 	scheme *runtime.Scheme
-}
-
-// Find the tenant namespace name based on prefix requirement
-func (r *ReconcileTenantNamespace) getNamespaceName(prefix bool, instance *tenancyv1alpha1.TenantNamespace) string {
-	name := instance.Spec.Name
-	if name == "" {
-		name = instance.Name
-	}
-	if prefix {
-		name = instance.Namespace + "-" + name
-	}
-	return name
 }
 
 // Add a ownerReference and tenant admin namespace annotation to input namespace
@@ -170,7 +159,7 @@ func (r *ReconcileTenantNamespace) Reconcile(request reconcile.Request) (reconci
 	}
 
 	// In case namespace already exists
-	tenantNsName := r.getNamespaceName(requireNamespacePrefix, instance)
+	tenantNsName := util.GetTenantNamespaceName(requireNamespacePrefix, instance)
 	expectedOwnerRef := metav1.OwnerReference{
 		APIVersion: tenancyv1alpha1.SchemeGroupVersion.String(),
 		Kind:       "TenantNamespace",

--- a/tenant/pkg/util/tenant_utils.go
+++ b/tenant/pkg/util/tenant_utils.go
@@ -14,13 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package tenantnamespace
 
 import (
 	tenancyv1alpha1 "github.com/multi-tenancy/tenant/pkg/apis/tenancy/v1alpha1"
 )
 
-// Determine the tenant namespace name based on prefix requirement
+// GetTenantNamespaceName returns the tenant namespace name based on following conditions:
+// If the tenant requires all tenant namespaces to have tenant admin namespace name as
+// prefix (i.e., prefix is true), the namespace of the tenantnamespace instance is used
+// to prefix the name in the spec. If the name in the spec is empty, the name of the
+// tenantnamespace instance is used.
 func GetTenantNamespaceName(prefix bool, instance *tenancyv1alpha1.TenantNamespace) string {
 	name := instance.Spec.Name
 	if name == "" {

--- a/tenant/pkg/util/tenant_utils.go
+++ b/tenant/pkg/util/tenant_utils.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	tenancyv1alpha1 "github.com/multi-tenancy/tenant/pkg/apis/tenancy/v1alpha1"
+)
+
+// Determine the tenant namespace name based on prefix requirement
+func GetTenantNamespaceName(prefix bool, instance *tenancyv1alpha1.TenantNamespace) string {
+	name := instance.Spec.Name
+	if name == "" {
+		name = instance.Name
+	}
+	if prefix {
+		name = instance.Namespace + "-" + name
+	}
+	return name
+}

--- a/tenant/pkg/webhook/default_server/tenantnamespace/validating/tenantnamespace_create_update_handler.go
+++ b/tenant/pkg/webhook/default_server/tenantnamespace/validating/tenantnamespace_create_update_handler.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 
 	tenancyv1alpha1 "github.com/multi-tenancy/tenant/pkg/apis/tenancy/v1alpha1"
-	"github.com/multi-tenancy/tenant/pkg/util"
+	tenantutil "github.com/multi-tenancy/tenant/pkg/util"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -78,7 +78,7 @@ func (h *TenantNamespaceCreateUpdateHandler) validateTenantNamespaceCreate(tList
 	if !foundTenant {
 		allErrs = append(allErrs, field.Invalid(path.Child("namespace"), obj.Namespace, "namespace of tenantnamespace CR has to be a tenant admin namespace"))
 	}
-	name := util.GetTenantNamespaceName(requireNamespacePrefix, obj)
+	name := tenantutil.GetTenantNamespaceName(requireNamespacePrefix, obj)
 	for _, msg := range apivalidation.ValidateNamespaceName(name, false) {
 		allErrs = append(allErrs, field.Invalid(path.Child("namespace"), name, msg))
 	}


### PR DESCRIPTION
Let us fail the tenantnamespace CR creation if the to-be-created namespace name is invalid. 
Otherwise, the failure will happen in reconcile loop which is harder to be aware of. 