### PR TITLE
Code refactoring: move constants declared in `controller` to be in `api`

### DIFF
--- a/incubator/hnc/api/v1alpha1/hierarchy_types.go
+++ b/incubator/hnc/api/v1alpha1/hierarchy_types.go
@@ -28,6 +28,9 @@ const (
 	CritAncestor              Code = "CRIT_ANCESTOR"
 	ObjectOverridden          Code = "OBJECT_OVERRIDDEN"
 	ObjectDescendantOverriden Code = "OBJECT_DESCENDANT_OVERRIDDEN"
+	MetaGroup                      = "hnc.x-k8s.io"
+	LabelInheritedFrom             = MetaGroup + "/inheritedFrom"
+	AnnotationModified             = MetaGroup + "/modified"
 )
 
 var (

--- a/incubator/hnc/pkg/controllers/hierarchy_controller.go
+++ b/incubator/hnc/pkg/controllers/hierarchy_controller.go
@@ -265,7 +265,7 @@ func (r *HierarchyReconciler) syncLabel(log logr.Logger, nsInst *corev1.Namespac
 	// AncestoryNames includes the namespace itself.
 	ancestors := ns.AncestoryNames(nil)
 	for i, ancestor := range ancestors {
-		labelDepthSuffix := ancestor + ".tree." + metaGroup + "/depth"
+		labelDepthSuffix := ancestor + ".tree." + api.MetaGroup + "/depth"
 		dist := strconv.Itoa(len(ancestors) - i - 1)
 		setLabel(nsInst, labelDepthSuffix, dist)
 	}

--- a/incubator/hnc/pkg/controllers/hierarchy_controller_test.go
+++ b/incubator/hnc/pkg/controllers/hierarchy_controller_test.go
@@ -13,10 +13,6 @@ import (
 	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
 )
 
-const (
-	metaGroup = "hnc.x-k8s.io"
-)
-
 var _ = Describe("Hierarchy", func() {
 	ctx := context.Background()
 
@@ -190,38 +186,38 @@ var _ = Describe("Hierarchy", func() {
 		// Verify that bar has a tree label related to foo
 		Eventually(func() bool {
 			barNS := getNamespace(ctx, barName)
-			_, ok := barNS.GetLabels()[fooName+".tree."+metaGroup+"/depth"]
+			_, ok := barNS.GetLabels()[fooName+".tree."+api.MetaGroup+"/depth"]
 			return ok
 		}).Should(BeTrue())
 		// Verify the label value
 		Eventually(func() string {
 			barNS := getNamespace(ctx, barName)
-			val, _ := barNS.GetLabels()[fooName+".tree."+metaGroup+"/depth"]
+			val, _ := barNS.GetLabels()[fooName+".tree."+api.MetaGroup+"/depth"]
 			return val
 		}).Should(Equal("1"))
 		// Verify that bar has a tree label related to bar itself
 		Eventually(func() bool {
 			barNS := getNamespace(ctx, barName)
-			_, ok := barNS.GetLabels()[barName+".tree."+metaGroup+"/depth"]
+			_, ok := barNS.GetLabels()[barName+".tree."+api.MetaGroup+"/depth"]
 			return ok
 		}).Should(BeTrue())
 		// Verify the label value
 		Eventually(func() string {
 			barNS := getNamespace(ctx, barName)
-			val, _ := barNS.GetLabels()[barName+".tree."+metaGroup+"/depth"]
+			val, _ := barNS.GetLabels()[barName+".tree."+api.MetaGroup+"/depth"]
 			return val
 		}).Should(Equal("0"))
 		// Verify that foo has a tree label related to foo itself
 		Eventually(func() bool {
 			fmt.Println(getHierarchy(ctx, fooName))
 			fooNS := getNamespace(ctx, fooName)
-			_, ok := fooNS.GetLabels()[fooName+".tree."+metaGroup+"/depth"]
+			_, ok := fooNS.GetLabels()[fooName+".tree."+api.MetaGroup+"/depth"]
 			return ok
 		}).Should(BeTrue())
 		// Verify the label value
 		Eventually(func() string {
 			fooNS := getNamespace(ctx, fooName)
-			val, _ := fooNS.GetLabels()[fooName+".tree."+metaGroup+"/depth"]
+			val, _ := fooNS.GetLabels()[fooName+".tree."+api.MetaGroup+"/depth"]
 			return val
 		}).Should(Equal("0"))
 	})


### PR DESCRIPTION
The constants all are part of the API so there's no point for them to be in the `controller` package.

Tested by running `make test`

/assign @adrianludwin 