### PR TITLE
Rename 'patches' to 'patchesStrategicMerge' and update README with missing dependencies install intructions

### DIFF
--- a/incubator/hnc/README.md
+++ b/incubator/hnc/README.md
@@ -26,6 +26,11 @@ or just join a MTWG meeting.
 
 ## Usage
 
+Make sure you have downloaded the following libraries/packages:
+  - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+  - [kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md)
+  - [kubebuilder](https://github.com/kubernetes-sigs/controller-runtime/issues/90#issuecomment-494878527) (_Github issue_). You will most likely encounter this issue when running the tests or any other command.
+
 Install the operator as you would any other kubebuilder controller (eg `make
 install`, `make deploy`). No prebuilt images exist yet.
 
@@ -69,7 +74,7 @@ I do most of my testing in [KIND](https://kind.sigs.k8s.io).
 
 ### Testing on KIND (Kubernetes IN Docker)
 
-* Run `. devenv` to setup your `KUBECONFIG` and `PATH` env vars correctly.
+* Run `. devenv` (or `source devenv`) to setup your `KUBECONFIG` and `PATH` env vars correctly.
 * Run `./kind-reset` to stop any existing KIND cluster and setup a new one,
   including the cert manager required to run the webhooks.
 * Run `make test` to run the controller (excluding the validating webhook)

--- a/incubator/hnc/config/crd/kustomization.yaml
+++ b/incubator/hnc/config/crd/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 - bases/hnc.x-k8s.io_hierarchies.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
-patches:
+patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_hierarchies.yaml

--- a/incubator/hnc/config/default/kustomization.yaml
+++ b/incubator/hnc/config/default/kustomization.yaml
@@ -19,7 +19,7 @@ bases:
 - ../webhook
 - ../certmanager
 
-patches:
+patchesStrategicMerge::
 - manager_image_patch.yaml
   # Protect the /metrics endpoint by putting it behind auth.
   # Only one of manager_auth_proxy_patch.yaml and


### PR DESCRIPTION
Hey there delilah,

This PR is being done due to the difficulties I encountered when setting up the HNC project. I have added them to the README. 

There is one change, though, which is the renaming `patches` to `patchesStrategicMerge` on the config yml files due to this issue https://github.com/kubernetes-sigs/kustomize/issues/1429