### PR TITLE
[incubator][vc] add script to build docker image for each component

### DIFF
--- a/incubator/virtualcluster/.gitignore
+++ b/incubator/virtualcluster/.gitignore
@@ -5,7 +5,7 @@
 *.dll
 *.so
 *.dylib
-bin
+_output
 
 # Test binary, build with `go test -c`
 *.test

--- a/incubator/virtualcluster/Makefile
+++ b/incubator/virtualcluster/Makefile
@@ -4,19 +4,32 @@ export GO111MODULE=on
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 
-all: test manager vn-agent
+# Build code.
+#
+# Args:
+#   WHAT: Directory names to build.  If any of these directories has a 'main'
+#     package, the build will produce executable files under $(OUT_DIR).
+#     If not specified, "everything" will be built.
+#   GOFLAGS: Extra flags to pass to 'go' when building.
+#   GOLDFLAGS: Extra linking flags passed to 'go' when building.
+#   GOGCFLAGS: Additional go compile flags passed to 'go' when building.
+#
+# Example:
+#   make
+#   make all
+#   make all WHAT=cmd/kubelet GOFLAGS=-v
+#   make all GOLDFLAGS=""
+#     Note: Specify GOLDFLAGS as an empty string for building unstripped binaries, which allows
+#           you to use code debugging tools like delve. When GOLDFLAGS is unspecified, it defaults
+#           to "-s -w" which strips debug information. Other flags that can be used for GOLDFLAGS
+#           are documented at https://golang.org/cmd/link/
+.PHONY: all
+all: test
+	hack/make-rules/build.sh $(WHAT)
 
 # Run tests
 test: generate fmt vet manifests
 	go test ./pkg/... ./cmd/... -coverprofile cover.out
-
-# Build manager binary
-manager: generate fmt vet
-	go build -o bin/manager github.com/multi-tenancy/incubator/virtualcluster/cmd/manager
-
-# Build vn-agent binary
-vn-agent: fmt vet
-	go build -o bin/vn-agent github.com/multi-tenancy/incubator/virtualcluster/cmd/vn-agent
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet
@@ -50,11 +63,13 @@ ifndef GOPATH
 endif
 	go generate ./pkg/... ./cmd/...
 
-# Build the docker image
-docker-build: test
-	docker build . -t ${IMG}
-	@echo "updating kustomize image patch file for manager resource"
-	sed -i'' -e 's@image: .*@image: '"${IMG}"'@' ./config/default/manager_image_patch.yaml
+# Build docker image.
+#
+# 1. build all binaries.
+# 2. copy binaries to the corresponding docker image.
+.PHONY: release-images
+release-images: test
+	hack/make-rules/release-images.sh
 
 # Push the docker image
 docker-push:

--- a/incubator/virtualcluster/hack/lib/build.sh
+++ b/incubator/virtualcluster/hack/lib/build.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+readonly VC_GO_PACKAGE=github.com/multi-tenancy/incubator/virtualcluster
+
+readonly VC_ALL_TARGETS=(
+  cmd/manager
+  cmd/syncer
+  cmd/vn-agent
+)
+readonly VC_ALL_BINARIES=("${VC_ALL_TARGETS[@]##*/}")
+
+# binaries_from_targets take a list of build targets and return the
+# full go package to be built
+binaries_from_targets() {
+  local target
+  for target; do
+    # If the target starts with what looks like a domain name, assume it has a
+    # fully-qualified package name rather than one that needs the Kubernetes
+    # package prepended.
+    if [[ "${target}" =~ ^([[:alnum:]]+".")+[[:alnum:]]+"/" ]]; then
+      echo "${target}"
+    else
+      echo "${VC_GO_PACKAGE}/${target}"
+    fi
+  done
+}
+
+# Build binaries targets specified
+#
+# Input:
+#   $@ - targets and go flags.  If no targets are set then all binaries targets
+#     are built.
+build_binaries() {
+  local goflags goldflags gcflags
+  goldflags="${GOLDFLAGS=-s -w}"
+  gcflags="${GOGCFLAGS:-}"
+  goflags=${GOFLAGS:-}
+
+  local -a targets=()
+  local arg
+
+  for arg; do
+    if [[ "${arg}" == -* ]]; then
+      # Assume arguments starting with a dash are flags to pass to go.
+      goflags+=("${arg}")
+    else
+      targets+=("${arg}")
+    fi
+  done
+
+  if [[ ${#targets[@]} -eq 0 ]]; then
+    targets=("${VC_ALL_TARGETS[@]}")
+  fi
+
+  local -a binaries
+  while IFS="" read -r binary; do binaries+=("$binary"); done < <(binaries_from_targets "${targets[@]}")
+
+  mkdir -p ${VC_BIN_DIR}
+  cd ${VC_BIN_DIR}
+  for binary in "${binaries[@]}"; do
+    echo "Building ${binary}"
+    GOOS=linux go build -ldflags "${goldflags:-}" -gcflags "${gcflags:-}" ${goflags} ${binary}
+  done
+}

--- a/incubator/virtualcluster/hack/lib/docker-image.sh
+++ b/incubator/virtualcluster/hack/lib/docker-image.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Get the set of binaries that run in Docker (on Linux)
+# Entry format is "<name-of-binary>,<base-image>".
+# Binaries are placed in /usr/local/bin inside the image.
+#
+# $1 - server architecture
+get_docker_wrapped_binaries() {
+  local arch=$1
+  local debian_base_version=v1.0.0
+  local debian_iptables_version=v11.0.2
+  ### If you change any of these lists, please also update VC_ALL_TARGETS
+  local targets=(
+    manager,"${VC_BASE_IMAGE_REGISTRY}/debian-base-${arch}:${debian_base_version}"
+    syncer,"${VC_BASE_IMAGE_REGISTRY}/debian-base-${arch}:${debian_base_version}"
+    vn-agent,"${VC_BASE_IMAGE_REGISTRY}/debian-base-${arch}:${debian_base_version}"
+  )
+
+  echo "${targets[@]}"
+}
+
+
+# This builds all the release docker images (One docker image per binary)
+# Args:
+#  $1 - binary_dir, the directory to save the tared images to.
+#  $2 - arch, architecture for which we are building docker images.
+create_docker_image() {
+  local binary_dir="$1"
+  local arch="$2"
+  local binary_name
+  local binaries=($(get_docker_wrapped_binaries "${arch}"))
+
+  local -r docker_registry="${VC_DOCKER_REGISTRY}"
+  # Docker tags cannot contain '+'
+  local docker_tag="${VC_GIT_VERSION/+/_}"
+  if [[ -z "${docker_tag}" ]]; then
+    echo "git version information missing; cannot create Docker tag"
+    return 1
+  fi
+
+  for wrappable in "${binaries[@]}"; do
+
+    local oldifs=$IFS
+    IFS=","
+    set $wrappable
+    IFS=$oldifs
+
+    local binary_name="$1"
+    local base_image="$2"
+    local docker_build_path="${binary_dir}/${binary_name}.dockerbuild"
+    local docker_file_path="${docker_build_path}/Dockerfile"
+    local binary_file_path="${binary_dir}/${binary_name}"
+    local docker_image_tag="${docker_registry}/${binary_name}-${arch}:${docker_tag}"
+
+    echo "Starting docker build for image: ${binary_name}-${arch}"
+    (
+      rm -rf "${docker_build_path}"
+      mkdir -p "${docker_build_path}"
+      ln "${binary_dir}/${binary_name}" "${docker_build_path}/${binary_name}"
+      cat <<EOF > "${docker_file_path}"
+FROM ${base_image}
+COPY ${binary_name} /usr/local/bin/${binary_name}
+EOF
+
+      "${DOCKER[@]}" build -q -t "${docker_image_tag}" "${docker_build_path}" >/dev/null
+      # If we are building an official/alpha/beta release we want to keep
+      # docker images and tag them appropriately.
+      local -r release_docker_image_tag="${VC_DOCKER_REGISTRY-$docker_registry}/${binary_name}-${arch}:${VC_DOCKER_IMAGE_TAG-$docker_tag}"
+      if [[ "${release_docker_image_tag}" != "${docker_image_tag}" ]]; then
+        echo "Tagging docker image ${docker_image_tag} as ${release_docker_image_tag}"
+        "${DOCKER[@]}" rmi "${release_docker_image_tag}" 2>/dev/null || true
+        "${DOCKER[@]}" tag "${docker_image_tag}" "${release_docker_image_tag}" 2>/dev/null
+      fi
+    ) &
+  done
+
+  wait-for-jobs || { echo "previous Docker build failed"; return 1; }
+  echo "Docker builds done"
+}
+
+# Package up all of the binaries in docker images
+build_images() {
+  # Clean out any old images
+  rm -rf "${VC_RELEASE_DIR}"
+  mkdir -p "${VC_RELEASE_DIR}"
+  cd ${VC_BIN_DIR}
+  cp "${VC_ALL_BINARIES[@]/#/}" ${VC_RELEASE_DIR}
+
+  create_docker_image "${VC_RELEASE_DIR}" "amd64"
+}

--- a/incubator/virtualcluster/hack/lib/init.sh
+++ b/incubator/virtualcluster/hack/lib/init.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export GO111MODULE=on
+
+VC_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+VC_OUTPUT_DIR=${VC_ROOT}/_output/
+VC_BIN_DIR=${VC_OUTPUT_DIR}/bin/
+VC_RELEASE_DIR=${VC_OUTPUT_DIR}/release/
+
+readonly VC_DOCKER_REGISTRY="${VC_DOCKER_REGISTRY:-registry.hub.docker.com/virtualcluster}"
+readonly VC_BASE_IMAGE_REGISTRY="${VC_BASE_IMAGE_REGISTRY:-k8s.gcr.io}"
+
+VC_GIT_VERSION=$(git rev-parse --short HEAD)$(if ! git diff --no-ext-diff --quiet --exit-code; then echo -dirty; fi)
+
+DOCKER="docker"
+
+source "${VC_ROOT}/hack/lib/build.sh"
+source "${VC_ROOT}/hack/lib/docker-image.sh"
+source "${VC_ROOT}/hack/lib/util.sh"

--- a/incubator/virtualcluster/hack/lib/util.sh
+++ b/incubator/virtualcluster/hack/lib/util.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Wait for background jobs to finish. Return with
+# an error status if any of the jobs failed.
+wait-for-jobs() {
+  local fail=0
+  local job
+  for job in $(jobs -p); do
+    wait "${job}" || fail=$((fail + 1))
+  done
+  return ${fail}
+}

--- a/incubator/virtualcluster/hack/make-rules/build.sh
+++ b/incubator/virtualcluster/hack/make-rules/build.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+VC_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+source "${VC_ROOT}/hack/lib/init.sh"
+
+build_binaries "$@"

--- a/incubator/virtualcluster/hack/make-rules/release-images.sh
+++ b/incubator/virtualcluster/hack/make-rules/release-images.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+VC_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+source "${VC_ROOT}/hack/lib/init.sh"
+
+build_binaries
+build_images


### PR DESCRIPTION
1. build binaries
```bash
➜  virtualcluster git:(make-image) ✗ make all WHAT=cmd/vn-agent
hack/make-rules/build.sh cmd/vn-agent
Building github.com/multi-tenancy/incubator/virtualcluster/cmd/vn-agent
➜  virtualcluster git:(make-image) ✗ make all
hack/make-rules/build.sh
Building github.com/multi-tenancy/incubator/virtualcluster/cmd/manager
Building github.com/multi-tenancy/incubator/virtualcluster/cmd/syncer
Building github.com/multi-tenancy/incubator/virtualcluster/cmd/vn-agent
```
2. build images
```bash
➜  virtualcluster git:(make-image) ✗ make release-images
hack/make-rules/release-images.sh
Building github.com/multi-tenancy/incubator/virtualcluster/cmd/manager
Building github.com/multi-tenancy/incubator/virtualcluster/cmd/syncer
Building github.com/multi-tenancy/incubator/virtualcluster/cmd/vn-agent
Starting docker build for image: manager-amd64
Starting docker build for image: syncer-amd64
Starting docker build for image: vn-agent-amd64
Docker builds done
➜  virtualcluster git:(make-image) ✗ docker images
REPOSITORY                                              TAG                 IMAGE ID            CREATED             SIZE
registry.hub.docker.com/virtualcluster/syncer-amd64     135a700-dirty       db0b517b3242        3 seconds ago       73.8MB
registry.hub.docker.com/virtualcluster/manager-amd64    135a700-dirty       bb0913789fd1        3 seconds ago       72.5MB
registry.hub.docker.com/virtualcluster/vn-agent-amd64   135a700-dirty       8c8198a00b0b        3 seconds ago       68.3MB
k8s.gcr.io/debian-base-amd64                            v1.0.0              204e96332c91        6 months ago        42.3MB
➜  virtualcluster git:(make-image) ✗
```
Signed-off-by: jerryzhuang <zhuangqhc@gmail.com>