### PR TITLE
Enable multithreading in the HC controller

### DIFF
--- a/incubator/hnc/cmd/manager/main.go
+++ b/incubator/hnc/cmd/manager/main.go
@@ -51,6 +51,7 @@ func init() {
 func main() {
 	var (
 		metricsAddr          string
+		maxReconciles        int
 		enableLeaderElection bool
 		novalidation         bool
 		debugLogs            bool
@@ -60,6 +61,7 @@ func main() {
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&novalidation, "novalidation", false, "Disables validating webhook")
 	flag.BoolVar(&debugLogs, "debug-logs", false, "Shows verbose logs in a human-friendly format.")
+	flag.IntVar(&maxReconciles, "max-reconciles", 1, "Number of concurrent reconciles to perform.")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.Logger(debugLogs))
@@ -76,7 +78,8 @@ func main() {
 
 	// Create all reconciling controllers
 	f := forest.NewForest()
-	if err := controllers.Create(mgr, f); err != nil {
+	setupLog.Info("Creating controllers", "maxReconciles", maxReconciles)
+	if err := controllers.Create(mgr, f, maxReconciles); err != nil {
 		setupLog.Error(err, "cannot create controllers")
 		os.Exit(1)
 	}

--- a/incubator/hnc/config/default/manager_auth_proxy_patch.yaml
+++ b/incubator/hnc/config/default/manager_auth_proxy_patch.yaml
@@ -23,3 +23,4 @@ spec:
         args:
         - "--metrics-addr=127.0.0.1:8080"
         - "--enable-leader-election"
+        - "--max-reconciles=10"

--- a/incubator/hnc/config/manager/manager.yaml
+++ b/incubator/hnc/config/manager/manager.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
       - command:
         - /manager
-        args:
+        args: # overridden if manager_auth_proxy_patch.yaml is used
         - --enable-leader-election
         image: controller:latest
         name: manager

--- a/incubator/hnc/pkg/controllers/setup.go
+++ b/incubator/hnc/pkg/controllers/setup.go
@@ -15,7 +15,7 @@ import (
 // configuration object.
 //
 // This function is called both from main.go as well as from the integ tests.
-func Create(mgr ctrl.Manager, f *forest.Forest) error {
+func Create(mgr ctrl.Manager, f *forest.Forest, maxReconciles int) error {
 	// Create all object reconcillers
 	gvks := []schema.GroupVersionKind{
 		{Group: "", Version: "v1", Kind: "Secret"},
@@ -48,7 +48,7 @@ func Create(mgr ctrl.Manager, f *forest.Forest) error {
 		Types:    objReconcilers,
 		Affected: make(chan event.GenericEvent),
 	}
-	if err := hr.SetupWithManager(mgr); err != nil {
+	if err := hr.SetupWithManager(mgr, maxReconciles); err != nil {
 		return fmt.Errorf("cannot create Hierarchy controller: %s", err.Error())
 	}
 

--- a/incubator/hnc/pkg/controllers/suite_test.go
+++ b/incubator/hnc/pkg/controllers/suite_test.go
@@ -83,7 +83,7 @@ var _ = BeforeSuite(func(done Done) {
 		Scheme: scheme.Scheme,
 	})
 	Expect(err).ToNot(HaveOccurred())
-	err = controllers.Create(k8sManager, forest.NewForest())
+	err = controllers.Create(k8sManager, forest.NewForest(), 100)
 	Expect(err).ToNot(HaveOccurred())
 
 	k8sClient = k8sManager.GetClient()


### PR DESCRIPTION
Tested: manual testing on GKE. I also instrumented the logs (removed in
this commit) to report the maximum actual concurrency when I started 100
threads; it peaked at about 15. However, the "startup time" (the time
from when the controller starts to when it stops making changes) didn't
change on my test cases and remained constant at about 30s. However,
think it's a good idea to turn this on now to flush out any problems.

Fixes #102 