### PR TITLE
fix Canonical function

### DIFF
--- a/incubator/hnc/pkg/object/object.go
+++ b/incubator/hnc/pkg/object/object.go
@@ -8,6 +8,16 @@ import (
 	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
 )
 
+// metaPrefix returns the prefix (if any) of a label key.
+// Reference https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+func metaPrefix(s string) string {
+	p := strings.Split(s, "/")
+	if len(p) == 1 {
+		return ""
+	}
+	return p[0]
+}
+
 // Canonical returns a canonicalized version of the object - that is, one that has the same name,
 // spec and non-HNC labels and annotations, but with the status and all other metadata cleared
 // (including, notably, the namespace). The resulting object is suitable to be copied into a new
@@ -26,7 +36,7 @@ func Canonical(inst *unstructured.Unstructured) *unstructured.Unstructured {
 	// Non-HNC annotations:
 	newAnnots := map[string]string{}
 	for k, v := range inst.GetAnnotations() {
-		if !strings.HasPrefix(k, api.MetaGroup) {
+		if !strings.HasSuffix(metaPrefix(k), api.MetaGroup) {
 			newAnnots[k] = v
 		}
 	}
@@ -35,7 +45,7 @@ func Canonical(inst *unstructured.Unstructured) *unstructured.Unstructured {
 	// Non-HNC labels:
 	newLabels := map[string]string{}
 	for k, v := range inst.GetLabels() {
-		if !strings.HasPrefix(k, api.MetaGroup) {
+		if !strings.HasSuffix(metaPrefix(k), api.MetaGroup) {
 			newLabels[k] = v
 		}
 	}

--- a/incubator/hnc/pkg/object/object_test.go
+++ b/incubator/hnc/pkg/object/object_test.go
@@ -1,0 +1,85 @@
+package object
+
+import (
+	. "github.com/onsi/gomega"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+)
+
+func TestCanonical(t *testing.T) {
+	tests := []struct {
+		name     string
+		inst     *unstructured.Unstructured
+		expected *unstructured.Unstructured
+	}{{
+		name: "Non-HNC metadata should be kept",
+		inst: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{
+						"label": "value",
+					},
+					"annotations": map[string]interface{}{
+						"annotation": "example",
+					},
+				},
+			},
+		},
+	}, {
+		name: "HNC metadata should be stripped",
+		inst: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{
+						api.LabelInheritedFrom: "foo",
+						// tree label
+						"foo.tree." + api.MetaGroup + "/depth": "1",
+					},
+					"annotations": map[string]interface{}{
+						api.MetaGroup + "/annotation": "value",
+					},
+				},
+			},
+		},
+		expected: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels":      map[string]interface{}{},
+					"annotations": map[string]interface{}{},
+				},
+			},
+		},
+	}, {
+		name: "HNC-alike metadata (unlikely) should be kept",
+		inst: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{
+						"label" + api.MetaGroup: "value",
+					},
+					"annotations": map[string]interface{}{
+						"It is unlikely to contain " + api.MetaGroup + " for non-HNC annotations": "example",
+					},
+				},
+			},
+		},
+	},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup
+			g := NewGomegaWithT(t)
+			// Test
+			got := Canonical(tc.inst)
+			if tc.expected == nil {
+				tc.expected = tc.inst
+			}
+			// Report
+			g.Expect(got).Should(Equal(tc.expected))
+		})
+	}
+}


### PR DESCRIPTION
Currently the tree label will stay in the canocial version of the object

/resolve #238