### PR TITLE
replace the old import path

### DIFF
--- a/incubator/virtualcluster/Dockerfile
+++ b/incubator/virtualcluster/Dockerfile
@@ -14,7 +14,7 @@ COPY pkg/    pkg/
 COPY cmd/    cmd/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager github.com/multi-tenancy/incubator/virtualcluster/cmd/manager
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/cmd/manager
 
 # Copy the controller-manager into a thin image
 FROM ubuntu:latest

--- a/incubator/virtualcluster/PROJECT
+++ b/incubator/virtualcluster/PROJECT
@@ -1,3 +1,3 @@
 version: "1"
 domain: x-k8s.io
-repo: github.com/multi-tenancy/incubator/virtualcluster
+repo: github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster

--- a/incubator/virtualcluster/cmd/manager/main.go
+++ b/incubator/virtualcluster/cmd/manager/main.go
@@ -20,9 +20,9 @@ import (
 	"flag"
 	"os"
 
-	"github.com/multi-tenancy/incubator/virtualcluster/pkg/apis"
-	"github.com/multi-tenancy/incubator/virtualcluster/pkg/controller"
-	"github.com/multi-tenancy/incubator/virtualcluster/pkg/webhook"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/webhook"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"

--- a/incubator/virtualcluster/cmd/vcctl/subcmd/create.go
+++ b/incubator/virtualcluster/cmd/vcctl/subcmd/create.go
@@ -33,9 +33,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	vcctlutil "github.com/multi-tenancy/incubator/virtualcluster/cmd/vcctl/util"
-	tenancyv1alpha1 "github.com/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
-	netutil "github.com/multi-tenancy/incubator/virtualcluster/pkg/controller/util/net"
+	vcctlutil "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/cmd/vcctl/util"
+	tenancyv1alpha1 "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	netutil "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/util/net"
 )
 
 const (

--- a/incubator/virtualcluster/cmd/vcctl/subcmd/delete.go
+++ b/incubator/virtualcluster/cmd/vcctl/subcmd/delete.go
@@ -22,8 +22,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	vcctlutil "github.com/multi-tenancy/incubator/virtualcluster/cmd/vcctl/util"
-	tenancyv1alpha1 "github.com/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	vcctlutil "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/cmd/vcctl/util"
+	tenancyv1alpha1 "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
 )
 
 // Delete deletes the Virtualcluster vcName

--- a/incubator/virtualcluster/cmd/vcctl/vcctl.go
+++ b/incubator/virtualcluster/cmd/vcctl/vcctl.go
@@ -20,7 +20,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/multi-tenancy/incubator/virtualcluster/cmd/vcctl/subcmd"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/cmd/vcctl/subcmd"
 	_ "sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 

--- a/incubator/virtualcluster/go.mod
+++ b/incubator/virtualcluster/go.mod
@@ -1,4 +1,4 @@
-module github.com/multi-tenancy/incubator/virtualcluster
+module github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster
 
 go 1.12
 

--- a/incubator/virtualcluster/pkg/apis/addtoscheme_tenancy_v1alpha1.go
+++ b/incubator/virtualcluster/pkg/apis/addtoscheme_tenancy_v1alpha1.go
@@ -17,7 +17,7 @@ limitations under the License.
 package apis
 
 import (
-	"github.com/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
 )
 
 func init() {

--- a/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1/doc.go
+++ b/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the tenancy v1alpha1 API group
 // +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy
+// +k8s:conversion-gen=github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy
 // +k8s:defaulter-gen=TypeMeta
 // +groupName=tenancy.x-k8s.io
 package v1alpha1

--- a/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1/register.go
+++ b/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1/register.go
@@ -19,7 +19,7 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the tenancy v1alpha1 API group
 // +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy
+// +k8s:conversion-gen=github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy
 // +k8s:defaulter-gen=TypeMeta
 // +groupName=tenancy.x-k8s.io
 package v1alpha1

--- a/incubator/virtualcluster/pkg/controller/add_clusterversion.go
+++ b/incubator/virtualcluster/pkg/controller/add_clusterversion.go
@@ -17,7 +17,7 @@ limitations under the License.
 package controller
 
 import (
-	"github.com/multi-tenancy/incubator/virtualcluster/pkg/controller/clusterversion"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/clusterversion"
 )
 
 func init() {

--- a/incubator/virtualcluster/pkg/controller/add_virtualcluster.go
+++ b/incubator/virtualcluster/pkg/controller/add_virtualcluster.go
@@ -17,7 +17,7 @@ limitations under the License.
 package controller
 
 import (
-	"github.com/multi-tenancy/incubator/virtualcluster/pkg/controller/virtualcluster"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/virtualcluster"
 )
 
 func init() {

--- a/incubator/virtualcluster/pkg/controller/clusterversion/clusterversion_controller.go
+++ b/incubator/virtualcluster/pkg/controller/clusterversion/clusterversion_controller.go
@@ -28,8 +28,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	tenancyv1alpha1 "github.com/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
-	ctrlutil "github.com/multi-tenancy/incubator/virtualcluster/pkg/controller/util"
+	tenancyv1alpha1 "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	ctrlutil "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/util"
 )
 
 var log = logf.Log.WithName("clusterversion-controller")

--- a/incubator/virtualcluster/pkg/controller/clusterversion/clusterversion_controller_suite_test.go
+++ b/incubator/virtualcluster/pkg/controller/clusterversion/clusterversion_controller_suite_test.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/multi-tenancy/incubator/virtualcluster/pkg/apis"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis"
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"

--- a/incubator/virtualcluster/pkg/controller/clusterversion/clusterversion_controller_test.go
+++ b/incubator/virtualcluster/pkg/controller/clusterversion/clusterversion_controller_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	tenancyv1alpha1 "github.com/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	tenancyv1alpha1 "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/incubator/virtualcluster/pkg/controller/kubeconfig/kubeconfig.go
+++ b/incubator/virtualcluster/pkg/controller/kubeconfig/kubeconfig.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"text/template"
 
-	vcpki "github.com/multi-tenancy/incubator/virtualcluster/pkg/controller/pki"
+	vcpki "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/pki"
 )
 
 const (

--- a/incubator/virtualcluster/pkg/controller/pki/pki.go
+++ b/incubator/virtualcluster/pkg/controller/pki/pki.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/client-go/util/cert"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 
-	tenancyv1alpha1 "github.com/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	tenancyv1alpha1 "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
 )
 
 const (

--- a/incubator/virtualcluster/pkg/controller/secret/secret.go
+++ b/incubator/virtualcluster/pkg/controller/secret/secret.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 
-	vcpki "github.com/multi-tenancy/incubator/virtualcluster/pkg/controller/pki"
+	vcpki "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/pki"
 )
 
 const (

--- a/incubator/virtualcluster/pkg/controller/virtualcluster/virtualcluster_controller.go
+++ b/incubator/virtualcluster/pkg/controller/virtualcluster/virtualcluster_controller.go
@@ -38,11 +38,11 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	tenancyv1alpha1 "github.com/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
-	"github.com/multi-tenancy/incubator/virtualcluster/pkg/controller/kubeconfig"
-	vcpki "github.com/multi-tenancy/incubator/virtualcluster/pkg/controller/pki"
-	"github.com/multi-tenancy/incubator/virtualcluster/pkg/controller/secret"
-	ctrlutil "github.com/multi-tenancy/incubator/virtualcluster/pkg/controller/util"
+	tenancyv1alpha1 "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/kubeconfig"
+	vcpki "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/pki"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/secret"
+	ctrlutil "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/util"
 )
 
 const (
@@ -107,7 +107,7 @@ func (r *ReconcileVirtualcluster) createPKI(vc *tenancyv1alpha1.Virtualcluster, 
 	rootCACrt, rootKey, rootCAErr := pkiutil.NewCertificateAuthority(
 		&cert.Config{
 			CommonName:   "kubernetes",
-			Organization: []string{"kubernetes-sig.multi-tenancy.virtualcluster"},
+			Organization: []string{"kubernetes-sig.kubernetes-sigs/multi-tenancy.virtualcluster"},
 		})
 	if rootCAErr != nil {
 		return rootCAErr

--- a/incubator/virtualcluster/pkg/controller/virtualcluster/virtualcluster_controller_suite_test.go
+++ b/incubator/virtualcluster/pkg/controller/virtualcluster/virtualcluster_controller_suite_test.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/multi-tenancy/incubator/virtualcluster/pkg/apis"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis"
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"

--- a/incubator/virtualcluster/pkg/controller/virtualcluster/virtualcluster_controller_test.go
+++ b/incubator/virtualcluster/pkg/controller/virtualcluster/virtualcluster_controller_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	tenancyv1alpha1 "github.com/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	tenancyv1alpha1 "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"


### PR DESCRIPTION
replace the old import path (github.com/multi-tenancy -> github.com/kubernetes-sgis/multi-tenancy)

`make all` will fail, since import paths in the vn-agent and the syncer have not been replaced yet. To build `manager`, use the following commands.

```bash
make build WHAT=cmd/manager
make vcctl-osx
```