### PR TITLE
Check authz when changing a namespace's parent

### DIFF
--- a/incubator/hnc/pkg/forest/forest.go
+++ b/incubator/hnc/pkg/forest/forest.go
@@ -205,16 +205,25 @@ func (ns *Namespace) RelativesNames() []string {
 // a path from `other` to the current namespace (if `other` is nil, the first element of the slice
 // will be the root of the tree, *not* the empty string).
 func (ns *Namespace) AncestoryNames(other *Namespace) []string {
+	if ns == nil {
+		// Nil forest has nil ancestory
+		return nil
+	}
 	if ns == other || (ns.parent == nil && other == nil) {
+		// Either we found `other` or the root
 		return []string{ns.name}
 	}
 	if ns.parent == nil {
+		// Ancestory to `other` doesn't exist
 		return nil
 	}
 	ancestory := ns.parent.AncestoryNames(other)
 	if ancestory == nil {
+		// Ancestory to `other` wasn't found
 		return nil
 	}
+
+	// Add ourselves to the ancestory
 	return append(ancestory, ns.name)
 }
 

--- a/incubator/hnc/pkg/validators/hierarchy.go
+++ b/incubator/hnc/pkg/validators/hierarchy.go
@@ -3,15 +3,17 @@ package validators
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
 
 	"github.com/go-logr/logr"
-	authenticationv1 "k8s.io/api/authentication/v1"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	authnv1 "k8s.io/api/authentication/v1"
+	authzv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	tenancy "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/forest"
 )
 
@@ -30,57 +32,252 @@ const (
 type Hierarchy struct {
 	Log     logr.Logger
 	Forest  *forest.Forest
-	client  client.Client
+	authz   authzClient
 	decoder *admission.Decoder
 }
 
-func (v *Hierarchy) Handle(ctx context.Context, req admission.Request) admission.Response {
-	log := v.Log.WithValues("ns", req.Namespace)
-
-	if isHNCServiceAccount(req.AdmissionRequest.UserInfo) {
-		log.Info("Allowed change by HNC SA")
-		return admission.Allowed("Change by HNC SA")
-	}
-
-	inst := &tenancy.HierarchyConfiguration{}
-	err := v.decoder.Decode(req, inst)
-	if err != nil {
-		log.Error(err, "Couldn't decode request")
-		return admission.Errored(http.StatusBadRequest, err)
-	}
-
-	return v.handle(ctx, log, inst)
+// authzClient represents the authz checks that should typically be performed against the apiserver,
+// but need to be stubbed out during unit testing.
+type authzClient interface {
+	// IsAdmin takes a UserInfo and the name of a namespace, and returns true if the user is an admin
+	// of that namespace (ie, can update the hierarchical config).
+	IsAdmin(ctx context.Context, ui *authnv1.UserInfo, nnm string) (bool, error)
 }
 
-// handle implements the non-webhook-y businesss logic of this validator, allowing it to be more
-// easily unit tested (ie without constructing an admission.Request, setting up user infos, etc).
-func (v *Hierarchy) handle(ctx context.Context, log logr.Logger, inst *tenancy.HierarchyConfiguration) admission.Response {
-	nnm := inst.ObjectMeta.Namespace
-	pnm := inst.Spec.Parent
-	if pnm == "" {
-		log.Info("Allowed", "parent", "<none>")
-		return admission.Allowed("No parent set")
+// request defines the aspects of the admission.Request that we care about.
+type request struct {
+	hc *api.HierarchyConfiguration
+	ui *authnv1.UserInfo
+}
+
+// Handle implements the validation webhook.
+//
+// During updates, the validator currently ignores the existing state of the object (`oldObject`).
+// The reason is that most of the checks being performed are on the state of the entire forest, not
+// on any one object, so having the _very_ latest information on _one_ object doesn't really help
+// us. That is, we're basically forced to assume that the in-memory forest is fully up-to-date.
+//
+// Obviously, there are times when this assumption will be incorrect - for example, when the HNC is
+// just starting up, or perhaps if there have been a lot of changes made very quickly that the
+// reconciler has't caught up with yet. In such cases, this validator can produce both false
+// negatives (legal changes are incorrectly rejected) or false positives (illegal changes are
+// mistakenly allowed).  False negatives can easily be retried and so are not a significant problem,
+// since (by definition) we expect the problem to be transient.
+//
+// False positives are a more serious concern, but the reconciler has been designed to assume that
+// the validator is _never_ running, and any illegal configuration that makes it into K8s will
+// simply be reported via HierarchyConfiguration.Status.Conditions. It's the admins'
+// responsibilities to monitor these conditions and ensure that, transient exceptions aside, all
+// namespaces are condition-free.
+func (v *Hierarchy) Handle(ctx context.Context, req admission.Request) admission.Response {
+	decoded, err := v.decodeRequest(req)
+	log := v.Log.WithValues("ns", decoded.hc.ObjectMeta.Namespace, "user", decoded.ui.Username)
+
+	if err != nil {
+		log.Error(err, "Couldn't decode request")
+		return deny(metav1.StatusReasonBadRequest, err.Error())
 	}
 
+	resp := v.handle(ctx, log, decoded)
+	log.Info("Handled", "allowed", resp.Allowed, "code", resp.Result.Code, "reason", resp.Result.Reason, "message", resp.Result.Message)
+	return resp
+}
+
+// handle implements the non-boilerplate logic of this validator, allowing it to be more easily unit
+// tested (ie without constructing a full admission.Request).
+//
+// This follows the standard HNC pattern of:
+// - Load a bunch of stuff from the apiserver
+// - Lock the forest and do all checks
+// - Finish up with the apiserver (although we just run _additional_ checks, we don't modify things)
+//
+// This minimizes the amount of time that the forest is locked, allowing different threads to
+// proceed in parallel.
+func (v *Hierarchy) handle(ctx context.Context, log logr.Logger, req *request) admission.Response {
+	// Early exit: the HNC SA can do whatever it wants. This is because if an illegal HC already
+	// exists on the K8s server, we need to be able to update its status even though the rest of the
+	// object wouldn't pass legality. We should probably only give the HNC SA the ability to modify
+	// the _status_, though. TODO: https://github.com/kubernetes-sigs/multi-tenancy/issues/80.
+	if isHNCServiceAccount(req.ui) {
+		log.Info("Allowed change by HNC SA")
+		return allow("HNC SA")
+	}
+
+	// Do all checks that require holding the in-memory lock. Generate a list of authz checks we
+	// should perform once the lock is released.
+	authzReqs, resp := v.checkForest(req.hc)
+	if !resp.Allowed {
+		return resp
+	}
+
+	// Ensure the user has the required permissions to make the change.
+	return v.checkAuthz(ctx, req.ui, authzReqs)
+}
+
+// checkForest validates that the request is allowed based on the current in-memory state of the
+// forest. If it is, it returns a list of namespaces that the user needs to be authorized to update
+// in order to be allowed to make the change; these checks are executed _after_ the in-memory lock
+// is released.
+func (v *Hierarchy) checkForest(hc *api.HierarchyConfiguration) ([]authzReq, admission.Response) {
 	v.Forest.Lock()
 	defer v.Forest.Unlock()
-	ns := v.Forest.Get(nnm)
-	pns := v.Forest.Get(pnm)
-	if !pns.Exists() {
-		// TODO: only allow if sufficient privileges
-		log.Info("Allowed missing", "parent", pnm)
-		return admission.Allowed("Parent does not exist yet")
+
+	// Load stuff from the forest
+	ns := v.Forest.Get(hc.ObjectMeta.Namespace)
+	curParent := ns.Parent()
+	newParent := v.Forest.Get(hc.Spec.Parent)
+
+	// No change -> no problem
+	if curParent == newParent {
+		return nil, allow("parent unchanged")
 	}
-	if reason := ns.CanSetParent(pns); reason != "" {
-		log.Info("Rejected", "parent", pnm, "reason", reason)
-		return admission.Denied("Illegal parent: " + reason)
+
+	// Is this change structurally legal? Note that this can "leak" information about the hierarchy
+	// since we haven't done our authz checks yet. However, the fact that they've gotten this far
+	// means that the user has permission to update the _current_ namespace, which means they also
+	// have visibility into its ancestry and descendents, and this check can only fail if the new
+	// parent conflicts with something in the _existing_ hierarchy.
+	if reason := ns.CanSetParent(newParent); reason != "" {
+		return nil, deny(metav1.StatusReasonConflict, "Illegal parent: "+reason)
 	}
-	log.Info("Allowed", "parent", pnm)
-	return admission.Allowed("Parent is legal")
+
+	// TODO: requiredChild check: https://github.com/kubernetes-sigs/multi-tenancy/issues/99
+
+	// The structure looks good. Get the list of namespaces we need authz checks on.
+	return v.needAuthzOn(curParent, newParent), allow("")
+}
+
+// authzReq represents a request for authorization
+type authzReq struct {
+	nnm    string // the namespace the user needs to be authorized to modify
+	reason string // the reason we're checking it (for logs and error messages)
+}
+
+// needAuthzOn returns the namespaces that the user must be authorized to update in order to make
+// this change. It must be called while the forest lock is held.
+//
+// This method is a bit verbose; I've tried to optimize readability over conciseness since it's a
+// tricky bit of code to understand.
+func (v *Hierarchy) needAuthzOn(curParent, newParent *forest.Namespace) []authzReq {
+	// Get the ancestry chain of both parents (see getExistingAncestry for details of what we actually
+	// return).
+	//
+	// TODO: if the new parent doesn't exist yet, only allow it if the user has permission to create
+	// it. https://github.com/kubernetes-sigs/multi-tenancy/issues/158.
+	curChain := v.getExistingAncestry(curParent)
+	newChain := v.getExistingAncestry(newParent)
+
+	// No (valid) current or new ancestors -> nothing to check.
+	if len(curChain) == 0 && len(newChain) == 0 {
+		return nil
+	}
+
+	// If only one of them exists, return that one. If they both exist, but have different roots, add
+	// both of them. Note that we've already covered the case where _neither_ exists, so if one
+	// doesn't exist, the other certainly does.
+	if len(curChain) == 0 {
+		return []authzReq{{nnm: newChain[len(newChain)-1], reason: "proposed parent"}}
+	}
+	if len(newChain) == 0 {
+		return []authzReq{{nnm: curChain[0], reason: "root ancestor of the current parent"}}
+	}
+
+	// If they don't share any common ancestors, return them both (trying to factor out the code to
+	// create the requests actually made this function harder to read, IMO).
+	if curChain[0] != newChain[0] {
+		return []authzReq{
+			{nnm: curChain[0], reason: "root ancestor of the current parent"},
+			{nnm: newChain[len(newChain)-1], reason: "proposed parent"},
+		}
+	}
+
+	// There's at least one common ancestor; find the most recent one and return it.
+	mrca := curChain[0]
+	for i := 1; i < len(curChain) && i < len(newChain); i++ {
+		if curChain[i] != newChain[i] {
+			break
+		}
+		mrca = curChain[i]
+	}
+	return []authzReq{{
+		nnm:    mrca,
+		reason: fmt.Sprintf("most recent common ancestor of current parent %s and proposed parent %s", curParent.Name(), newParent.Name()),
+	}}
+}
+
+// getExistingAncestry returns the ancestry of the given namespace, with all nonexistent namespaces
+// filtered out. We need to compare the ancestry of the two parents so we can find the most recent
+// common ancestor and do authz checks on it. However, since we can assign parents before they
+// exist, the MRCA might not actually exist yet, which means that K8s obviously can't do an authz
+// check on it yet.
+//
+// It's even trickier than you might think: the ancestry chain can actually contain gaps! For
+// example, namespace A might have a required child B which hasn't been created yet (for some
+// reason), while namespace C lists namespace B as its parent. In this case, A and C exist, but not
+// B. In this case, we should probably run the check on A, since it's admins are obviously supposed
+// to have control over C and its descendents.
+//
+// Alternatively, B and C might both exist, and A might not. In this case, we can't run the check on
+// A, so we do the best we can: we should run the check on B.
+//
+// We can solve both of these cases by simply filtering out the missing namespaces.
+func (v *Hierarchy) getExistingAncestry(ns *forest.Namespace) []string {
+	chain := ns.AncestoryNames(nil) // Returns empty slice if ns is nil.
+	existing := []string{}
+	for _, anm := range chain {
+		if v.Forest.Get(anm).Exists() {
+			existing = append(existing, anm)
+		}
+	}
+	return existing
+}
+
+// checkAuthz executes the list of requested checks.
+func (v *Hierarchy) checkAuthz(ctx context.Context, ui *authnv1.UserInfo, reqs []authzReq) admission.Response {
+	if v.authz == nil {
+		return allow("") // unit test; TODO put in fake
+	}
+
+	// TODO: parallelize?
+	for _, req := range reqs {
+		allowed, err := v.authz.IsAdmin(ctx, ui, req.nnm)
+
+		// Interpret the result
+		if err != nil {
+			return deny(metav1.StatusReasonUnknown, fmt.Sprintf("while checking authz for %s, the %s: %s", req.nnm, req.reason, err))
+		}
+
+		if !allowed {
+			return deny(metav1.StatusReasonUnauthorized, fmt.Sprintf("User %s is not authorized to modify the subtree of %s, which is the %s",
+				ui.Username, req.nnm, req.reason))
+		}
+	}
+
+	return allow("")
+}
+
+// decodeRequest gets the information we care about into a simple struct that's easy to both a) use
+// and b) factor out in unit tests.
+func (v *Hierarchy) decodeRequest(in admission.Request) (*request, error) {
+	hc := &api.HierarchyConfiguration{}
+	err := v.decoder.Decode(in, hc)
+	if err != nil {
+		return nil, err
+	}
+
+	return &request{
+		hc: hc,
+		ui: &in.UserInfo,
+	}, nil
 }
 
 // isHNCServiceAccount is inspired by isGKServiceAccount from open-policy-agent/gatekeeper.
-func isHNCServiceAccount(user authenticationv1.UserInfo) bool {
+func isHNCServiceAccount(user *authnv1.UserInfo) bool {
+	if user == nil {
+		// useful for unit tests
+		return false
+	}
+
 	ns, found := os.LookupEnv("POD_NAMESPACE")
 	if !found {
 		ns = "hnc-system"
@@ -95,11 +292,87 @@ func isHNCServiceAccount(user authenticationv1.UserInfo) bool {
 }
 
 func (v *Hierarchy) InjectClient(c client.Client) error {
-	v.client = c
+	v.authz = &realAuthzClient{client: c}
 	return nil
 }
 
 func (v *Hierarchy) InjectDecoder(d *admission.Decoder) error {
 	v.decoder = d
 	return nil
+}
+
+// realAuthzClient implements authzClient, and is not use during unit tests.
+type realAuthzClient struct {
+	client client.Client
+}
+
+// IsAdmin implements authzClient
+func (r *realAuthzClient) IsAdmin(ctx context.Context, ui *authnv1.UserInfo, nnm string) (bool, error) {
+	// Construct the request
+	sar := &authzv1.SubjectAccessReview{
+		Spec: authzv1.SubjectAccessReviewSpec{
+			ResourceAttributes: &authzv1.ResourceAttributes{
+				Namespace: nnm,
+				Verb:      "update",
+				Group:     "hnc.x-k8s.io",
+				Version:   "*",
+				Resource:  "hierarchyconfigurations",
+			},
+			User:   ui.Username,
+			Groups: ui.Groups,
+			UID:    ui.UID,
+			// TODO: add Extra (need to convert the types)
+		},
+	}
+
+	// Call the server
+	err := r.client.Create(ctx, sar)
+
+	// Extract the interesting result
+	return sar.Status.Allowed, err
+}
+
+// allow is a replacement for controller-runtime's admission.Allowed() that allows you to set the
+// message (human-readable) as opposed to the reason (machine-readable).
+func allow(msg string) admission.Response {
+	return admission.Response{AdmissionResponse: admissionv1beta1.AdmissionResponse{
+		Allowed: true,
+		Result: &metav1.Status{
+			Code:    0,
+			Message: msg,
+		},
+	}}
+}
+
+// deny is a replacement for controller-runtime's admission.Denied() that allows you to set _both_ a
+// human-readable message _and_ a machine-readable reason, and also sets the code correctly instead
+// of hardcoding it to 403 Forbidden.
+func deny(reason metav1.StatusReason, msg string) admission.Response {
+	return admission.Response{AdmissionResponse: admissionv1beta1.AdmissionResponse{
+		Allowed: false,
+		Result: &metav1.Status{
+			Code:    codeFromReason(reason),
+			Message: msg,
+			Reason:  reason,
+		},
+	}}
+}
+
+// codeFromReason implements the needed subset of
+// https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#StatusReason
+func codeFromReason(reason metav1.StatusReason) int32 {
+	switch reason {
+	case metav1.StatusReasonUnknown:
+		return 500
+	case metav1.StatusReasonUnauthorized:
+		return 401
+	case metav1.StatusReasonConflict:
+		return 409
+	case metav1.StatusReasonBadRequest:
+		return 400
+	case metav1.StatusReasonInternalError:
+		return 500
+	default:
+		return 500
+	}
 }

--- a/incubator/hnc/pkg/validators/hierarchy_test.go
+++ b/incubator/hnc/pkg/validators/hierarchy_test.go
@@ -5,20 +5,19 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	authn "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/forest"
 )
 
-func TestHierarchy(t *testing.T) {
+func TestStructure(t *testing.T) {
 	f := forest.NewForest()
-	foo := f.Get("foo")
-	bar := f.Get("bar")
-	baz := f.Get("baz")
-	foo.SetExists()
-	bar.SetExists()
-	baz.SetExists()
+	foo := createNS(f, "foo", nil)
+	bar := createNS(f, "bar", nil)
+	createNS(f, "baz", nil)
 	bar.SetParent(foo)
 	h := &Hierarchy{Forest: f}
 	l := zap.Logger(false)
@@ -38,18 +37,125 @@ func TestHierarchy(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup
 			g := NewGomegaWithT(t)
-			hier := &api.HierarchyConfiguration{Spec: api.HierarchyConfigurationSpec{Parent: tc.pnm}}
-			hier.ObjectMeta.Name = api.Singleton
-			hier.ObjectMeta.Namespace = tc.nnm
+			hc := &api.HierarchyConfiguration{Spec: api.HierarchyConfigurationSpec{Parent: tc.pnm}}
+			hc.ObjectMeta.Name = api.Singleton
+			hc.ObjectMeta.Namespace = tc.nnm
+			req := &request{hc: hc}
 
 			// Test
-			got := h.handle(context.Background(), l, hier)
+			got := h.handle(context.Background(), l, req)
 
 			// Report
-			reason := got.AdmissionResponse.Result.Reason
-			code := got.AdmissionResponse.Result.Code
-			t.Logf("Got reason %q, code %d", reason, code)
+			logResult(t, got.AdmissionResponse.Result)
 			g.Expect(got.AdmissionResponse.Allowed).ShouldNot(Equal(tc.fail))
 		})
 	}
+}
+
+func TestAuthz(t *testing.T) {
+	tests := []struct {
+		name    string
+		authz   fakeAuthz
+		from    string
+		to      string
+		fail    bool
+		unexist []string
+	}{
+		{name: "no permission in tree", from: "c", to: "g", fail: true},
+		{name: "root permission in tree", from: "c", to: "g", authz: fakeAuthz{"a"}},
+		{name: "cur parent only in tree", from: "c", to: "g", authz: fakeAuthz{"c"}, fail: true},
+		{name: "dst only in tree", from: "c", to: "g", authz: fakeAuthz{"g"}, fail: true},
+		{name: "dst only across trees", from: "c", to: "h", authz: fakeAuthz{"h"}, fail: true},
+		{name: "cur root only across trees", from: "c", to: "h", authz: fakeAuthz{"a"}, fail: true},
+		{name: "dst and cur parent across trees", from: "c", to: "h", authz: fakeAuthz{"c", "h"}, fail: true},
+		{name: "dst and cur root across trees", from: "c", to: "h", authz: fakeAuthz{"a", "h"}},
+		{name: "mrca in tree", from: "e", to: "g", authz: fakeAuthz{"d"}},
+		{name: "parents in tree", from: "c", to: "g", authz: fakeAuthz{"c", "g"}, fail: true},
+		{name: "parents in tree, missing intermediate", from: "c", to: "g", authz: fakeAuthz{"c", "g"}, unexist: []string{"b", "d"}, fail: true},
+		{name: "parents in tree, missing ancestors", from: "c", to: "g", authz: fakeAuthz{"c", "g"}, unexist: []string{"a", "b", "d"}},
+		{name: "parents in tree, missing root", from: "c", to: "g", authz: fakeAuthz{"c", "g"}, unexist: []string{"a"}, fail: true},
+		{name: "grandparents in tree, missing root", from: "c", to: "g", authz: fakeAuthz{"b", "g"}, unexist: []string{"a"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup
+			g := NewGomegaWithT(t)
+			f := createTestForest(tc.unexist)
+			foo := createNS(f, "foo", nil)
+			foo.SetParent(f.Get(tc.from))
+			h := &Hierarchy{Forest: f, authz: tc.authz}
+			l := zap.Logger(false)
+
+			// Create request
+			hc := &api.HierarchyConfiguration{Spec: api.HierarchyConfigurationSpec{Parent: tc.to}}
+			hc.ObjectMeta.Name = api.Singleton
+			hc.ObjectMeta.Namespace = "foo"
+			req := &request{hc: hc, ui: &authn.UserInfo{Username: "jen"}}
+
+			// Test
+			got := h.handle(context.Background(), l, req)
+
+			// Report
+			logResult(t, got.AdmissionResponse.Result)
+			//reason := got.AdmissionResponse.Result.Reason
+			g.Expect(got.AdmissionResponse.Allowed).ShouldNot(Equal(tc.fail))
+		})
+	}
+}
+
+// createTestForest creates the following forest:
+// a -> b -> c -> foo
+//   |
+//   -> d -> e
+//        |
+//        -> g
+// h
+//
+// The ue (UnExists) parameter prevents the specified namespaces from having SetExists called on
+// them.
+func createTestForest(ue []string) *forest.Forest {
+	f := forest.NewForest()
+	a := createNS(f, "a", ue)
+	b := createNS(f, "b", ue)
+	c := createNS(f, "c", ue)
+	d := createNS(f, "d", ue)
+	e := createNS(f, "e", ue)
+	g := createNS(f, "g", ue)
+	createNS(f, "h", ue)
+	b.SetParent(a)
+	c.SetParent(b)
+	d.SetParent(a)
+	e.SetParent(d)
+	g.SetParent(d)
+	return f
+}
+
+// createNS creates nnm and sets it to existing, unless it's listed in the ue (UnExists) list. Note
+// that we can't call UnsetExists() since that also destroys the hierarchy and cleans it up.
+func createNS(f *forest.Forest, nnm string, ue []string) *forest.Namespace {
+	ns := f.Get(nnm)
+	for _, u := range ue { // hey, it's fast _enough_ :)
+		if u == nnm {
+			return ns
+		}
+	}
+	ns.SetExists()
+	return ns
+}
+
+func logResult(t *testing.T, result *metav1.Status) {
+	t.Logf("Got reason %q, code %d, msg %q", result.Reason, result.Code, result.Message)
+}
+
+// fakeAuthz implements authzClient. Any namespaces that are in the slice are allowed; anything else
+// is denied.
+type fakeAuthz []string
+
+func (f fakeAuthz) IsAdmin(_ context.Context, _ *authn.UserInfo, nnm string) (bool, error) {
+	for _, n := range f {
+		if n == nnm {
+			return true, nil
+		}
+	}
+	return false, nil
 }


### PR DESCRIPTION
This implements the logic described in the design doc to prevent a
subadmin from depriving a superadmin of access to a namespace by
assigning it away, and from gaining access to a new namespace's
propagated objects by joining it as a child.

Tested: new unit tests. Also manually verified that by default, acting
as a service account did not allow me to change the hierarchy of a
subnamespace even if I had get/update permissions on its
hierarchyconfig. Verified that as I added rolebindings to the parents,
the error messages changed accordingly as the reasons for failures
changed until I had sufficient permissions, at which point it passed. I
have not tested this exhaustively, apart from the unit tests.