### PR TITLE
HNC: forbid propagated objects from being modified

### DIFF
--- a/incubator/hnc/pkg/object/object.go
+++ b/incubator/hnc/pkg/object/object.go
@@ -1,0 +1,45 @@
+package object
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+)
+
+// Canonical returns a canonicalized version of the object - that is, one that has the same name,
+// spec and non-HNC labels and annotations, but with the status and all other metadata cleared
+// (including, notably, the namespace). The resulting object is suitable to be copied into a new
+// namespace, or two canonicalized objects are suitable for being compared via reflect.DeepEqual.
+//
+// As a side effect, the label and annotation maps are always initialized in the returned value.
+func Canonical(inst *unstructured.Unstructured) *unstructured.Unstructured {
+	// Start with a copy and clear the status and metadata
+	c := inst.DeepCopy()
+	delete(c.Object, "status")
+	delete(c.Object, "metadata")
+
+	// Restore the whitelisted metadata. Name:
+	c.SetName(inst.GetName())
+
+	// Non-HNC annotations:
+	newAnnots := map[string]string{}
+	for k, v := range inst.GetAnnotations() {
+		if !strings.HasPrefix(k, api.MetaGroup) {
+			newAnnots[k] = v
+		}
+	}
+	c.SetAnnotations(newAnnots)
+
+	// Non-HNC labels:
+	newLabels := map[string]string{}
+	for k, v := range inst.GetLabels() {
+		if !strings.HasPrefix(k, api.MetaGroup) {
+			newLabels[k] = v
+		}
+	}
+	c.SetLabels(newLabels)
+
+	return c
+}


### PR DESCRIPTION
Manual test:
org1
|
- team1

(1) Create a secret in org1. Modification to the origin secret is
allowed, but modification to the secret in team1 is not allowed.
(2) Create ResourceQuota in org1. Create a pod in org1 and see
ResourceQuota has been partially used, but the propagated ResourceQuota
for team1 is not affected.

P.S. #238 will be resolved in another PR. This PR will focus on the refactoring the canonical function.

/resolve #89 

