### PR TITLE
[incubator][VC] support service account for tenant

### DIFF
--- a/incubator/virtualcluster/go.mod
+++ b/incubator/virtualcluster/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/spf13/cobra v0.0.0-20180319062004-c439c4fa0937
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.4.0
+	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 // indirect
 	golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc
 	golang.org/x/sys v0.0.0-20190429190828-d89cdac9e872 // indirect
 	golang.org/x/text v0.3.2 // indirect

--- a/incubator/virtualcluster/pkg/syncer/controller/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/controller/controller.go
@@ -270,8 +270,16 @@ func (c *MultiClusterController) processNextWorkItem() bool {
 }
 
 func getTargetObject(objectType runtime.Object) runtime.Object {
-	if _, ok := objectType.(*v1.ConfigMap); ok {
+	switch objectType.(type) {
+	case *v1.ConfigMap:
 		return &v1.ConfigMap{}
+	case *v1.Pod:
+		return &v1.Pod{}
+	case *v1.Secret:
+		return &v1.Secret{}
+	case *v1.ServiceAccount:
+		return &v1.ServiceAccount{}
+	default:
+		return nil
 	}
-	return &v1.Pod{}
 }

--- a/incubator/virtualcluster/pkg/syncer/controller/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/controller/controller.go
@@ -277,6 +277,8 @@ func getTargetObject(objectType runtime.Object) runtime.Object {
 		return &v1.Pod{}
 	case *v1.Secret:
 		return &v1.Secret{}
+	case *v1.Service:
+		return &v1.Service{}
 	case *v1.ServiceAccount:
 		return &v1.ServiceAccount{}
 	default:

--- a/incubator/virtualcluster/pkg/syncer/controllers/node/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/node/controller.go
@@ -68,8 +68,8 @@ func Register(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: c.backPopulate,
 			UpdateFunc: func(oldObj, newObj interface{}) {
-				newNode := newObj.(*v1.Pod)
-				oldNode := oldObj.(*v1.Pod)
+				newNode := newObj.(*v1.Node)
+				oldNode := oldObj.(*v1.Node)
 				if newNode.ResourceVersion == oldNode.ResourceVersion {
 					return
 				}

--- a/incubator/virtualcluster/pkg/syncer/controllers/register.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/register.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/controllers/pod"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/controllers/secret"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/controllers/service"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/controllers/serviceaccount"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 )
 
@@ -34,6 +35,7 @@ func Register(client clientset.Interface, informerFactory informers.SharedInform
 	pod.Register(client.CoreV1(), informerFactory.Core().V1().Pods(), controllerManager)
 	configmap.Register(client.CoreV1(), informerFactory.Core().V1().ConfigMaps(), controllerManager)
 	secret.Register(client.CoreV1(), informerFactory.Core().V1().Secrets(), controllerManager)
+	serviceaccount.Register(client.CoreV1(), informerFactory.Core().V1().ServiceAccounts(), controllerManager)
 	node.Register(client.CoreV1(), informerFactory.Core().V1().Nodes(), controllerManager)
 	service.Register(client.CoreV1(), informerFactory.Core().V1().Services(), controllerManager)
 }

--- a/incubator/virtualcluster/pkg/syncer/controllers/service/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/service/controller.go
@@ -96,6 +96,9 @@ func (c *controller) backPopulate(obj interface{}) {
 	}
 	var client *clientset.Clientset
 	innerCluster := c.multiClusterServiceController.GetCluster(clusterName)
+	if innerCluster == nil {
+		return
+	}
 	client, err = clientset.NewForConfig(restclient.AddUserAgent(innerCluster.GetClientInfo().Config, "syncer"))
 	if err != nil {
 		return
@@ -111,6 +114,7 @@ func (c *controller) backPopulate(obj interface{}) {
 			klog.Errorf("failed to update service %s/%s of cluster %s %v", vService.Namespace, vService.Name, clusterName, err)
 			return
 		}
+		return
 	}
 
 	if !equality.Semantic.DeepEqual(vService.Status, service.Status) {

--- a/incubator/virtualcluster/pkg/syncer/controllers/serviceaccount/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/serviceaccount/controller.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serviceaccount
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/cluster"
+	sc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/controller"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/listener"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
+)
+
+type controller struct {
+	client                               v1core.CoreV1Interface
+	saInformer                           coreinformers.ServiceAccountInformer
+	multiClusterServiceAccountController *sc.MultiClusterController
+}
+
+func Register(
+	client v1core.CoreV1Interface,
+	saInformer coreinformers.ServiceAccountInformer,
+	controllerManager *manager.ControllerManager,
+) {
+	c := &controller{
+		client: client,
+	}
+
+	// Create the multi cluster secret controller
+	options := sc.Options{Reconciler: c}
+	multiClusterSecretController, err := sc.NewController("tenant-masters-service-account-controller", &v1.ServiceAccount{}, options)
+	if err != nil {
+		klog.Errorf("failed to create multi cluster secret controller %v", err)
+		return
+	}
+	c.multiClusterServiceAccountController = multiClusterSecretController
+	controllerManager.AddController(multiClusterSecretController)
+
+	// Register the controller as cluster change listener
+	listener.AddListener(c)
+}
+
+func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
+	klog.Infof("reconcile service account %s/%s %s event for cluster %s", request.Namespace, request.Name, request.Event, request.Cluster.Name)
+
+	switch request.Event {
+	case reconciler.AddEvent:
+		err := c.reconcileServiceAccountCreate(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.ServiceAccount))
+		if err != nil {
+			klog.Errorf("failed reconcile service account %s/%s CREATE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
+			return reconciler.Result{Requeue: true}, err
+		}
+	case reconciler.UpdateEvent:
+		err := c.reconcileServiceAccountUpdate(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.ServiceAccount))
+		if err != nil {
+			klog.Errorf("failed reconcile service account %s/%s CREATE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
+			return reconciler.Result{Requeue: true}, err
+		}
+	case reconciler.DeleteEvent:
+		err := c.reconcileServiceAccountRemove(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.ServiceAccount))
+		if err != nil {
+			klog.Errorf("failed reconcile service account %s/%s DELETE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
+			return reconciler.Result{Requeue: true}, err
+		}
+	}
+	return reconciler.Result{}, nil
+}
+
+func (c *controller) reconcileServiceAccountCreate(cluster, namespace, name string, secret *v1.ServiceAccount) error {
+	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
+	// just mark the default service account as a tenant related resource.
+	// service account controller will create it for us.
+	if name == "default" {
+		sa, err := c.client.ServiceAccounts(targetNamespace).Get("default", metav1.GetOptions{})
+		if err != nil {
+			// maybe the sa is not created, retry
+			return err
+		}
+
+		if len(sa.Annotations) == 0 {
+			sa.Annotations = make(map[string]string)
+		}
+		sa.Annotations[conversion.LabelCluster] = cluster
+		_, err = c.client.ServiceAccounts(targetNamespace).Update(sa)
+		return err
+	}
+	newObj, err := conversion.BuildMetadata(cluster, targetNamespace, secret)
+	if err != nil {
+		return err
+	}
+
+	pServiceAccount := newObj.(*v1.ServiceAccount)
+	// set to empty and token controller will regenerate one.
+	pServiceAccount.Secrets = nil
+
+	_, err = c.client.ServiceAccounts(targetNamespace).Create(pServiceAccount)
+	if errors.IsAlreadyExists(err) {
+		klog.Infof("service account %s/%s of cluster %s already exist in super master", namespace, name, cluster)
+		return nil
+	}
+	return err
+}
+
+func (c *controller) reconcileServiceAccountUpdate(cluster, namespace, name string, secret *v1.ServiceAccount) error {
+	// do nothing.
+	return nil
+}
+
+func (c *controller) reconcileServiceAccountRemove(cluster, namespace, name string, secret *v1.ServiceAccount) error {
+	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
+	opts := &metav1.DeleteOptions{
+		PropagationPolicy: &conversion.DefaultDeletionPolicy,
+	}
+	err := c.client.ServiceAccounts(targetNamespace).Delete(name, opts)
+	if errors.IsNotFound(err) {
+		klog.Warningf("service account %s/%s of cluster not found in super master", namespace, name, cluster)
+		return nil
+	}
+	return err
+}
+
+func (c *controller) AddCluster(cluster *cluster.Cluster) {
+	klog.Infof("tenant-masters-service-account-controller watch cluster %s for secret resource", cluster.Name)
+	err := c.multiClusterServiceAccountController.WatchClusterResource(cluster, sc.WatchOptions{})
+	if err != nil {
+		klog.Errorf("failed to watch cluster %s secret event: %v", cluster.Name, err)
+	}
+}
+
+func (c *controller) RemoveCluster(cluster *cluster.Cluster) {
+	klog.Warningf("not implemented yet")
+}

--- a/incubator/virtualcluster/pkg/syncer/conversion/helper.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/helper.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	LabelCluster = "tenancy.x-k8s.io/cluster"
+	LabelUID     = "tenancy.x-k8s.io/uid"
 
 	DefaultSAMountPath = "/var/run/secrets/kubernetes.io/serviceaccount"
 )
@@ -63,6 +64,8 @@ func BuildMetadata(cluster, targetNamespace string, obj runtime.Object) (runtime
 		return nil, err
 	}
 
+	uid := m.GetUID()
+
 	resetMetadata(m)
 	if len(targetNamespace) > 0 {
 		m.SetNamespace(targetNamespace)
@@ -73,6 +76,7 @@ func BuildMetadata(cluster, targetNamespace string, obj runtime.Object) (runtime
 		anno = map[string]string{}
 	}
 	anno[LabelCluster] = cluster
+	anno[LabelUID] = string(uid)
 	m.SetAnnotations(anno)
 
 	return target, nil

--- a/incubator/virtualcluster/pkg/syncer/conversion/helper.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/helper.go
@@ -22,8 +22,9 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
@@ -32,10 +33,12 @@ const (
 	LabelCluster = "tenancy.x-k8s.io/cluster"
 	LabelUID     = "tenancy.x-k8s.io/uid"
 
-	DefaultSAMountPath = "/var/run/secrets/kubernetes.io/serviceaccount"
+	SecretSyncStatusKey      = "tenancy.x-k8s.io/secret.sync.status"
+	SecretSyncStatusNotReady = "NotReady"
+	SecretSyncStatusReady    = "Ready"
 )
 
-var DefaultDeletionPolicy = v1.DeletePropagationBackground
+var DefaultDeletionPolicy = metav1.DeletePropagationBackground
 
 func ToSuperMasterNamespace(cluster, ns string) string {
 	targetNamespace := strings.Join([]string{cluster, ns}, "-")
@@ -96,13 +99,13 @@ func BuildSuperMasterNamespace(cluster string, obj runtime.Object) (runtime.Obje
 	return target, nil
 }
 
-func resetMetadata(obj v1.Object) {
+func resetMetadata(obj metav1.Object) {
 	obj.SetGenerateName("")
 	obj.SetSelfLink("")
 	obj.SetUID("")
 	obj.SetResourceVersion("")
 	obj.SetGeneration(0)
-	obj.SetCreationTimestamp(v1.Time{})
+	obj.SetCreationTimestamp(metav1.Time{})
 	obj.SetDeletionTimestamp(nil)
 	obj.SetDeletionGracePeriodSeconds(nil)
 	obj.SetOwnerReferences(nil)
@@ -111,12 +114,12 @@ func resetMetadata(obj v1.Object) {
 	obj.SetInitializers(nil)
 }
 
-func MutatePod(namespace string, pod *corev1.Pod) {
+// MutatePod convert the meta data of containers to super master namespace.
+// replace the service account token volume mounts to super master side one.
+func MutatePod(namespace string, pod *corev1.Pod, vSASecret, SASecret *v1.Secret) {
 	pod.Status = corev1.PodStatus{}
 	pod.Spec.NodeName = ""
-	pod.Spec.ServiceAccountName = ""
 
-	var saSecret string
 	for i := range pod.Spec.Containers {
 		for j, env := range pod.Spec.Containers[i].Env {
 			if env.ValueFrom != nil && env.ValueFrom.FieldRef != nil && env.ValueFrom.FieldRef.FieldPath == "metadata.name" {
@@ -128,26 +131,20 @@ func MutatePod(namespace string, pod *corev1.Pod) {
 				pod.Spec.Containers[i].Env[j].Value = namespace
 			}
 		}
-		// remove serviceaccount volume mount
-		// TODO: add SA volume mount back once we figure out network issue
-		var volumeMounts []corev1.VolumeMount
-		for _, volumeMount := range pod.Spec.Containers[i].VolumeMounts {
-			if volumeMount.MountPath != DefaultSAMountPath {
-				volumeMounts = append(volumeMounts, volumeMount)
-			} else {
-				saSecret = volumeMount.Name
+
+		for j, volumeMount := range pod.Spec.Containers[i].VolumeMounts {
+			if volumeMount.Name == vSASecret.Name {
+				pod.Spec.Containers[i].VolumeMounts[j].Name = SASecret.Name
 			}
 		}
-		pod.Spec.Containers[i].VolumeMounts = volumeMounts
 	}
 
-	var volumes []corev1.Volume
-	for _, volume := range pod.Spec.Volumes {
-		if volume.Name != saSecret {
-			volumes = append(volumes, volume)
+	for i, volume := range pod.Spec.Volumes {
+		if volume.Name == vSASecret.Name {
+			pod.Spec.Volumes[i].Name = SASecret.Name
+			pod.Spec.Volumes[i].Secret.SecretName = SASecret.Name
 		}
 	}
-	pod.Spec.Volumes = volumes
 }
 
 func MutateService(newService *corev1.Service) {

--- a/incubator/virtualcluster/pkg/syncer/utils/client.go
+++ b/incubator/virtualcluster/pkg/syncer/utils/client.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+func GetSecret(client v1core.CoreV1Interface, namespace, saName string) (*v1.Secret, error) {
+	sa, err := client.ServiceAccounts(namespace).Get(saName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service account: %v", err)
+	}
+	if len(sa.Secrets) == 0 {
+		return nil, fmt.Errorf("secret in serivce account is not ready")
+	}
+
+	return client.Secrets(namespace).Get(sa.Secrets[0].Name, metav1.GetOptions{})
+}


### PR DESCRIPTION
notes: CA in tenant scope must be same with super master, because tokens controller always reset the CA field to super master ca.

fixes: #248 