### PR TITLE
Add --optionalChild flag and assorted changes to kubectl-hnc-set

### DIFF
--- a/incubator/hnc/pkg/kubectl/root.go
+++ b/incubator/hnc/pkg/kubectl/root.go
@@ -72,6 +72,10 @@ func init() {
 		},
 	}
 	kubecfgFlags.AddFlags(rootCmd.PersistentFlags())
+
+	rootCmd.AddCommand(newSetCmd())
+	rootCmd.AddCommand(newShowCmd())
+	rootCmd.AddCommand(newTreeCmd())
 }
 
 func Execute() {

--- a/incubator/hnc/pkg/kubectl/show.go
+++ b/incubator/hnc/pkg/kubectl/show.go
@@ -75,6 +75,6 @@ var showCmd = &cobra.Command{
 	},
 }
 
-func init() {
-	rootCmd.AddCommand(showCmd)
+func newShowCmd() *cobra.Command {
+	return showCmd
 }

--- a/incubator/hnc/pkg/kubectl/tree.go
+++ b/incubator/hnc/pkg/kubectl/tree.go
@@ -90,6 +90,6 @@ func nameAndFootnotes(hier *tenancy.HierarchyConfiguration) string {
 	return fmt.Sprintf("%s (%s)", hier.Namespace, strings.Join(ns, ","))
 }
 
-func init() {
-	rootCmd.AddCommand(treeCmd)
+func newTreeCmd() *cobra.Command {
+	return treeCmd
 }


### PR DESCRIPTION
Other changes:

- Fixed initialization segfault when the init() functions stopped
being called in the order I wanted (oops).
- Only all `getHierarchy` and `updateHierarchy` once during `set` with
better messages explaining what's going on.

Tested: manually confirmed that illegal names or valid, existing
required children were removed. Also retried --parent, --root and
--requiredChild in various combinations and everythign seems to work as
expected. Filed
https://github.com/kubernetes-sigs/multi-tenancy/issues/173 to add
better unit testing in the future.

/cc @vjdhama 
/assign @rjbez17 