### PR TITLE
Add GOPATH/bin to PATH env var in ci-test.sh

### DIFF
--- a/incubator/hnc/hack/ci-test.sh
+++ b/incubator/hnc/hack/ci-test.sh
@@ -14,6 +14,17 @@
 
 set -e
 
+# Not included or existing by default in Prow
+#  - This is part of an ongoing discussion present on the issue:
+#    https://github.com/kubernetes/test-infra/issues/9469;
+#  - Other projects that use Prow as the CI, e.g. kubernetes-sigs/controller-runtime,
+#    https://github.com/kubernetes-sigs/controller-runtime/blob/master/hack/ci-check-everything.sh,
+#    also have this custom configuration;
+#  - In Prow, the GOPATH is set to /home/prow/go, whereas in
+#    the Docker container is /go, which is the default one.
+export PATH=$(go env GOPATH)/bin:$PATH
+mkdir -p $(go env GOPATH)/bin
+
 echo "Installing 'kubebuilder'"
 wget https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.0.0-alpha.1/kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz
 tar -zxvf kubebuilder_2.0.0-alpha.1_linux_amd64.tar.gz


### PR DESCRIPTION
Hey there delilah,

Here we set GOPATH/bin in PATH env var (because is not included or existing by default in Prow) in the `incubator/hnc/hack/ci-test.sh`. This is part of an ongoing discussion present on the issue https://github.com/kubernetes/test-infra/issues/9469. 
