### PR TITLE
HNC: Added Client Interface to support test cases for kubectl commands

### DIFF
--- a/incubator/hnc/pkg/kubectl/set.go
+++ b/incubator/hnc/pkg/kubectl/set.go
@@ -29,7 +29,7 @@ var setCmd = &cobra.Command{
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		nnm := args[0]
-		hc := getHierarchy(nnm)
+		hc := client.getHierarchy(nnm)
 		oldpnm := hc.Spec.Parent
 		flags := cmd.Flags()
 		numChanges := 0
@@ -100,7 +100,7 @@ var setCmd = &cobra.Command{
 		}
 
 		if numChanges > 0 {
-			updateHierarchy(hc, fmt.Sprintf("setting hierarchical configuration of %s", nnm))
+			client.updateHierarchy(hc, fmt.Sprintf("setting hierarchical configuration of %s", nnm))
 			word := "property"
 			if numChanges > 1 {
 				word = "properties"

--- a/incubator/hnc/pkg/kubectl/show.go
+++ b/incubator/hnc/pkg/kubectl/show.go
@@ -30,7 +30,7 @@ var showCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		nnm := args[0]
 		fmt.Printf("Hierarchy configuration for namespace %s\n", nnm)
-		hier := getHierarchy(nnm)
+		hier := client.getHierarchy(nnm)
 
 		// Parent
 		if hier.Spec.Parent != "" {

--- a/incubator/hnc/pkg/kubectl/tree.go
+++ b/incubator/hnc/pkg/kubectl/tree.go
@@ -50,7 +50,7 @@ var treeCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		for _, nnm := range nsList {
-			hier := getHierarchy(nnm)
+			hier := client.getHierarchy(nnm)
 			//If we're showing the default list, skip all non-root namespaces since they'll be displayed as part of another namespace's tree.
 			if defaultList && hier.Spec.Parent != "" {
 				continue
@@ -70,7 +70,7 @@ var treeCmd = &cobra.Command{
 
 func printSubtree(prefix string, hier *api.HierarchyConfiguration) {
 	for i, cn := range hier.Status.Children {
-		ch := getHierarchy(cn)
+		ch := client.getHierarchy(cn)
 		tx := nameAndFootnotes(ch)
 		if i < len(hier.Status.Children)-1 {
 			fmt.Printf("%s├── %s\n", prefix, tx)


### PR DESCRIPTION
Changes:
Create Client interface in kubectl package and some code refactoring. This change is done to make the kubectl package functions testable in future.

Tested:  manually run kubectl tree, show and set commands and verified that they were
reported correctly.