### PR TITLE
Include UserInfo.Extra in authz check

### DIFF
--- a/incubator/hnc/pkg/validators/hierarchy.go
+++ b/incubator/hnc/pkg/validators/hierarchy.go
@@ -308,6 +308,12 @@ type realAuthzClient struct {
 
 // IsAdmin implements authzClient
 func (r *realAuthzClient) IsAdmin(ctx context.Context, ui *authnv1.UserInfo, nnm string) (bool, error) {
+	// Convert the Extra type
+	authzExtra := map[string]authzv1.ExtraValue{}
+	for k, v := range ui.Extra {
+		authzExtra[k] = (authzv1.ExtraValue)(v)
+	}
+
 	// Construct the request
 	sar := &authzv1.SubjectAccessReview{
 		Spec: authzv1.SubjectAccessReviewSpec{
@@ -321,7 +327,7 @@ func (r *realAuthzClient) IsAdmin(ctx context.Context, ui *authnv1.UserInfo, nnm
 			User:   ui.Username,
 			Groups: ui.Groups,
 			UID:    ui.UID,
-			// TODO: add Extra (need to convert the types)
+			Extra:  authzExtra,
 		},
 	}
 


### PR DESCRIPTION
I'd left this out because I was too lazy to do the type conversion in
the initial checkin and it didn't seem to be needed, but GKE uses it for
supplemental authn information when authorizing via IAM instead of RBAC.

Tested: validation fails without this change on GKE, passes with it.