### PR TITLE
PSPs aren't namespaced and shouldn't be watched by the HNC

### DIFF
--- a/incubator/hnc/pkg/controllers/object_controller.go
+++ b/incubator/hnc/pkg/controllers/object_controller.go
@@ -103,6 +103,15 @@ func (r *ObjectReconciler) SyncNamespace(ctx context.Context, log logr.Logger, n
 // update deletes this object if it's an obsolete copy, and otherwise ensures it's been propagated
 // to any child namespaces.
 func (r *ObjectReconciler) update(ctx context.Context, log logr.Logger, inst *unstructured.Unstructured) error {
+	// If for some reason this has been called on an object that isn't namespaced, let's generate some
+	// logspam!
+	if inst.GetNamespace() == "" {
+		for i := 0; i < 100; i++ {
+			log.Info("Non-namespaced object!!!")
+		}
+		return nil
+	}
+
 	// Make sure this object is correct and supposed to propagate. If not, delete it.
 	srcInst, err := r.getSourceInst(ctx, log, inst)
 	if err != nil {

--- a/incubator/hnc/pkg/controllers/setup.go
+++ b/incubator/hnc/pkg/controllers/setup.go
@@ -22,7 +22,6 @@ func Create(mgr ctrl.Manager, f *forest.Forest) error {
 		{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "Role"},
 		{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "RoleBinding"},
 		{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"},
-		{Group: "policy", Version: "v1beta1", Kind: "PodSecurityPolicy"},
 		{Group: "", Version: "v1", Kind: "ResourceQuota"},
 		{Group: "", Version: "v1", Kind: "LimitRange"},
 		{Group: "", Version: "v1", Kind: "ConfigMap"},


### PR DESCRIPTION
A recent refactoring started panicking on Kind because Kind has PSPs by
default, which it turns out aren't namespaced (oops). This change adds
some logspam in case this ever happens again and removes PSPs from the
HNC.

Tested: verified logspam before removing PSPs (and that it didn't
crash), then removed PSPs from setup.go and verified the logspam went
away.

/assign @srampal 