### PR TITLE
Fix object webhook configuration

### DIFF
--- a/incubator/hnc/config/webhook/manifests.yaml
+++ b/incubator/hnc/config/webhook/manifests.yaml
@@ -24,3 +24,129 @@ webhooks:
     - UPDATE
     resources:
     - hierarchyconfigurations
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-objects
+  failurePolicy: Ignore
+  name: secrets.objects.hnc.x-k8s.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-objects
+  failurePolicy: Ignore
+  name: roles.objects.hnc.x-k8s.io
+  rules:
+  - apiGroups:
+    - rbac.authorization.k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rols
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-objects
+  failurePolicy: Ignore
+  name: rolebindings.objects.hnc.x-k8s.io
+  rules:
+  - apiGroups:
+    - rbac.authorization.k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rolebindings
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-objects
+  failurePolicy: Ignore
+  name: networkpolicies.objects.hnc.x-k8s.io
+  rules:
+  - apiGroups:
+    - networking.k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - networkpolicies
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-objects
+  failurePolicy: Ignore
+  name: resourcesquotas.objects.hnc.x-k8s.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - resourcequotas
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-objects
+  failurePolicy: Ignore
+  name: limitranges.objects.hnc.x-k8s.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - limitranges
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-objects
+  failurePolicy: Ignore
+  name: configmaps.objects.hnc.x-k8s.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - configmaps

--- a/incubator/hnc/pkg/validators/object.go
+++ b/incubator/hnc/pkg/validators/object.go
@@ -22,13 +22,13 @@ const (
 // Note: the validating webhook FAILS OPEN. This means that if the webhook goes down, all further
 // changes to the objects are allowed.
 //
-// +kubebuilder:webhook:path=/validate-objects,mutating=false,failurePolicy=ignore,groups="",resources=secrets,verbs=create;update,versions=v1,name=secrets
-// +kubebuilder:webhook:path=/validate-objects,mutating=false,failurePolicy=ignore,groups="rbac.authorization.k8s.io",resources=rols,verbs=create;update,versions=v1,name=roles.rbac.authorization.k8s.io
-// +kubebuilder:webhook:path=/validate-objects,mutating=false,failurePolicy=ignore,groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=create;update,versions=v1,name=rolebindings.rbac.authorization.k8s.io
-// +kubebuilder:webhook:path=/validate-objects,mutating=false,failurePolicy=ignore,groups="networking.k8s.io",resources=networkpolicies,verbs=create;update,versions=v1,name=networkpolicies.networking.k8s.io
-// +kubebuilder:webhook:path=/validate-objects,mutating=false,failurePolicy=ignore,groups="",resources=resourcequotas,verbs=create;update,versions=v1,name=resourcesquotas
-// +kubebuilder:webhook:path=/validate-objects,mutating=false,failurePolicy=ignore,groups="",resources=limitranges,verbs=create;update,versions=v1,name=limitranges
-// +kubebuilder:webhook:path=/validate-objects,mutating=false,failurePolicy=ignore,groups="",resources=configmaps,verbs=create;update,versions=v1,name=configmaps
+// +kubebuilder:webhook:path=/validate-objects,mutating=false,failurePolicy=ignore,groups="",resources=secrets,verbs=create;update,versions=v1,name=secrets.objects.hnc.x-k8s.io
+// +kubebuilder:webhook:path=/validate-objects,mutating=false,failurePolicy=ignore,groups="rbac.authorization.k8s.io",resources=rols,verbs=create;update,versions=v1,name=roles.objects.hnc.x-k8s.io
+// +kubebuilder:webhook:path=/validate-objects,mutating=false,failurePolicy=ignore,groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=create;update,versions=v1,name=rolebindings.objects.hnc.x-k8s.io
+// +kubebuilder:webhook:path=/validate-objects,mutating=false,failurePolicy=ignore,groups="networking.k8s.io",resources=networkpolicies,verbs=create;update,versions=v1,name=networkpolicies.objects.hnc.x-k8s.io
+// +kubebuilder:webhook:path=/validate-objects,mutating=false,failurePolicy=ignore,groups="",resources=resourcequotas,verbs=create;update,versions=v1,name=resourcesquotas.objects.hnc.x-k8s.io
+// +kubebuilder:webhook:path=/validate-objects,mutating=false,failurePolicy=ignore,groups="",resources=limitranges,verbs=create;update,versions=v1,name=limitranges.objects.hnc.x-k8s.io
+// +kubebuilder:webhook:path=/validate-objects,mutating=false,failurePolicy=ignore,groups="",resources=configmaps,verbs=create;update,versions=v1,name=configmaps.objects.hnc.x-k8s.io
 
 type Object struct {
 	Log     logr.Logger


### PR DESCRIPTION
Tested: applying the webhook fails without this change and passes with
it. Also manually tried an illegal change and verified that the response
came from a webhook that was clearly identified as HNC
("secrets.objects.hnc.x-k8s.io").

/assign @lafh