### PR TITLE
HNC: hardcoded value for resource is replaced by constant

### DIFF
--- a/incubator/hnc/api/v1alpha1/hierarchy_types.go
+++ b/incubator/hnc/api/v1alpha1/hierarchy_types.go
@@ -32,6 +32,7 @@ const (
 
 var (
 	Singleton = "hierarchy"
+	Resource  = "hierarchyconfigurations"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/incubator/hnc/pkg/kubectl/root.go
+++ b/incubator/hnc/pkg/kubectl/root.go
@@ -99,7 +99,7 @@ func getHierarchy(nnm string) *tenancy.HierarchyConfiguration {
 	hier := &tenancy.HierarchyConfiguration{}
 	hier.Name = tenancy.Singleton
 	hier.Namespace = nnm
-	err := hncClient.Get().Resource("hierarchyconfigurations").Namespace(nnm).Name(tenancy.Singleton).Do().Into(hier)
+	err := hncClient.Get().Resource(tenancy.Resource).Namespace(nnm).Name(tenancy.Singleton).Do().Into(hier)
 	if err != nil && !errors.IsNotFound(err) {
 		fmt.Printf("Error reading hierarchy for %s: %s\n", nnm, err)
 		os.Exit(1)
@@ -111,9 +111,9 @@ func updateHierarchy(hier *tenancy.HierarchyConfiguration, reason string) {
 	nnm := hier.Namespace
 	var err error
 	if hier.CreationTimestamp.IsZero() {
-		err = hncClient.Post().Resource("hierarchyconfigurations").Namespace(nnm).Name(tenancy.Singleton).Body(hier).Do().Error()
+		err = hncClient.Post().Resource(tenancy.Resource).Namespace(nnm).Name(tenancy.Singleton).Body(hier).Do().Error()
 	} else {
-		err = hncClient.Put().Resource("hierarchyconfigurations").Namespace(nnm).Name(tenancy.Singleton).Body(hier).Do().Error()
+		err = hncClient.Put().Resource(tenancy.Resource).Namespace(nnm).Name(tenancy.Singleton).Body(hier).Do().Error()
 	}
 	if err != nil {
 		fmt.Printf("Error %s: %s\n", reason, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR added a constant for resource to replace hardcoded value of resource `hierarchyconfigurations`

**Which issue(s) this PR fixes**:
Fixes #146

