### PR TITLE
Prevent users from applying the inheritedFrom label

### DIFF
--- a/incubator/hnc/cmd/manager/main.go
+++ b/incubator/hnc/cmd/manager/main.go
@@ -86,9 +86,16 @@ func main() {
 
 	// Create validating admission controllers
 	if !novalidation {
+		// Create webhook for Hierarchy
 		setupLog.Info("Registering validating webhook (won't work when running locally; use --novalidation)")
 		mgr.GetWebhookServer().Register(validators.HierarchyServingPath, &webhook.Admission{Handler: &validators.Hierarchy{
 			Log:    ctrl.Log.WithName("validators").WithName("Hierarchy"),
+			Forest: f,
+		}})
+
+		// Create webhooks for managed objects
+		mgr.GetWebhookServer().Register(validators.ObjectsServingPath, &webhook.Admission{Handler: &validators.Object{
+			Log:    ctrl.Log.WithName("validators").WithName("Object"),
 			Forest: f,
 		}})
 	}

--- a/incubator/hnc/pkg/config/gvk.go
+++ b/incubator/hnc/pkg/config/gvk.go
@@ -1,0 +1,16 @@
+package config
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+// GVKs is currently hardcoded to the set of GVKs handled by the HNC - namely, Secrets,
+// Roles and RoleBindings - but in the future we should get this from a
+// configuration object.
+var GVKs = []schema.GroupVersionKind{
+	{Group: "", Version: "v1", Kind: "Secret"},
+	{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "Role"},
+	{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "RoleBinding"},
+	{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"},
+	{Group: "", Version: "v1", Kind: "ResourceQuota"},
+	{Group: "", Version: "v1", Kind: "LimitRange"},
+	{Group: "", Version: "v1", Kind: "ConfigMap"},
+}

--- a/incubator/hnc/pkg/controllers/setup.go
+++ b/incubator/hnc/pkg/controllers/setup.go
@@ -3,31 +3,20 @@ package controllers
 import (
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/config"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/forest"
 )
 
-// Create creates all reconcilers. For now, it also hardcodes the list of GVKs handled by the HNC -
-// namely, Secrets, Roles and RoleBindings - but in the future we should get this from a
-// configuration object.
+// Create creates all reconcilers.
 //
 // This function is called both from main.go as well as from the integ tests.
 func Create(mgr ctrl.Manager, f *forest.Forest, maxReconciles int) error {
 	// Create all object reconcillers
-	gvks := []schema.GroupVersionKind{
-		{Group: "", Version: "v1", Kind: "Secret"},
-		{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "Role"},
-		{Group: "rbac.authorization.k8s.io", Version: "v1", Kind: "RoleBinding"},
-		{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"},
-		{Group: "", Version: "v1", Kind: "ResourceQuota"},
-		{Group: "", Version: "v1", Kind: "LimitRange"},
-		{Group: "", Version: "v1", Kind: "ConfigMap"},
-	}
 	objReconcilers := []NamespaceSyncer{}
-	for _, gvk := range gvks {
+	for _, gvk := range config.GVKs {
 		or := &ObjectReconciler{
 			Client: mgr.GetClient(),
 			Log:    ctrl.Log.WithName("controllers").WithName(gvk.Kind),

--- a/incubator/hnc/pkg/validators/hierarchy.go
+++ b/incubator/hnc/pkg/validators/hierarchy.go
@@ -405,6 +405,8 @@ func codeFromReason(reason metav1.StatusReason) int32 {
 		return 500
 	case metav1.StatusReasonUnauthorized:
 		return 401
+	case metav1.StatusReasonForbidden:
+		return 403
 	case metav1.StatusReasonConflict:
 		return 409
 	case metav1.StatusReasonBadRequest:

--- a/incubator/hnc/pkg/validators/object.go
+++ b/incubator/hnc/pkg/validators/object.go
@@ -1,0 +1,119 @@
+package validators
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/forest"
+)
+
+// ObjectsServingPath is where the validator will run. Must be kept in sync with the
+// kubebuilder markers below.
+const (
+	ObjectsServingPath = "/validate-objects"
+)
+
+// Note: the validating webhook FAILS OPEN. This means that if the webhook goes down, all further
+// changes to the objects are allowed.
+//
+// +kubebuilder:webhook:path=/validate-objects,mutating=false,failurePolicy=ignore,groups="",resources=secrets,verbs=create;update,versions=v1,name=secrets
+// +kubebuilder:webhook:path=/validate-objects,mutating=false,failurePolicy=ignore,groups="rbac.authorization.k8s.io",resources=rols,verbs=create;update,versions=v1,name=roles.rbac.authorization.k8s.io
+// +kubebuilder:webhook:path=/validate-objects,mutating=false,failurePolicy=ignore,groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=create;update,versions=v1,name=rolebindings.rbac.authorization.k8s.io
+// +kubebuilder:webhook:path=/validate-objects,mutating=false,failurePolicy=ignore,groups="networking.k8s.io",resources=networkpolicies,verbs=create;update,versions=v1,name=networkpolicies.networking.k8s.io
+// +kubebuilder:webhook:path=/validate-objects,mutating=false,failurePolicy=ignore,groups="",resources=resourcequotas,verbs=create;update,versions=v1,name=resourcesquotas
+// +kubebuilder:webhook:path=/validate-objects,mutating=false,failurePolicy=ignore,groups="",resources=limitranges,verbs=create;update,versions=v1,name=limitranges
+// +kubebuilder:webhook:path=/validate-objects,mutating=false,failurePolicy=ignore,groups="",resources=configmaps,verbs=create;update,versions=v1,name=configmaps
+
+type Object struct {
+	Log     logr.Logger
+	Forest  *forest.Forest
+	client  client.Client
+	decoder *admission.Decoder
+}
+
+func (o *Object) Handle(ctx context.Context, req admission.Request) admission.Response {
+	log := o.Log.WithValues("nm", req.Name, "nnm", req.Namespace)
+	if isHNCServiceAccount(&req.AdmissionRequest.UserInfo) {
+		log.Info("Allowed change by HNC SA")
+		return allow("HNC SA")
+	}
+
+	inst := &unstructured.Unstructured{}
+	if err := o.decoder.Decode(req, inst); err != nil {
+		log.Error(err, "Couldn't decode req.Object", "raw", req.Object)
+		return deny(metav1.StatusReasonBadRequest, err.Error())
+	}
+	log = log.WithValues("object", inst.GetName())
+
+	oldInst := &unstructured.Unstructured{}
+	// req.OldObject is the existing object. DecodeRaw will return an error if it's empty, so we should skip the decoding here.
+	if len(req.OldObject.Raw) > 0 {
+		if err := o.decoder.DecodeRaw(req.OldObject, oldInst); err != nil {
+			log.Error(err, "Couldn't decode req.OldObject", "raw", req.OldObject)
+			return deny(metav1.StatusReasonBadRequest, err.Error())
+		}
+	}
+
+	resp := o.handle(ctx, log, inst, oldInst)
+	log.Info("Handled", "allowed", resp.Allowed, "code", resp.Result.Code, "reason", resp.Result.Reason, "message", resp.Result.Message)
+	return resp
+}
+
+// handle implements the non-webhook-y businesss logic of this validator, allowing it to be more
+// easily unit tested (ie without constructing an admission.Request, setting up user infos, etc).
+func (o *Object) handle(ctx context.Context, log logr.Logger, inst *unstructured.Unstructured, oldInst *unstructured.Unstructured) admission.Response {
+	oldValue, oldExists := getLabel(oldInst, api.LabelInheritedFrom)
+	newValue, newExists := getLabel(inst, api.LabelInheritedFrom)
+	// If old object holds the label but the new one doesn't, reject it. Vice versa.
+	if oldExists != newExists {
+		verb := "add"
+		if !newExists {
+			verb = "remove"
+		}
+		return deny(metav1.StatusReasonForbidden, "Users should not "+verb+" the label "+api.LabelInheritedFrom)
+	}
+	// If both old and new objects hold the label but with different values, reject it.
+	if newExists && newValue != oldValue {
+		return deny(metav1.StatusReasonForbidden, "Users should not change the value of label "+api.LabelInheritedFrom)
+	}
+	return allow("")
+}
+
+func (o *Object) InjectClient(c client.Client) error {
+	o.client = c
+	return nil
+}
+
+func (o *Object) InjectDecoder(d *admission.Decoder) error {
+	o.decoder = d
+	return nil
+}
+
+type apiInstances interface {
+	GetLabels() map[string]string
+	SetLabels(labels map[string]string)
+}
+
+func setLabel(inst apiInstances, label string, value string) {
+	labels := inst.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[label] = value
+	inst.SetLabels(labels)
+}
+
+func getLabel(inst apiInstances, label string) (string, bool) {
+	labels := inst.GetLabels()
+	if labels == nil {
+		return "", false
+	}
+	value, ok := labels[label]
+	return value, ok
+}

--- a/incubator/hnc/pkg/validators/object_test.go
+++ b/incubator/hnc/pkg/validators/object_test.go
@@ -1,0 +1,69 @@
+package validators
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/forest"
+)
+
+func TestInheritedFromLabel(t *testing.T) {
+	f := forest.NewForest()
+	o := &Object{Forest: f}
+	l := zap.Logger(false)
+
+	tests := []struct {
+		name     string
+		oldLabel string
+		oldValue string
+		newLabel string
+		newValue string
+		fail     bool
+	}{{
+		name:     "Regular labels can be changed",
+		oldLabel: "oldLabel", oldValue: "foo",
+		newLabel: "newLabel", newValue: "bar",
+	}, {
+		name:     "Label stays the same",
+		oldLabel: api.LabelInheritedFrom, oldValue: "foo",
+		newLabel: api.LabelInheritedFrom, newValue: "foo",
+	}, {
+		name:     "Change in label's value",
+		oldLabel: api.LabelInheritedFrom, oldValue: "foo",
+		newLabel: api.LabelInheritedFrom, newValue: "bar",
+		fail: true,
+	}, {
+		name:     "Label is removed",
+		oldLabel: api.LabelInheritedFrom, oldValue: "foo",
+		fail: true,
+	}, {
+		name:     "Label is added",
+		newLabel: api.LabelInheritedFrom, newValue: "foo",
+		fail: true,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup
+			g := NewGomegaWithT(t)
+			oldInst := &unstructured.Unstructured{}
+			setLabel(oldInst, tc.oldLabel, tc.oldValue)
+			inst := &unstructured.Unstructured{}
+			setLabel(inst, tc.newLabel, tc.newValue)
+
+			// Test
+			got := o.handle(context.Background(), l, inst, oldInst)
+
+			// Report
+			reason := got.AdmissionResponse.Result.Reason
+			code := got.AdmissionResponse.Result.Code
+			t.Logf("Got reason %q, code %d", reason, code)
+			g.Expect(got.AdmissionResponse.Allowed).ShouldNot(Equal(tc.fail))
+		})
+	}
+}


### PR DESCRIPTION
`hnc.x-k8s.io/inheritedFrom` is used by the controller to determine which
objects to manage, so we decide to add a webhook to prevent users from
applying it directly.

Minor Code refactoring: move customized GVKs to `pkg/config` as the usage is not
limited to `controller` only.

/resolve #104 