### PR TITLE
Change API package import to 'api'

### DIFF
--- a/incubator/hnc/cmd/manager/main.go
+++ b/incubator/hnc/cmd/manager/main.go
@@ -29,7 +29,7 @@ import (
 
 	// +kubebuilder:scaffold:imports
 
-	tenancy "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/controllers"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/forest"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/validators"
@@ -43,7 +43,7 @@ var (
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
 
-	_ = tenancy.AddToScheme(scheme)
+	_ = api.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }

--- a/incubator/hnc/pkg/controllers/hierarchy_controller.go
+++ b/incubator/hnc/pkg/controllers/hierarchy_controller.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	tenancy "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/forest"
 )
 
@@ -143,7 +143,7 @@ func (r *HierarchyReconciler) reconcile(ctx context.Context, log logr.Logger, nm
 // be able to proceed until this one is finished. While the results of the reconiliation may not be
 // fully written back to the apiserver yet, each namespace is reconciled in isolation (apart from
 // the in-memory forest) so this is fine.
-func (r *HierarchyReconciler) syncWithForest(log logr.Logger, nsInst *corev1.Namespace, inst *tenancy.HierarchyConfiguration) {
+func (r *HierarchyReconciler) syncWithForest(log logr.Logger, nsInst *corev1.Namespace, inst *api.HierarchyConfiguration) {
 	r.Forest.Lock()
 	defer r.Forest.Unlock()
 	ns := r.Forest.Get(inst.ObjectMeta.Namespace)
@@ -205,7 +205,7 @@ func (r *HierarchyReconciler) markExisting(log logr.Logger, ns *forest.Namespace
 	}
 }
 
-func (r *HierarchyReconciler) syncRequiredChildOf(log logr.Logger, inst *tenancy.HierarchyConfiguration, ns *forest.Namespace) {
+func (r *HierarchyReconciler) syncRequiredChildOf(log logr.Logger, inst *api.HierarchyConfiguration, ns *forest.Namespace) {
 	if ns.RequiredChildOf == "" {
 		return
 	}
@@ -221,18 +221,18 @@ func (r *HierarchyReconciler) syncRequiredChildOf(log logr.Logger, inst *tenancy
 		r.enqueueAffected(log, "incorrect parent of the subnamespace", inst.Spec.Parent)
 		msg := fmt.Sprintf("required child of %s but parent is set to %s", ns.RequiredChildOf, inst.Spec.Parent)
 		r.enqueueAffected(log, "wrong parent set as a parent", inst.Spec.Parent)
-		ns.SetCondition(forest.Local, tenancy.CritRequiredChildConflict, msg)
+		ns.SetCondition(forest.Local, api.CritRequiredChildConflict, msg)
 	}
 }
 
-func (r *HierarchyReconciler) syncParent(log logr.Logger, inst *tenancy.HierarchyConfiguration, ns *forest.Namespace) {
+func (r *HierarchyReconciler) syncParent(log logr.Logger, inst *api.HierarchyConfiguration, ns *forest.Namespace) {
 	// Sync this namespace with its current parent.
 	var curParent *forest.Namespace
 	if inst.Spec.Parent != "" {
 		curParent = r.Forest.Get(inst.Spec.Parent)
 		if !curParent.Exists() {
 			log.Info("Missing parent", "parent", inst.Spec.Parent)
-			ns.SetCondition(forest.Local, tenancy.CritParentMissing, "missing parent")
+			ns.SetCondition(forest.Local, api.CritParentMissing, "missing parent")
 		}
 	}
 
@@ -242,7 +242,7 @@ func (r *HierarchyReconciler) syncParent(log logr.Logger, inst *tenancy.Hierarch
 		log.Info("Updating parent", "old", oldParent.Name(), "new", curParent.Name())
 		if err := ns.SetParent(curParent); err != nil {
 			log.Info("Couldn't update parent", "reason", err, "parent", inst.Spec.Parent)
-			ns.SetCondition(forest.Local, tenancy.CritParentInvalid, err.Error())
+			ns.SetCondition(forest.Local, api.CritParentInvalid, err.Error())
 		} else {
 			// Only call other parts of the hierarchy recursively if this one was successfully updated;
 			// otherwise, if you get a cycle, this could get into an infinite loop.
@@ -278,7 +278,7 @@ func (r *HierarchyReconciler) syncLabel(log logr.Logger, nsInst *corev1.Namespac
 // syncChildren looks at the current list of children and compares it to the children that
 // have been marked as required. If any required children are missing, we add them to the in-memory
 // forest and enqueue the (missing) child for reconciliation; we also handle various error cases.
-func (r *HierarchyReconciler) syncChildren(log logr.Logger, inst *tenancy.HierarchyConfiguration, ns *forest.Namespace) {
+func (r *HierarchyReconciler) syncChildren(log logr.Logger, inst *api.HierarchyConfiguration, ns *forest.Namespace) {
 	inst.Status.Children = ns.ChildNames()
 	// Make a set to make it easy to look up if a child is required or not
 	reqSet := map[string]bool{}
@@ -295,7 +295,7 @@ func (r *HierarchyReconciler) syncChildren(log logr.Logger, inst *tenancy.Hierar
 			delete(reqSet, cn)                      // remove so we know we found it
 			if cns.Exists() && cns.Parent() != ns { // condition if it's assigned elsewhere
 				msg := fmt.Sprintf("required subnamespace %s exists but has parent %s", cn, cns.Parent().Name())
-				ns.SetCondition(forest.Local, tenancy.CritRequiredChildConflict, msg)
+				ns.SetCondition(forest.Local, api.CritRequiredChildConflict, msg)
 			}
 		} else if cns.RequiredChildOf == ns.Name() {
 			// This isn't a required child, but it looks like it *used* to be a required child of this
@@ -307,7 +307,7 @@ func (r *HierarchyReconciler) syncChildren(log logr.Logger, inst *tenancy.Hierar
 			// child! Oops. Add a condition to this namespace so we know we have a child that we
 			// shouldn't.
 			msg := fmt.Sprintf("child namespace %s should be a child of %s", cn, cns.RequiredChildOf)
-			ns.SetCondition(forest.Local, tenancy.CritRequiredChildConflict, msg)
+			ns.SetCondition(forest.Local, api.CritRequiredChildConflict, msg)
 		}
 	}
 
@@ -330,17 +330,17 @@ func (r *HierarchyReconciler) syncChildren(log logr.Logger, inst *tenancy.Hierar
 			} else {
 				msg = fmt.Sprintf("required subnamespace %s exists but cannot be set as a child of this namespace", cn)
 			}
-			ns.SetCondition(forest.Local, tenancy.CritRequiredChildConflict, msg)
+			ns.SetCondition(forest.Local, api.CritRequiredChildConflict, msg)
 		} else {
 			// Someone else got it first. This should never happen if the validator is working correctly.
 			log.Info("Required child is claimed by another parent", "child", cn, "otherParent", cns.RequiredChildOf)
 			msg := fmt.Sprintf("required child namespace %s is already a child namespace of %s", cn, cns.RequiredChildOf)
-			ns.SetCondition(forest.Local, tenancy.CritRequiredChildConflict, msg)
+			ns.SetCondition(forest.Local, api.CritRequiredChildConflict, msg)
 		}
 	}
 }
 
-func (r *HierarchyReconciler) syncConditions(log logr.Logger, inst *tenancy.HierarchyConfiguration, ns *forest.Namespace, hadCrit bool) {
+func (r *HierarchyReconciler) syncConditions(log logr.Logger, inst *api.HierarchyConfiguration, ns *forest.Namespace, hadCrit bool) {
 	// Sync critical conditions after all locally-set conditions are updated.
 	r.syncCritConditions(log, ns, hadCrit)
 
@@ -367,7 +367,7 @@ func (r *HierarchyReconciler) syncCritConditions(log logr.Logger, ns *forest.Nam
 	r.enqueueAffected(log, "descendant of a namespace with critical conditions "+msg, ns.DescendantNames()...)
 }
 
-func setCritAncestorCondition(log logr.Logger, inst *tenancy.HierarchyConfiguration, ns *forest.Namespace) {
+func setCritAncestorCondition(log logr.Logger, inst *api.HierarchyConfiguration, ns *forest.Namespace) {
 	ans := ns.Parent()
 	for ans != nil {
 		if !ans.HasCritCondition() {
@@ -376,10 +376,10 @@ func setCritAncestorCondition(log logr.Logger, inst *tenancy.HierarchyConfigurat
 		}
 		log.Info("Ancestor has a critical condition", "ancestor", ans.Name())
 		msg := fmt.Sprintf("%s is the most recent ancestor with a critical condition", ans.Name())
-		condition := tenancy.Condition{
-			Code:    tenancy.CritAncestor,
+		condition := api.Condition{
+			Code:    api.CritAncestor,
 			Msg:     msg,
-			Affects: []tenancy.AffectedObject{{Namespace: ans.Name()}},
+			Affects: []api.AffectedObject{{Namespace: ans.Name()}},
 		}
 		inst.Status.Conditions = append(inst.Status.Conditions, condition)
 		return
@@ -394,15 +394,15 @@ func (r *HierarchyReconciler) enqueueAffected(log logr.Logger, reason string, af
 		for _, nm := range affected {
 			log.Info("Enqueuing for reconcilation", "affected", nm, "reason", reason)
 			// The watch handler doesn't care about anything except the metadata.
-			inst := &tenancy.HierarchyConfiguration{}
-			inst.ObjectMeta.Name = tenancy.Singleton
+			inst := &api.HierarchyConfiguration{}
+			inst.ObjectMeta.Name = api.Singleton
 			inst.ObjectMeta.Namespace = nm
 			r.Affected <- event.GenericEvent{Meta: inst}
 		}
 	}()
 }
 
-func (r *HierarchyReconciler) getInstances(ctx context.Context, log logr.Logger, nm string) (inst *tenancy.HierarchyConfiguration, ns *corev1.Namespace, err error) {
+func (r *HierarchyReconciler) getInstances(ctx context.Context, log logr.Logger, nm string) (inst *api.HierarchyConfiguration, ns *corev1.Namespace, err error) {
 	inst, err = r.getSingleton(ctx, nm)
 	if err != nil {
 		log.Error(err, "Couldn't read singleton")
@@ -417,7 +417,7 @@ func (r *HierarchyReconciler) getInstances(ctx context.Context, log logr.Logger,
 	return inst, ns, nil
 }
 
-func (r *HierarchyReconciler) writeInstances(ctx context.Context, log logr.Logger, oldHC, newHC *tenancy.HierarchyConfiguration, oldNS, newNS *corev1.Namespace) error {
+func (r *HierarchyReconciler) writeInstances(ctx context.Context, log logr.Logger, oldHC, newHC *api.HierarchyConfiguration, oldNS, newNS *corev1.Namespace) error {
 	if err := r.writeHierarchy(ctx, log, oldHC, newHC); err != nil {
 		return err
 	}
@@ -427,7 +427,7 @@ func (r *HierarchyReconciler) writeInstances(ctx context.Context, log logr.Logge
 	return nil
 }
 
-func (r *HierarchyReconciler) writeHierarchy(ctx context.Context, log logr.Logger, orig, inst *tenancy.HierarchyConfiguration) error {
+func (r *HierarchyReconciler) writeHierarchy(ctx context.Context, log logr.Logger, orig, inst *api.HierarchyConfiguration) error {
 	if reflect.DeepEqual(orig, inst) {
 		return nil
 	}
@@ -502,16 +502,16 @@ func (r *HierarchyReconciler) unlockNamespace(nm string) {
 }
 
 // getSingleton returns the singleton if it exists, or creates an empty one if it doesn't.
-func (r *HierarchyReconciler) getSingleton(ctx context.Context, nm string) (*tenancy.HierarchyConfiguration, error) {
-	nnm := types.NamespacedName{Namespace: nm, Name: tenancy.Singleton}
-	inst := &tenancy.HierarchyConfiguration{}
+func (r *HierarchyReconciler) getSingleton(ctx context.Context, nm string) (*api.HierarchyConfiguration, error) {
+	nnm := types.NamespacedName{Namespace: nm, Name: api.Singleton}
+	inst := &api.HierarchyConfiguration{}
 	if err := r.Get(ctx, nnm, inst); err != nil {
 		if !errors.IsNotFound(err) {
 			return nil, err
 		}
 
 		// It doesn't exist - initialize it to a sane initial value.
-		inst.ObjectMeta.Name = tenancy.Singleton
+		inst.ObjectMeta.Name = api.Singleton
 		inst.ObjectMeta.Namespace = nm
 	}
 
@@ -539,13 +539,13 @@ func (r *HierarchyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		func(a handler.MapObject) []reconcile.Request {
 			return []reconcile.Request{
 				{NamespacedName: types.NamespacedName{
-					Name:      tenancy.Singleton,
+					Name:      api.Singleton,
 					Namespace: a.Meta.GetName(),
 				}},
 			}
 		})
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&tenancy.HierarchyConfiguration{}).
+		For(&api.HierarchyConfiguration{}).
 		Watches(&source.Channel{Source: r.Affected}, &handler.EnqueueRequestForObject{}).
 		Watches(&source.Kind{Type: &corev1.Namespace{}}, &handler.EnqueueRequestsFromMapFunc{ToRequests: nsMapFn}).
 		Complete(r)

--- a/incubator/hnc/pkg/controllers/hierarchy_controller_test.go
+++ b/incubator/hnc/pkg/controllers/hierarchy_controller_test.go
@@ -10,7 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	tenancy "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
 )
 
 const (
@@ -45,7 +45,7 @@ var _ = Describe("Hierarchy", func() {
 		barHier := newHierarchy(barName)
 		barHier.Spec.Parent = "brumpf"
 		updateHierarchy(ctx, barHier)
-		Eventually(hasCondition(ctx, barName, tenancy.CritParentMissing)).Should(Equal(true))
+		Eventually(hasCondition(ctx, barName, api.CritParentMissing)).Should(Equal(true))
 	})
 
 	It("should unset CritParentMissing condition if the parent is later created", func() {
@@ -54,7 +54,7 @@ var _ = Describe("Hierarchy", func() {
 		barHier := newHierarchy(barName)
 		barHier.Spec.Parent = brumpfName
 		updateHierarchy(ctx, barHier)
-		Eventually(hasCondition(ctx, barName, tenancy.CritParentMissing)).Should(Equal(true))
+		Eventually(hasCondition(ctx, barName, api.CritParentMissing)).Should(Equal(true))
 
 		// Create the missing parent
 		brumpfNS := &corev1.Namespace{}
@@ -62,7 +62,7 @@ var _ = Describe("Hierarchy", func() {
 		Expect(k8sClient.Create(ctx, brumpfNS)).Should(Succeed())
 
 		// Ensure the condition is resolved on the child
-		Eventually(hasCondition(ctx, barName, tenancy.CritParentMissing)).Should(Equal(false))
+		Eventually(hasCondition(ctx, barName, api.CritParentMissing)).Should(Equal(false))
 
 		// Ensure the child is listed on the parent
 		Eventually(func() []string {
@@ -76,13 +76,13 @@ var _ = Describe("Hierarchy", func() {
 		barHier := newHierarchy(barName)
 		barHier.Spec.Parent = "brumpf"
 		updateHierarchy(ctx, barHier)
-		Eventually(hasCondition(ctx, barName, tenancy.CritParentMissing)).Should(Equal(true))
+		Eventually(hasCondition(ctx, barName, api.CritParentMissing)).Should(Equal(true))
 
 		// Set bar as foo's parent
 		fooHier := newHierarchy(fooName)
 		fooHier.Spec.Parent = barName
 		updateHierarchy(ctx, fooHier)
-		Eventually(hasCondition(ctx, fooName, tenancy.CritAncestor)).Should(Equal(true))
+		Eventually(hasCondition(ctx, fooName, api.CritAncestor)).Should(Equal(true))
 	})
 
 	It("should unset CritAncestor condition if critical conditions in ancestors are gone", func() {
@@ -91,13 +91,13 @@ var _ = Describe("Hierarchy", func() {
 		barHier := newHierarchy(barName)
 		barHier.Spec.Parent = brumpfName
 		updateHierarchy(ctx, barHier)
-		Eventually(hasCondition(ctx, barName, tenancy.CritParentMissing)).Should(Equal(true))
+		Eventually(hasCondition(ctx, barName, api.CritParentMissing)).Should(Equal(true))
 
 		// Set bar as foo's parent
 		fooHier := newHierarchy(fooName)
 		fooHier.Spec.Parent = barName
 		updateHierarchy(ctx, fooHier)
-		Eventually(hasCondition(ctx, fooName, tenancy.CritAncestor)).Should(Equal(true))
+		Eventually(hasCondition(ctx, fooName, api.CritAncestor)).Should(Equal(true))
 
 		// Create the missing parent
 		brumpfNS := &corev1.Namespace{}
@@ -105,7 +105,7 @@ var _ = Describe("Hierarchy", func() {
 		Expect(k8sClient.Create(ctx, brumpfNS)).Should(Succeed())
 
 		// Ensure the condition is resolved on the child
-		Eventually(hasCondition(ctx, barName, tenancy.CritParentMissing)).Should(Equal(false))
+		Eventually(hasCondition(ctx, barName, api.CritParentMissing)).Should(Equal(false))
 
 		// Ensure the child is listed on the parent
 		Eventually(func() []string {
@@ -115,14 +115,14 @@ var _ = Describe("Hierarchy", func() {
 
 		// Ensure foo is enqueued and thus get CritAncestor condition updated after
 		// critical conditions are resolved in bar.
-		Eventually(hasCondition(ctx, fooName, tenancy.CritAncestor)).Should(Equal(false))
+		Eventually(hasCondition(ctx, fooName, api.CritAncestor)).Should(Equal(false))
 	})
 
 	It("should set CritParentInvalid condition if a self-cycle is detected", func() {
 		fooHier := newHierarchy(fooName)
 		fooHier.Spec.Parent = fooName
 		updateHierarchy(ctx, fooHier)
-		Eventually(hasCondition(ctx, fooName, tenancy.CritParentInvalid)).Should(Equal(true))
+		Eventually(hasCondition(ctx, fooName, api.CritParentInvalid)).Should(Equal(true))
 	})
 
 	It("should set CritParentInvalid condition if a cycle is detected", func() {
@@ -138,7 +138,7 @@ var _ = Describe("Hierarchy", func() {
 		fooHier := getHierarchy(ctx, fooName)
 		fooHier.Spec.Parent = barName
 		updateHierarchy(ctx, fooHier)
-		Eventually(hasCondition(ctx, fooName, tenancy.CritParentInvalid)).Should(Equal(true))
+		Eventually(hasCondition(ctx, fooName, api.CritParentInvalid)).Should(Equal(true))
 	})
 
 	It("should create a child namespace if requested", func() {
@@ -173,9 +173,9 @@ var _ = Describe("Hierarchy", func() {
 		updateHierarchy(ctx, barHier)
 
 		// Verify that all three namespaces have CritRequiredChildConflict condition set.
-		Eventually(hasCondition(ctx, fooName, tenancy.CritRequiredChildConflict)).Should(Equal(true))
-		Eventually(hasCondition(ctx, barName, tenancy.CritRequiredChildConflict)).Should(Equal(true))
-		Eventually(hasCondition(ctx, bazName, tenancy.CritRequiredChildConflict)).Should(Equal(true))
+		Eventually(hasCondition(ctx, fooName, api.CritRequiredChildConflict)).Should(Equal(true))
+		Eventually(hasCondition(ctx, barName, api.CritRequiredChildConflict)).Should(Equal(true))
+		Eventually(hasCondition(ctx, bazName, api.CritRequiredChildConflict)).Should(Equal(true))
 	})
 
 	It("should have a tree label", func() {
@@ -227,7 +227,7 @@ var _ = Describe("Hierarchy", func() {
 	})
 })
 
-func hasCondition(ctx context.Context, nm string, code tenancy.Code) func() bool {
+func hasCondition(ctx context.Context, nm string, code api.Code) func() bool {
 	return func() bool {
 		conds := getHierarchy(ctx, nm).Status.Conditions
 		for _, cond := range conds {
@@ -239,20 +239,20 @@ func hasCondition(ctx context.Context, nm string, code tenancy.Code) func() bool
 	}
 }
 
-func newHierarchy(nm string) *tenancy.HierarchyConfiguration {
-	hier := &tenancy.HierarchyConfiguration{}
+func newHierarchy(nm string) *api.HierarchyConfiguration {
+	hier := &api.HierarchyConfiguration{}
 	hier.ObjectMeta.Namespace = nm
-	hier.ObjectMeta.Name = tenancy.Singleton
+	hier.ObjectMeta.Name = api.Singleton
 	return hier
 }
 
-func getHierarchy(ctx context.Context, nm string) *tenancy.HierarchyConfiguration {
+func getHierarchy(ctx context.Context, nm string) *api.HierarchyConfiguration {
 	return getHierarchyWithOffset(1, ctx, nm)
 }
 
-func getHierarchyWithOffset(offset int, ctx context.Context, nm string) *tenancy.HierarchyConfiguration {
-	snm := types.NamespacedName{Namespace: nm, Name: tenancy.Singleton}
-	hier := &tenancy.HierarchyConfiguration{}
+func getHierarchyWithOffset(offset int, ctx context.Context, nm string) *api.HierarchyConfiguration {
+	snm := types.NamespacedName{Namespace: nm, Name: api.Singleton}
+	hier := &api.HierarchyConfiguration{}
 	EventuallyWithOffset(offset+1, func() error {
 		return k8sClient.Get(ctx, snm, hier)
 	}).Should(Succeed())
@@ -272,7 +272,7 @@ func getNamespaceWithOffset(offset int, ctx context.Context, nm string) *corev1.
 	return ns
 }
 
-func updateHierarchy(ctx context.Context, h *tenancy.HierarchyConfiguration) {
+func updateHierarchy(ctx context.Context, h *api.HierarchyConfiguration) {
 	if h.CreationTimestamp.IsZero() {
 		Expect(k8sClient.Create(ctx, h)).Should(Succeed())
 	} else {

--- a/incubator/hnc/pkg/controllers/object_controller_test.go
+++ b/incubator/hnc/pkg/controllers/object_controller_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
-	tenancy "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
 )
 
 var _ = Describe("Secret", func() {
@@ -148,11 +148,11 @@ func setParent(ctx context.Context, nm string, pnm string) {
 	}
 }
 
-func newOrGetHierarchy(ctx context.Context, nm string) *tenancy.HierarchyConfiguration {
-	hier := &tenancy.HierarchyConfiguration{}
+func newOrGetHierarchy(ctx context.Context, nm string) *api.HierarchyConfiguration {
+	hier := &api.HierarchyConfiguration{}
 	hier.ObjectMeta.Namespace = nm
-	hier.ObjectMeta.Name = tenancy.Singleton
-	snm := types.NamespacedName{Namespace: nm, Name: tenancy.Singleton}
+	hier.ObjectMeta.Name = api.Singleton
+	snm := types.NamespacedName{Namespace: nm, Name: api.Singleton}
 	if err := k8sClient.Get(ctx, snm, hier); err != nil {
 		ExpectWithOffset(2, errors.IsNotFound(err)).Should(BeTrue())
 	}

--- a/incubator/hnc/pkg/controllers/suite_test.go
+++ b/incubator/hnc/pkg/controllers/suite_test.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	// +kubebuilder:scaffold:imports
 
-	tenancy "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/controllers"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/forest"
 )
@@ -69,7 +69,7 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
 
-	err = tenancy.AddToScheme(scheme.Scheme)
+	err = api.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = corev1.AddToScheme(scheme.Scheme)

--- a/incubator/hnc/pkg/kubectl/tree.go
+++ b/incubator/hnc/pkg/kubectl/tree.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	tenancy "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
 )
 
 var (
@@ -52,7 +52,7 @@ var treeCmd = &cobra.Command{
 	},
 }
 
-func printSubtree(prefix string, hier *tenancy.HierarchyConfiguration) {
+func printSubtree(prefix string, hier *api.HierarchyConfiguration) {
 	for i, cn := range hier.Status.Children {
 		ch := getHierarchy(cn)
 		tx := nameAndFootnotes(ch)
@@ -66,7 +66,7 @@ func printSubtree(prefix string, hier *tenancy.HierarchyConfiguration) {
 	}
 }
 
-func nameAndFootnotes(hier *tenancy.HierarchyConfiguration) string {
+func nameAndFootnotes(hier *api.HierarchyConfiguration) string {
 	notes := []int{}
 	for _, cond := range hier.Status.Conditions {
 		txt := cond.Msg


### PR DESCRIPTION
We used to import the HNC API as `tenancy` because the APIs were
initially in the `tenancy.k8s.io` group (or something like that). Now,
however, they're in `hnc.x-k8s.io` and calling that API "tenancy"
doesn't really make sense anymore. Importing it as `api` is unambiguous
in the context of the HNC (all other imported APIs are named) and is
also shorter to type and easier to read.

/cc @yiqigao217 
/cc @lafh 
/assign @rjbez17 