### PR TITLE
HNC: Fix for typo in kustomization yaml file

### DIFF
--- a/incubator/hnc/config/crd/kustomization.yaml
+++ b/incubator/hnc/config/crd/kustomization.yaml
@@ -2,7 +2,7 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/hnc.x-k8s.io_hierarchies.yaml
+- bases/hnc.x-k8s.io_hierarchyconfigurations.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/incubator/hnc/config/default/kustomization.yaml
+++ b/incubator/hnc/config/default/kustomization.yaml
@@ -19,7 +19,7 @@ bases:
 - ../webhook
 - ../certmanager
 
-patchesStrategicMerge::
+patchesStrategicMerge:
 - manager_image_patch.yaml
   # Protect the /metrics endpoint by putting it behind auth.
   # Only one of manager_auth_proxy_patch.yaml and


### PR DESCRIPTION
`make deploy` failed because `kustomize build config/default` failed due to typos introduced in the previous CLs 

Test: run `kustomize build config/default` and see it succeed

/assign @adrianludwin 