### PR TITLE
Add OwnedNamespace field in TenantNamespace CRD status

### DIFF
--- a/tenant/config/crds/tenancy_v1alpha1_tenantnamespace.yaml
+++ b/tenant/config/crds/tenancy_v1alpha1_tenantnamespace.yaml
@@ -34,6 +34,10 @@ spec:
               type: string
           type: object
         status:
+          properties:
+            ownedNamespace:
+              description: The namespace that the tenantnamespace CR owns.
+              type: string
           type: object
   version: v1alpha1
 status:

--- a/tenant/pkg/apis/tenancy/v1alpha1/tenantnamespace_types.go
+++ b/tenant/pkg/apis/tenancy/v1alpha1/tenantnamespace_types.go
@@ -30,8 +30,9 @@ type TenantNamespaceSpec struct {
 
 // TenantNamespaceStatus defines the observed state of TenantNamespace
 type TenantNamespaceStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
+	// The namespace that the tenantnamespace CR owns.
+	// +optional
+	OwnedNamespace string `json:"ownedNamespace,omitempty"`
 }
 
 // +genclient


### PR DESCRIPTION
This change simply adds a field to indicate the name of the created namespace, which is the result of considering multiple factors. 