### PR TITLE
Fix unicode character in kubectl-hnc tree

### DIFF
--- a/incubator/hnc/pkg/kubectl/tree.go
+++ b/incubator/hnc/pkg/kubectl/tree.go
@@ -74,7 +74,7 @@ func printSubtree(prefix string, hier *api.HierarchyConfiguration) {
 		tx := nameAndFootnotes(ch)
 		if i < len(hier.Status.Children)-1 {
 			fmt.Printf("%s├── %s\n", prefix, tx)
-			printSubtree(prefix+"|   ", ch)
+			printSubtree(prefix+"│   ", ch)
 		} else {
 			fmt.Printf("%s└── %s\n", prefix, tx)
 			printSubtree(prefix+"    ", ch)


### PR DESCRIPTION
I had used the regular pipe character ("|", U+007C) but this wasn't
lining up correctly. The correct character appears to be "Box Drawings
Light Vertical" ("│", U+2502).

Tested: ran `tree` and confirmed it was more visually appealing.