### PR TITLE
[incubator][vc] vn-agent support streaming api

### DIFF
--- a/incubator/virtualcluster/go.mod
+++ b/incubator/virtualcluster/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v0.0.0-20180319062004-c439c4fa0937
 	github.com/spf13/pflag v1.0.3
+	github.com/stretchr/testify v1.3.0
+	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 // indirect
 	golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc
 	golang.org/x/sys v0.0.0-20190429190828-d89cdac9e872 // indirect
 	golang.org/x/text v0.3.2 // indirect

--- a/incubator/virtualcluster/pkg/vn-agent/testcerts/gencerts.sh
+++ b/incubator/virtualcluster/pkg/vn-agent/testcerts/gencerts.sh
@@ -81,7 +81,7 @@ package testcerts
 
 EOF
 
-echo "// TenantName is the CommonName in the tenant cert."
+echo "// TenantName is the CommonName in the tenant cert." >> $outfile
 echo "const TenantName = \"${TENANT_NAME}\"" >> $outfile
 
 for file in CA KubeletServer KubeletClient VnAgent Tenant; do


### PR DESCRIPTION
## What this PR do
vn-agent support exec, attach, portForward proxy.

## How does the test work?
First, we generate the testing certification chain. Each certification is signed by a root CA.
Second, vn-agent will require the client providing the tenant cert, make the connection goes on HTTPS.
streaming server is inside the fakeKubelet, kubelet communicate with local streaming server through http.

![image](https://user-images.githubusercontent.com/12205760/66468179-55731c00-eab8-11e9-9c46-e1c822ceb51e.png)
