### PR TITLE
Add the `tree` label to all namespaces with explicit hierarchies

### DIFF
--- a/incubator/hnc/pkg/controllers/object_controller.go
+++ b/incubator/hnc/pkg/controllers/object_controller.go
@@ -366,7 +366,12 @@ func setAnnotation(inst *unstructured.Unstructured, annotation string, value str
 	inst.SetAnnotations(annotations)
 }
 
-func setLabel(inst *unstructured.Unstructured, label string, value string) {
+type apiInstances interface {
+	GetLabels() map[string]string
+	SetLabels(labels map[string]string)
+}
+
+func setLabel(inst apiInstances, label string, value string) {
 	labels := inst.GetLabels()
 	if labels == nil {
 		labels = map[string]string{}

--- a/incubator/hnc/pkg/forest/forest.go
+++ b/incubator/hnc/pkg/forest/forest.go
@@ -228,6 +228,11 @@ func (ns *Namespace) IsAncestor(other *Namespace) bool {
 	return ns.parent.IsAncestor(other)
 }
 
+// HasCondition returns if the namespace has any local condition.
+func (ns *Namespace) HasCondition() bool {
+	return len(ns.conditions) > 0
+}
+
 // ClearConditions clears local conditions in the namespace.
 func (ns *Namespace) ClearConditions(key string) {
 	delete(ns.conditions, key)
@@ -318,4 +323,17 @@ func getAffectedObject(gvknn string, log logr.Logger) tenancy.AffectedObject {
 		Namespace: "INVALID OBJECT",
 		Name:      gvknn,
 	}
+}
+
+// DescendantNames returns a slice of strings like ["child" ... "grandchildren" ...] of
+// names of all namespaces in its subtree. Nil is returned if the namespace has no descendant.
+func (ns *Namespace) DescendantNames() []string {
+	children := ns.ChildNames()
+	descendants := children
+	for _, child := range children {
+		child_ns := ns.forest.Get(child)
+		descendantsOfChild := child_ns.DescendantNames()
+		descendants = append(descendants, descendantsOfChild...)
+	}
+	return descendants
 }

--- a/incubator/hnc/pkg/forest/forest_test.go
+++ b/incubator/hnc/pkg/forest/forest_test.go
@@ -81,3 +81,51 @@ func TestSetParent(t *testing.T) {
 		})
 	}
 }
+
+func TestDescendantNames(t *testing.T) {
+	// Test a tree has the following structure:
+	//         a
+	//       /  \
+	//     /     \
+	//    b       c
+	//  / | \    /  \
+	// x  y z  123 456
+	//          |
+	//         789
+	kinship := map[string][]string{
+		"a":   []string{"b", "c"},
+		"b":   []string{"x", "y", "z"},
+		"c":   []string{"123", "456"},
+		"123": []string{"789"},
+	}
+
+	// Create the forest
+	f := NewForest()
+	for parentName, childrenNames := range kinship {
+		parent := f.Get(parentName)
+		for _, childName := range childrenNames {
+			child := f.Get(childName)
+			child.SetParent(parent)
+		}
+	}
+
+	tests := []struct {
+		name string
+		root string
+		want []string
+	}{
+		{name: "no descendant", root: "456", want: nil},
+		{name: "one descendant", root: "123", want: []string{"789"}},
+		{name: "one-level descendants", root: "b", want: []string{"x", "y", "z"}},
+		{name: "two-level descendants", root: "c", want: []string{"123", "456", "789"}},
+		{name: "three-level descendants", root: "a", want: []string{"b", "c", "x", "y", "z", "123", "456", "789"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			root := f.Get(tc.root)
+			g.Expect(root.DescendantNames()).Should(Equal(tc.want))
+		})
+	}
+}


### PR DESCRIPTION
Add a `<namespace>.tree.hnc.x-k8s.io/depth` label to all namespaces with
nontrivial hierarchies (i.e. one or more children or any parent).

Resolve: #92 