### PR TITLE
[incubator][VC] vn-agent: support full klog options

### DIFF
--- a/incubator/virtualcluster/cmd/vn-agent/app/options/options.go
+++ b/incubator/virtualcluster/cmd/vn-agent/app/options/options.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"crypto/tls"
+	"fmt"
+
+	"github.com/pkg/errors"
+	cliflag "k8s.io/component-base/cli/flag"
+	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/vn-agent/config"
+)
+
+// Options holds the config from command line.
+type Options struct {
+	// ServerOption
+	ServerOption
+	// KubeletOption
+	KubeletOption kubeletclient.KubeletClientConfig
+}
+
+type ServerOption struct {
+	// ClientCAFile is the path to a PEM-encoded certificate bundle. If set, any request presenting a client certificate
+	// signed by one of the authorities in the bundle is authenticated with a username corresponding to the CommonName,
+	// and groups corresponding to the Organization in the client certificate.
+	ClientCAFile string
+	// CertDirectory is the directory where the TLS certs are located
+	CertDirectory string
+	// TLSCertFile is the file containing x509 Certificate for HTTPS
+	TLSCertFile string
+	// TLSPrivateKeyFile is the file containing x509 private key matching tlsCertFile
+	TLSPrivateKeyFile string
+
+	// Port is the vn-agent server listening on.
+	Port uint
+}
+
+func NewVnAgentOptions() (*Options, error) {
+	return &Options{
+		KubeletOption: kubeletclient.KubeletClientConfig{},
+	}, nil
+}
+
+// Flags in command line.
+func (o *Options) Flags() cliflag.NamedFlagSets {
+	fss := cliflag.NamedFlagSets{}
+
+	serverFS := fss.FlagSet("server")
+	serverFS.StringVar(&o.ClientCAFile, "client-ca-file", o.ClientCAFile, "kube config file to use for connecting to the Kubernetes API server")
+	serverFS.StringVar(&o.CertDirectory, "cert-dir", o.CertDirectory, "CertDirectory is the directory where the TLS certs are located")
+	serverFS.StringVar(&o.TLSCertFile, "tls-cert-file", o.TLSCertFile, "TLSCertFile is the file containing x509 Certificate for HTTPS")
+	serverFS.StringVar(&o.TLSPrivateKeyFile, "tls-private-key-file", o.TLSPrivateKeyFile, "TLSPrivateKeyFile is the file containing x509 private key matching tlsCertFile")
+	serverFS.UintVar(&o.Port, "port", 10550, "Port is the server listen on")
+
+	kubeletFS := fss.FlagSet("kubelet")
+	kubeletFS.StringVar(&o.KubeletOption.CertFile, "kubelet-client-certificate", o.KubeletOption.CertFile, "Path to a client cert file for TLS")
+	kubeletFS.StringVar(&o.KubeletOption.KeyFile, "kubelet-client-key", o.KubeletOption.KeyFile, "Path to a client key file for TLS")
+	kubeletFS.UintVar(&o.KubeletOption.Port, "kubelet-port", 10250, "Kubelet security port")
+
+	return fss
+}
+
+// Config is the config to create a vn-agent server handler.
+func (o *Options) Config() (*config.Config, *ServerOption, error) {
+	kubeletClientCertPair, err := tls.LoadX509KeyPair(o.KubeletOption.CertFile, o.KubeletOption.KeyFile)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "failed to load kubelet tls config")
+	}
+
+	return &config.Config{
+		KubeletClientCert: kubeletClientCertPair,
+		KubeletServerHost: fmt.Sprintf("https://127.0.0.1:%v", o.KubeletOption.Port),
+	}, &o.ServerOption, nil
+}

--- a/incubator/virtualcluster/cmd/vn-agent/app/server.go
+++ b/incubator/virtualcluster/cmd/vn-agent/app/server.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"k8s.io/apiserver/pkg/util/term"
+	certutil "k8s.io/client-go/util/cert"
+	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/component-base/cli/globalflag"
+	"k8s.io/klog"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/cmd/vn-agent/app/options"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/vn-agent/certificate"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/vn-agent/config"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/vn-agent/server"
+)
+
+func NewVnAgentCommand(stopChan <-chan struct{}) *cobra.Command {
+	s, err := options.NewVnAgentOptions()
+	if err != nil {
+		klog.Fatalf("unable to initialize command options: %v", err)
+	}
+
+	cmd := &cobra.Command{
+		Use:  "vn-agent",
+		Long: `The vn-agent is proxy between tenant apiserver and kubelet server on physical node.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			c, serverOptions, err := s.Config()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%v\n", err)
+				os.Exit(1)
+			}
+
+			if err := Run(c, serverOptions, stopChan); err != nil {
+				fmt.Fprintf(os.Stderr, "%v\n", err)
+				os.Exit(1)
+			}
+		},
+	}
+
+	fs := cmd.Flags()
+	namedFlagSets := s.Flags()
+	globalflag.AddGlobalFlags(namedFlagSets.FlagSet("global"), cmd.Name())
+
+	for _, f := range namedFlagSets.FlagSets {
+		fs.AddFlagSet(f)
+	}
+	usageFmt := "Usage:\n  %s\n"
+	cols, _, _ := term.TerminalSize(cmd.OutOrStdout())
+	cmd.SetUsageFunc(func(cmd *cobra.Command) error {
+		fmt.Fprintf(cmd.OutOrStderr(), usageFmt, cmd.UseLine())
+		cliflag.PrintSections(cmd.OutOrStderr(), namedFlagSets, cols)
+		return nil
+	})
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\n\n"+usageFmt, cmd.Long, cmd.UseLine())
+		cliflag.PrintSections(cmd.OutOrStdout(), namedFlagSets, cols)
+	})
+
+	return cmd
+}
+
+// Run start the vn-agent server.
+func Run(c *config.Config, serverOption *options.ServerOption, stopCh <-chan struct{}) error {
+	handler, err := server.NewServer(c)
+	if err != nil {
+		return errors.Wrapf(err, "create server")
+	}
+
+	s := &http.Server{
+		Addr:    fmt.Sprintf(":%d", serverOption.Port),
+		Handler: handler,
+		TLSConfig: &tls.Config{
+			ClientAuth: tls.RequestClientCert,
+		},
+	}
+
+	if serverOption.ClientCAFile != "" {
+		clientCAs, err := certutil.CertsFromFile(serverOption.ClientCAFile)
+		if err != nil {
+			return errors.Wrapf(err, "unable to load client CA file")
+		}
+
+		certPool := x509.NewCertPool()
+		for _, cert := range clientCAs {
+			certPool.AddCert(cert)
+		}
+
+		s.TLSConfig.ClientCAs = certPool
+		s.TLSConfig.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+
+	tlsConfig, err := certificate.InitializeTLS(serverOption.CertDirectory, serverOption.TLSCertFile, serverOption.TLSPrivateKeyFile, "vn")
+	if err != nil {
+		return errors.Wrapf(err, "failed to initial tls config")
+	}
+
+	klog.Infof("server listen on %s", s.Addr)
+
+	errCh := make(chan error)
+	go func() {
+		err := s.ListenAndServeTLS(tlsConfig.CertFile, tlsConfig.KeyFile)
+		errCh <- err
+	}()
+
+	select {
+	case <-stopCh:
+		klog.Infof("closing server...")
+		s.Close()
+	case err := <-errCh:
+		klog.Errorf("server listen error %v", err)
+	}
+
+	return nil
+}

--- a/incubator/virtualcluster/cmd/vn-agent/main.go
+++ b/incubator/virtualcluster/cmd/vn-agent/main.go
@@ -17,108 +17,25 @@ limitations under the License.
 package main
 
 import (
-	"crypto/tls"
-	"crypto/x509"
-	"fmt"
-	"k8s.io/klog"
-	"net/http"
+	"math/rand"
 	"os"
+	"time"
 
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-	certutil "k8s.io/client-go/util/cert"
+	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/component-base/logs"
 
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/vn-agent/certificate"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/vn-agent/config"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/vn-agent/server"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/cmd/vn-agent/app"
 )
 
 func main() {
-	var cfg config.Flags
-
-	cmd := NewCommand(cfg)
-
-	if err := cmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
-	}
-}
-
-// NewCommand creates a new top-level command.
-func NewCommand(c config.Flags) *cobra.Command {
-	cmd := &cobra.Command{
-		Use: "vn-agent",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return run(&c)
-		},
-	}
-
-	installFlags(cmd.Flags(), &c)
-	return cmd
-}
-
-func installFlags(flags *pflag.FlagSet, c *config.Flags) {
-	flags.StringVar(&c.ClientCAFile, "client-ca-file", c.ClientCAFile, "kube config file to use for connecting to the Kubernetes API server")
-	flags.StringVar(&c.CertDirectory, "cert-dir", c.CertDirectory, "CertDirectory is the directory where the TLS certs are located")
-	flags.StringVar(&c.TLSCertFile, "tls-cert-file", c.TLSCertFile, "TLSCertFile is the file containing x509 Certificate for HTTPS")
-	flags.StringVar(&c.TLSPrivateKeyFile, "tls-private-key-file", c.TLSPrivateKeyFile, "TLSPrivateKeyFile is the file containing x509 private key matching tlsCertFile")
-	flags.UintVar(&c.Port, "port", 10550, "Port is the server listen on")
-
-	flags.StringVar(&c.KubeletConfig.CertFile, "kubelet-client-certificate", c.KubeletConfig.CertFile, "Path to a client cert file for TLS")
-	flags.StringVar(&c.KubeletConfig.KeyFile, "kubelet-client-key", c.KubeletConfig.KeyFile, "Path to a client key file for TLS")
-	flags.UintVar(&c.KubeletConfig.Port, "kubelet-port", 10250, "Kubelet security port")
-}
-
-func run(c *config.Flags) error {
-	kubeletClientCertPair, err := tls.LoadX509KeyPair(c.KubeletConfig.CertFile, c.KubeletConfig.KeyFile)
-	if err != nil {
-		return errors.Wrapf(err, "failed to load kubelet tls config")
-	}
-
-	handler, err := server.NewServer(&config.Config{
-		KubeletClientCert: kubeletClientCertPair,
-		KubeletServerHost: fmt.Sprintf("https://127.0.0.1:%v", c.KubeletConfig.Port),
-	})
-	if err != nil {
-		return errors.Wrapf(err, "create server")
-	}
-
-	s := &http.Server{
-		Addr:    fmt.Sprintf(":%d", c.Port),
-		Handler: handler,
-		TLSConfig: &tls.Config{
-			ClientAuth: tls.RequestClientCert,
-		},
-	}
-
-	if c.ClientCAFile != "" {
-		clientCAs, err := certutil.CertsFromFile(c.ClientCAFile)
-		if err != nil {
-			return errors.Wrapf(err, "unable to load client CA file")
-		}
-
-		certPool := x509.NewCertPool()
-		for _, cert := range clientCAs {
-			certPool.AddCert(cert)
-		}
-
-		s.TLSConfig.ClientCAs = certPool
-		s.TLSConfig.ClientAuth = tls.RequireAndVerifyClientCert
-	}
-
-	tlsConfig, err := certificate.InitializeTLS(c)
-	if err != nil {
-		return errors.Wrapf(err, "failed to initial tls config")
-	}
+	rand.Seed(time.Now().UTC().UnixNano())
 
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	klog.Infof("server listen on %s", s.Addr)
-	klog.Infof("config %+v", c)
-	klog.Fatal(s.ListenAndServeTLS(tlsConfig.CertFile, tlsConfig.KeyFile))
+	stopChan := genericapiserver.SetupSignalHandler()
 
-	return nil
+	if err := app.NewVnAgentCommand(stopChan).Execute(); err != nil {
+		os.Exit(1)
+	}
 }

--- a/incubator/virtualcluster/pkg/vn-agent/certificate/cert.go
+++ b/incubator/virtualcluster/pkg/vn-agent/certificate/cert.go
@@ -30,12 +30,12 @@ import (
 
 // InitializeTLS checks for a configured TLSCertFile and TLSPrivateKeyFile: if unspecified a new self-signed
 // certificate and key file are generated.
-func InitializeTLS(f *config.Flags) (*config.TLSOptions, error) {
-	if f.TLSCertFile == "" && f.TLSPrivateKeyFile == "" {
-		f.TLSCertFile = path.Join(f.CertDirectory, "vn.crt")
-		f.TLSPrivateKeyFile = path.Join(f.CertDirectory, "vn.key")
+func InitializeTLS(certDirectory, certFile, privateKeyFile, suffix string) (*config.TLSOptions, error) {
+	if certFile == "" && privateKeyFile == "" {
+		certFile = path.Join(certDirectory, fmt.Sprintf("%s.crt", suffix))
+		privateKeyFile = path.Join(certDirectory, fmt.Sprintf("%s.key", suffix))
 
-		canReadCertAndKey, err := certutil.CanReadCertAndKey(f.TLSCertFile, f.TLSPrivateKeyFile)
+		canReadCertAndKey, err := certutil.CanReadCertAndKey(certFile, privateKeyFile)
 		if err != nil {
 			return nil, err
 		}
@@ -50,21 +50,21 @@ func InitializeTLS(f *config.Flags) (*config.TLSOptions, error) {
 				return nil, fmt.Errorf("unable to generate self signed cert: %v", err)
 			}
 
-			if err := certutil.WriteCert(f.TLSCertFile, cert); err != nil {
+			if err := certutil.WriteCert(certFile, cert); err != nil {
 				return nil, err
 			}
 
-			if err := keyutil.WriteKey(f.TLSPrivateKeyFile, key); err != nil {
+			if err := keyutil.WriteKey(privateKeyFile, key); err != nil {
 				return nil, err
 			}
 
-			klog.Infof("Using self-signed cert (%s, %s)", f.TLSCertFile, f.TLSPrivateKeyFile)
+			klog.Infof("Using self-signed cert (%s, %s)", certFile, privateKeyFile)
 		}
 	}
 
 	tlsOptions := &config.TLSOptions{
-		CertFile: f.TLSCertFile,
-		KeyFile:  f.TLSPrivateKeyFile,
+		CertFile: certFile,
+		KeyFile:  privateKeyFile,
 	}
 
 	return tlsOptions, nil

--- a/incubator/virtualcluster/pkg/vn-agent/config/config.go
+++ b/incubator/virtualcluster/pkg/vn-agent/config/config.go
@@ -18,29 +18,7 @@ package config
 
 import (
 	"crypto/tls"
-
-	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 )
-
-// Flags holds the config from command line.
-type Flags struct {
-	// ClientCAFile is the path to a PEM-encoded certificate bundle. If set, any request presenting a client certificate
-	// signed by one of the authorities in the bundle is authenticated with a username corresponding to the CommonName,
-	// and groups corresponding to the Organization in the client certificate.
-	ClientCAFile string
-	// CertDirectory is the directory where the TLS certs are located
-	CertDirectory string
-	// TLSCertFile is the file containing x509 Certificate for HTTPS
-	TLSCertFile string
-	// TLSPrivateKeyFile is the file containing x509 private key matching tlsCertFile
-	TLSPrivateKeyFile string
-
-	// Port is the vn-agent server listening on.
-	Port uint
-
-	// KubeletConfig
-	KubeletConfig kubeletclient.KubeletClientConfig
-}
 
 // TLSOptions holds the TLS options.
 type TLSOptions struct {


### PR DESCRIPTION
refactor vn-agent command to k8s style.

`k8s.io/component-base/cli/globalflag` this package will auto register the klog options

Signed-off-by: jerryzhuang <zhuangqhc@gmail.com>