### PR TITLE
Improvements to generation and display of conditions

### DIFF
--- a/incubator/hnc/pkg/kubectl/tree.go
+++ b/incubator/hnc/pkg/kubectl/tree.go
@@ -66,15 +66,17 @@ func printSubtree(prefix string, hier *tenancy.HierarchyConfiguration) {
 	}
 }
 
+// nameAndFootnotes returns the text to print to describe the namespace, in the form of the
+// namespace's name along with references to any footnotes. Example: default (1)
 func nameAndFootnotes(hier *tenancy.HierarchyConfiguration) string {
 	notes := []int{}
 	for _, cond := range hier.Status.Conditions {
-		txt := cond.Msg
+		txt := (string)(cond.Code) + ": " + cond.Msg
 		if idx, ok := footnotesByMsg[txt]; ok {
 			notes = append(notes, idx)
 		} else {
 			footnotes = append(footnotes, txt)
-			footnotesByMsg[cond.Msg] = len(footnotes)
+			footnotesByMsg[txt] = len(footnotes)
 			notes = append(notes, len(footnotes))
 		}
 	}


### PR DESCRIPTION
Changes:

- Better human-readable message for critical conditions in an ancestor.
- In `kubectl-hnc show`, pretty-prints all information from the
conditions, including the code and affected namespaces.
- In `kubectl-hnc tree`, the condition codes are now shown.
- Verbose log messages removed.

Tested: manually caused some conditions and verified that they were
reported correctly.