### PR TITLE
Add RBAC to allow tenant admin to create tenantnamespace CR and get the created namespace.

### DIFF
--- a/tenant/config/crds/tenancy_v1alpha1_tenant.yaml
+++ b/tenant/config/crds/tenancy_v1alpha1_tenant.yaml
@@ -30,7 +30,7 @@ spec:
           properties:
             requireNamespacePrefix:
               description: If set to True, all the namespaces belong to the tenant
-                are requried to have TenantAdminNamespaceName as name prefix. By default,
+                are required to have TenantAdminNamespaceName as name prefix. By default,
                 namespace prefix is not required.
               type: boolean
             tenantAdminNamespaceName:

--- a/tenant/config/manager/all_in_one.yaml
+++ b/tenant/config/manager/all_in_one.yaml
@@ -24,6 +24,8 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
+  - roles
+  - rolebindings
   - clusterroles
   - clusterrolebindings
   verbs:

--- a/tenant/config/rbac/rbac_role.yaml
+++ b/tenant/config/rbac/rbac_role.yaml
@@ -34,6 +34,26 @@ rules:
   - update
   - patch
 - apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+- apiGroups:
   - tenancy.x-k8s.io
   resources:
   - tenants

--- a/tenant/pkg/controller/tenantnamespace/tenantnamespace_controller.go
+++ b/tenant/pkg/controller/tenantnamespace/tenantnamespace_controller.go
@@ -23,6 +23,7 @@ import (
 	tenancyv1alpha1 "github.com/kubernetes-sigs/multi-tenancy/tenant/pkg/apis/tenancy/v1alpha1"
 	tenantutil "github.com/kubernetes-sigs/multi-tenancy/tenant/pkg/util"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -146,10 +147,12 @@ func (r *ReconcileTenantNamespace) Reconcile(request reconcile.Request) (reconci
 	// Find the tenant of this instance
 	requireNamespacePrefix := false
 	foundTenant := false
+	var tenantName string
 	for _, each := range tenantList.Items {
 		if each.Spec.TenantAdminNamespaceName == instance.Namespace {
 			requireNamespacePrefix = each.Spec.RequireNamespacePrefix
 			foundTenant = true
+			tenantName = each.Name
 			break
 		}
 	}
@@ -167,13 +170,15 @@ func (r *ReconcileTenantNamespace) Reconcile(request reconcile.Request) (reconci
 		UID:        instance.UID,
 	}
 
+	found := false
 	for _, each := range nsList.Items {
 		if each.Name == tenantNsName {
+			found = true
 			// Check OwnerReference
-			found := false
+			isOwner := false
 			for _, ownerRef := range each.OwnerReferences {
 				if ownerRef == expectedOwnerRef {
-					found = true
+					isOwner = true
 					break
 				} else if ownerRef.APIVersion == expectedOwnerRef.APIVersion && ownerRef.Kind == expectedOwnerRef.Kind {
 					// The namespace is owned by another TenantNamespace CR, fail the reconcile
@@ -181,31 +186,83 @@ func (r *ReconcileTenantNamespace) Reconcile(request reconcile.Request) (reconci
 					return reconcile.Result{}, err
 				}
 			}
-			if !found {
+			if !isOwner {
 				log.Info("Namespace has been created without TenantNamespace owner", "namespace", each.Name)
 				// Obtain namespace ownership by setting ownerReference, and add annotation
 				err = r.updateNamespace(&each, &instance.Namespace, &expectedOwnerRef)
 			}
-			return reconcile.Result{}, err
+			break
 		}
 	}
 
 	// In case a new namespace needs to be created
-	tenantNs := &corev1.Namespace{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: corev1.SchemeGroupVersion.String(),
-			Kind:       "Namespace",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: tenantNsName,
-			Annotations: map[string]string{
-				TenantAdminNamespaceAnnotation: instance.Namespace,
+	if !found {
+		tenantNs := &corev1.Namespace{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				Kind:       "Namespace",
 			},
-			OwnerReferences: []metav1.OwnerReference{expectedOwnerRef},
-		},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: tenantNsName,
+				Annotations: map[string]string{
+					TenantAdminNamespaceAnnotation: instance.Namespace,
+				},
+				OwnerReferences: []metav1.OwnerReference{expectedOwnerRef},
+			},
+		}
+		if err = r.Client.Create(context.TODO(), tenantNs); err != nil {
+			return reconcile.Result{}, err
+		}
 	}
-	if err = r.Client.Create(context.TODO(), tenantNs); err != nil {
+
+	// Update tenant clusterrule to allow tenant admins to access the tenant namespace.
+	cr := &rbacv1.ClusterRole{}
+	if err = r.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("%s-tenant-admin-role", tenantName)}, cr); err != nil {
 		return reconcile.Result{}, err
 	}
-	return reconcile.Result{}, nil
+	cr = cr.DeepCopy()
+	log.Info("FEI GUO original cr", "clusterrole", fmt.Sprintf("%v", cr))
+	foundNsRule := false
+	needUpdate := true
+	for i, each := range cr.Rules {
+		for _, resource := range each.Resources {
+			if resource == "namespaces" {
+				foundNsRule = true
+				break
+			}
+		}
+		if foundNsRule {
+			for _, resourceName := range each.ResourceNames {
+				if resourceName == tenantNsName {
+					needUpdate = false
+					break
+				}
+			}
+			if needUpdate {
+				cr.Rules[i].ResourceNames = append(cr.Rules[i].ResourceNames, tenantNsName)
+			}
+			break
+		}
+	}
+	if !foundNsRule {
+		err = fmt.Errorf("Cluster Role %s-tenant-admin-role does not have rules for namespaces.", tenantName)
+		return reconcile.Result{}, err
+	}
+	log.Info("FEI GUO add namespace to clusterrole", "needUpdate", needUpdate, "clusterrole", fmt.Sprintf("%v", cr))
+
+	if needUpdate {
+		crClone := cr.DeepCopy()
+		err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			crClone.Rules = cr.Rules
+			updateErr := r.Update(context.TODO(), crClone)
+			if updateErr == nil {
+				return nil
+			}
+			if err := r.Get(context.TODO(), types.NamespacedName{Name: crClone.Name}, crClone); err != nil {
+				log.Info("Fail to fetch clusterrole on update", "clusterrole", crClone.Name)
+			}
+			return updateErr
+		})
+	}
+	return reconcile.Result{}, err
 }

--- a/tenant/pkg/controller/tenantnamespace/tenantnamespace_controller.go
+++ b/tenant/pkg/controller/tenantnamespace/tenantnamespace_controller.go
@@ -189,7 +189,9 @@ func (r *ReconcileTenantNamespace) Reconcile(request reconcile.Request) (reconci
 			if !isOwner {
 				log.Info("Namespace has been created without TenantNamespace owner", "namespace", each.Name)
 				// Obtain namespace ownership by setting ownerReference, and add annotation
-				err = r.updateNamespace(&each, &instance.Namespace, &expectedOwnerRef)
+				if err = r.updateNamespace(&each, &instance.Namespace, &expectedOwnerRef); err != nil {
+					return reconcile.Result{}, err
+				}
 			}
 			break
 		}
@@ -260,6 +262,9 @@ func (r *ReconcileTenantNamespace) Reconcile(request reconcile.Request) (reconci
 			}
 			return updateErr
 		})
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 	}
-	return reconcile.Result{}, err
+	return reconcile.Result{}, nil
 }

--- a/tenant/pkg/controller/tenantnamespace/tenantnamespace_controller.go
+++ b/tenant/pkg/controller/tenantnamespace/tenantnamespace_controller.go
@@ -221,7 +221,6 @@ func (r *ReconcileTenantNamespace) Reconcile(request reconcile.Request) (reconci
 		return reconcile.Result{}, err
 	}
 	cr = cr.DeepCopy()
-	log.Info("FEI GUO original cr", "clusterrole", fmt.Sprintf("%v", cr))
 	foundNsRule := false
 	needUpdate := true
 	for i, each := range cr.Rules {
@@ -248,8 +247,6 @@ func (r *ReconcileTenantNamespace) Reconcile(request reconcile.Request) (reconci
 		err = fmt.Errorf("Cluster Role %s-tenant-admin-role does not have rules for namespaces.", tenantName)
 		return reconcile.Result{}, err
 	}
-	log.Info("FEI GUO add namespace to clusterrole", "needUpdate", needUpdate, "clusterrole", fmt.Sprintf("%v", cr))
-
 	if needUpdate {
 		crClone := cr.DeepCopy()
 		err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {


### PR DESCRIPTION
This change mainly does the following:

1) Allow tenant admin to fully manage tenantnamespace CR in tenantAdminNamespace by setting role and rolebinding
2) Update tenant clusterrole to allow tenant admin to access the namespace created by tenantnamespace controller.