### PR TITLE
Logic added to not propagate objects with nonempty finalizer list

### DIFF
--- a/incubator/hnc/pkg/controllers/object_controller.go
+++ b/incubator/hnc/pkg/controllers/object_controller.go
@@ -351,6 +351,10 @@ func (r *ObjectReconciler) isExcluded(log logr.Logger, inst *unstructured.Unstru
 		}
 		return false
 
+	// Object with nonempty finalizer list is not propagated
+	case inst != nil && len(inst.GetFinalizers()) != 0:
+		return true
+
 	default:
 		return false
 	}


### PR DESCRIPTION
Changes-
Logic added to not propagate objects with nonempty finalizer list

Tested: manually caused some conditions and verified that they were
reported correctly.