### PR TITLE
Set object conditions to replace modified annotation

### DIFF
--- a/incubator/hnc/api/v1alpha1/hierarchy_types.go
+++ b/incubator/hnc/api/v1alpha1/hierarchy_types.go
@@ -22,15 +22,14 @@ import (
 // Any changes here need to also be reflected in the kubebuilder:validation:Enum comment, below.
 // The meanings of all these constants are defined in the comment to Condition.Code, below.
 const (
-	CritParentMissing         Code = "CRIT_PARENT_MISSING"
-	CritParentInvalid         Code = "CRIT_PARENT_INVALID"
-	CritRequiredChildConflict Code = "CRIT_REQUIRED_CHILD_CONFLICT"
-	CritAncestor              Code = "CRIT_ANCESTOR"
-	ObjectOverridden          Code = "OBJECT_OVERRIDDEN"
-	ObjectDescendantOverriden Code = "OBJECT_DESCENDANT_OVERRIDDEN"
-	MetaGroup                      = "hnc.x-k8s.io"
-	LabelInheritedFrom             = MetaGroup + "/inheritedFrom"
-	AnnotationModified             = MetaGroup + "/modified"
+	CritParentMissing          Code = "CRIT_PARENT_MISSING"
+	CritParentInvalid          Code = "CRIT_PARENT_INVALID"
+	CritRequiredChildConflict  Code = "CRIT_REQUIRED_CHILD_CONFLICT"
+	CritAncestor               Code = "CRIT_ANCESTOR"
+	ObjectOverridden           Code = "OBJECT_OVERRIDDEN"
+	ObjectDescendantOverridden Code = "OBJECT_DESCENDANT_OVERRIDDEN"
+	MetaGroup                       = "hnc.x-k8s.io"
+	LabelInheritedFrom              = MetaGroup + "/inheritedFrom"
 )
 
 var (


### PR DESCRIPTION
This is a part of #76 and it's related to #89 .

This replaces modified annotation with object conditions when object is
detected as modified from source object. It will set ObjectOverridden
Condition on the modified object and ObjectDescendantOverridden
Condition on the source object. Before propagation, if any ancestor of
the object has ObjectOverridden Condition, it will not be propagated.

Tested: make test and manual test in Kind.