### PR TITLE
Enable one-line installation and smooth onboarding experience

### DIFF
--- a/incubator/hnc/.gitignore
+++ b/incubator/hnc/.gitignore
@@ -1,3 +1,5 @@
+# Release files
+releases/
 
 # Binaries for programs and plugins
 *.exe

--- a/incubator/hnc/Makefile
+++ b/incubator/hnc/Makefile
@@ -158,3 +158,10 @@ kind-reset: kind-reboot deploy-prereq
 # Convenience target to deploy specifically for kind
 kind-deploy:
 	CONFIG=kind $(MAKE) deploy
+
+###################### RELEASE ACTIONS #########################
+
+# Generate release YAML that can easily install HNC via `kubectl apply -f`
+release: manifests
+	mkdir -p releases
+	kustomize build config/default > releases/manifests.yaml

--- a/incubator/hnc/README.md
+++ b/incubator/hnc/README.md
@@ -34,6 +34,7 @@ accessible from your `PATH`:
   - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
   - [kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md)
   - [kubebuilder](https://github.com/kubernetes-sigs/controller-runtime/issues/90#issuecomment-494878527) (_Github issue_). You will most likely encounter this issue when running the tests or any other command.
+  - [cert-manager](https://github.com/jetstack/cert-manager)
 
 ### Deploying to a cluster
 


### PR DESCRIPTION
Now users can try out HNC by saying `kubectl apply -f <some single
file>`.