### PR TITLE
[incubator][VC] add work queue for upward syncer

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/constants/constants.go
+++ b/incubator/virtualcluster/pkg/syncer/constants/constants.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// LabelCluster records which cluster this resource belongs to.
+	LabelCluster = "tenancy.x-k8s.io/cluster"
+	// LabelUID is the uid in the tenant namespace.
+	LabelUID = "tenancy.x-k8s.io/uid"
+
+	// SyncStatusKey is a label key records the sync status of the resource.
+	SyncStatusKey = "tenancy.x-k8s.io/sync.status"
+	// SyncStatusNotReady means the resource has not synced.
+	SyncStatusNotReady = "NotReady"
+	// SyncStatusReady means the resource has synced.
+	SyncStatusReady = "Ready"
+
+	// DefaultControllerWorkers is the quantity of the worker routine for a controller.
+	DefaultControllerWorkers = 3
+)
+
+var DefaultDeletionPolicy = metav1.DeletePropagationBackground

--- a/incubator/virtualcluster/pkg/syncer/controllers/configmap/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/configmap/controller.go
@@ -22,14 +22,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/tools/cache"
-
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/cluster"
 	sc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/controller"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/listener"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
 )
@@ -56,28 +53,16 @@ func Register(
 		return
 	}
 	c.multiClusterConfigMapController = multiClusterConfigMapController
-	controllerManager.AddController(multiClusterConfigMapController)
 
-	configMapInformer.Informer().AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: c.backPopulate,
-		},
-	)
-
-	// Register the controller as cluster change listener
-	listener.AddListener(c)
+	controllerManager.AddController(c)
 }
 
-func (c *controller) backPopulate(obj interface{}) {
-	configMap := obj.(*v1.ConfigMap)
-	clusterName, namespace := conversion.GetOwner(configMap)
-	if len(clusterName) == 0 {
-		return
-	}
-	_, err := c.multiClusterConfigMapController.Get(clusterName, namespace, configMap.Name)
-	if errors.IsNotFound(err) {
-		return
-	}
+func (c *controller) StartUWS(stopCh <-chan struct{}) error {
+	return nil
+}
+
+func (c *controller) StartDWS(stopCh <-chan struct{}) error {
+	return c.multiClusterConfigMapController.Start(stopCh)
 }
 
 func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {

--- a/incubator/virtualcluster/pkg/syncer/controllers/configmap/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/configmap/controller.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/cluster"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	sc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/controller"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
@@ -113,7 +114,7 @@ func (c *controller) reconcileConfigMapUpdate(cluster, namespace, name string, c
 func (c *controller) reconcileConfigMapRemove(cluster, namespace, name string) error {
 	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
 	opts := &metav1.DeleteOptions{
-		PropagationPolicy: &conversion.DefaultDeletionPolicy,
+		PropagationPolicy: &constants.DefaultDeletionPolicy,
 	}
 	err := c.configMapClient.ConfigMaps(targetNamespace).Delete(name, opts)
 	if errors.IsNotFound(err) {

--- a/incubator/virtualcluster/pkg/syncer/controllers/namespace/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/namespace/controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/cluster"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	sc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/controller"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
@@ -113,7 +114,7 @@ func (c *controller) reconcileNamespaceUpdate(cluster, name string, namespace *v
 func (c *controller) reconcileNamespaceRemove(cluster, name string) error {
 	targetName := strings.Join([]string{cluster, name}, "-")
 	opts := &metav1.DeleteOptions{
-		PropagationPolicy: &conversion.DefaultDeletionPolicy,
+		PropagationPolicy: &constants.DefaultDeletionPolicy,
 	}
 	err := c.namespaceClient.Namespaces().Delete(targetName, opts)
 	if errors.IsNotFound(err) {

--- a/incubator/virtualcluster/pkg/syncer/controllers/node/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/node/controller.go
@@ -20,18 +20,15 @@ import (
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	coreinformers "k8s.io/client-go/informers/core/v1"
-	clientset "k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
-	restclient "k8s.io/client-go/rest"
+	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/cluster"
 	sc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/controller"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/listener"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
 )
@@ -42,6 +39,11 @@ type controller struct {
 	nodeNameToCluster          map[string]map[string]struct{}
 	nodeClient                 v1core.NodesGetter
 	multiClusterNodeController *sc.MultiClusterController
+
+	workers    int
+	nodeLister listersv1.NodeLister
+	queue      workqueue.RateLimitingInterface
+	nodeSynced cache.InformerSynced
 }
 
 func Register(
@@ -52,6 +54,8 @@ func Register(
 	c := &controller{
 		nodeNameToCluster: make(map[string]map[string]struct{}),
 		nodeClient:        client,
+		queue:             workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "super_master_node"),
+		workers:           1,
 	}
 
 	// Create the multi cluster node controller
@@ -62,11 +66,12 @@ func Register(
 		return
 	}
 	c.multiClusterNodeController = multiClusterNodeController
-	controllerManager.AddController(multiClusterNodeController)
 
+	c.nodeLister = nodeInformer.Lister()
+	c.nodeSynced = nodeInformer.Informer().HasSynced
 	nodeInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: c.backPopulate,
+			AddFunc: c.enqueueNode,
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				newNode := newObj.(*v1.Node)
 				oldNode := oldObj.(*v1.Node)
@@ -74,59 +79,17 @@ func Register(
 					return
 				}
 
-				c.backPopulate(newObj)
+				c.enqueueNode(newObj)
 			},
+			DeleteFunc: c.enqueueNode,
 		},
 	)
 
-	// Register the controller as cluster change listener
-	listener.AddListener(c)
+	controllerManager.AddController(c)
 }
 
-func (c *controller) backPopulate(obj interface{}) {
-	node := obj.(*v1.Node)
-
-	klog.Infof("back populate node %s/%s", node.Name, node.Namespace)
-	c.Lock()
-	clusterList := c.nodeNameToCluster[node.Name]
-	c.Unlock()
-
-	if len(clusterList) == 0 {
-		return
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(len(clusterList))
-	for clusterName, _ := range clusterList {
-		c.updateClusterNodeStatus(clusterName, node, &wg)
-	}
-	wg.Wait()
-}
-
-func (c *controller) updateClusterNodeStatus(cluster string, node *v1.Node, wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	innerCluster := c.multiClusterNodeController.GetCluster(cluster)
-	client, err := clientset.NewForConfig(restclient.AddUserAgent(innerCluster.GetClientInfo().Config, "syncer"))
-	if err != nil {
-		klog.Errorf("could not find cluster %s in controller cache %v", cluster, err)
-		return
-	}
-
-	vNode, err := client.CoreV1().Nodes().Get(node.Name, metav1.GetOptions{})
-	if err != nil {
-		klog.Errorf("could not find node %s/%s: %v", cluster, node.Name, err)
-		return
-	}
-
-	newVNode := vNode.DeepCopy()
-	newVNode.Status.Conditions = node.Status.Conditions
-
-	_, _, err = patchNodeStatus(client.CoreV1().Nodes(), types.NodeName(node.Name), vNode, newVNode)
-	if err != nil {
-		klog.Errorf("failed to update node %s/%s's heartbeats: %v", cluster, node.Name, err)
-		return
-	}
+func (c *controller) StartDWS(stopCh <-chan struct{}) error {
+	return c.multiClusterNodeController.Start(stopCh)
 }
 
 func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {

--- a/incubator/virtualcluster/pkg/syncer/controllers/node/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/node/controller.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/cluster"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	sc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/controller"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
@@ -55,7 +56,7 @@ func Register(
 		nodeNameToCluster: make(map[string]map[string]struct{}),
 		nodeClient:        client,
 		queue:             workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "super_master_node"),
-		workers:           1,
+		workers:           constants.DefaultControllerWorkers,
 	}
 
 	// Create the multi cluster node controller

--- a/incubator/virtualcluster/pkg/syncer/controllers/node/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/node/uws.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+)
+
+// StartUWS starts the upward syncer
+// and blocks until an empty struct is sent to the stop channel.
+func (c *controller) StartUWS(stopCh <-chan struct{}) error {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	klog.Infof("starting node upward syncer")
+
+	if !cache.WaitForCacheSync(stopCh, c.nodeSynced) {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+
+	klog.V(5).Infof("starting workers")
+	for i := 0; i < c.workers; i++ {
+		go wait.Until(c.run, 1*time.Second, stopCh)
+	}
+	<-stopCh
+	klog.V(1).Infof("shutting down")
+
+	return nil
+}
+
+func (c *controller) enqueueNode(obj interface{}) {
+	node := obj.(*v1.Node)
+	c.queue.Add(node.Name)
+}
+
+// run runs a run thread that just dequeues items, processes them, and marks them done.
+// It enforces that the syncHandler is never invoked concurrently with the same key.
+func (c *controller) run() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *controller) processNextWorkItem() bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	err := c.backPopulate(key.(string))
+	if err == nil {
+		c.queue.Forget(key)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("error processing pod %v (will retry): %v", key, err))
+	c.queue.AddRateLimited(key)
+	return true
+}
+
+func (c *controller) backPopulate(nodeName string) error {
+	node, err := c.nodeLister.Get(nodeName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// TODO: notify every tenant.
+			return nil
+		}
+		return err
+	}
+
+	klog.Infof("back populate node %s/%s", node.Namespace, node.Name)
+	c.Lock()
+	clusterList := c.nodeNameToCluster[node.Name]
+	c.Unlock()
+
+	if len(clusterList) == 0 {
+		return nil
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(clusterList))
+	for clusterName, _ := range clusterList {
+		c.updateClusterNodeStatus(clusterName, node, &wg)
+	}
+	wg.Wait()
+
+	return nil
+}
+
+func (c *controller) updateClusterNodeStatus(cluster string, node *v1.Node, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	innerCluster := c.multiClusterNodeController.GetCluster(cluster)
+	client, err := clientset.NewForConfig(restclient.AddUserAgent(innerCluster.GetClientInfo().Config, "syncer"))
+	if err != nil {
+		klog.Errorf("could not find cluster %s in controller cache %v", cluster, err)
+		return
+	}
+
+	vNode, err := client.CoreV1().Nodes().Get(node.Name, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("could not find node %s/%s: %v", cluster, node.Name, err)
+		return
+	}
+
+	newVNode := vNode.DeepCopy()
+	newVNode.Status.Conditions = node.Status.Conditions
+
+	_, _, err = patchNodeStatus(client.CoreV1().Nodes(), types.NodeName(node.Name), vNode, newVNode)
+	if err != nil {
+		klog.Errorf("failed to update node %s/%s's heartbeats: %v", cluster, node.Name, err)
+		return
+	}
+}

--- a/incubator/virtualcluster/pkg/syncer/controllers/pod/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/pod/uws.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/controllers/node"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+)
+
+// StartUWS starts the upward syncer
+// and blocks until an empty struct is sent to the stop channel.
+func (c *controller) StartUWS(stopCh <-chan struct{}) error {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	klog.Infof("starting pod upward syncer")
+
+	if !cache.WaitForCacheSync(stopCh, c.podSynced) {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+
+	klog.V(5).Infof("starting workers")
+	for i := 0; i < c.workers; i++ {
+		go wait.Until(c.run, 1*time.Second, stopCh)
+	}
+	<-stopCh
+	klog.V(1).Infof("shutting down")
+
+	return nil
+}
+
+// run runs a run thread that just dequeues items, processes them, and marks them done.
+// It enforces that the syncHandler is never invoked concurrently with the same key.
+func (c *controller) run() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *controller) processNextWorkItem() bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	err := c.backPopulate(key.(string))
+	if err == nil {
+		c.queue.Forget(key)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("error processing pod %v (will retry): %v", key, err))
+	c.queue.AddRateLimited(key)
+	return true
+}
+
+func (c *controller) backPopulate(key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("invalid resource key: %s", key))
+		return nil
+	}
+
+	pod, err := c.podLister.Pods(namespace).Get(name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	clusterName, vNamespace := conversion.GetOwner(pod)
+	if len(clusterName) == 0 {
+		return nil
+	}
+
+	klog.Infof("back populate pod %s/%s in cluster %s", vNamespace, pod.Name, clusterName)
+	vPodObj, err := c.multiClusterPodController.Get(clusterName, vNamespace, pod.Name)
+	if err != nil {
+		return fmt.Errorf("could not find pod %s/%s pod in controller cache %v", vNamespace, pod.Name, err)
+	}
+	var client *clientset.Clientset
+	innerCluster := c.multiClusterPodController.GetCluster(clusterName)
+	if innerCluster == nil {
+		// virtual cluster is gone.
+		return nil
+	}
+	client, err = clientset.NewForConfig(restclient.AddUserAgent(innerCluster.GetClientInfo().Config, "syncer"))
+	if err != nil {
+		return fmt.Errorf("failed to create client from cluster %s config: %v", clusterName, err)
+	}
+
+	vPod := vPodObj.(*v1.Pod)
+	if vPod.Spec.NodeName != pod.Spec.NodeName {
+		n, err := c.client.Nodes().Get(pod.Spec.NodeName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get node %s from super master: %v", pod.Spec.NodeName, err)
+		}
+
+		_, err = client.CoreV1().Nodes().Create(node.NewVirtualNode(n))
+		if errors.IsAlreadyExists(err) {
+			klog.Warningf("virtual node %s already exists", vPod.Spec.NodeName)
+		}
+
+		err = client.CoreV1().Pods(vPod.Namespace).Bind(&v1.Binding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      vPod.Name,
+				Namespace: vPod.Namespace,
+			},
+			Target: v1.ObjectReference{
+				Kind:       "Node",
+				Name:       pod.Spec.NodeName,
+				APIVersion: "v1",
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to bind vPod %s/%s to node %s %v", vPod.Namespace, vPod.Name, pod.Spec.NodeName, err)
+		}
+		// pod has been updated, return and waiting for next loop.
+		return nil
+	}
+	if !equality.Semantic.DeepEqual(vPod.Status, pod.Status) {
+		newPod := vPod.DeepCopy()
+		newPod.Status = pod.Status
+		if _, err = client.CoreV1().Pods(vPod.Namespace).UpdateStatus(newPod); err != nil {
+			return fmt.Errorf("failed to back populate pod %s/%s status update for cluster %s: %v", vPod.Namespace, vPod.Name, clusterName, err)
+		}
+	}
+
+	return nil
+}

--- a/incubator/virtualcluster/pkg/syncer/controllers/secret/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/secret/controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/cluster"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	sc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/controller"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
@@ -117,12 +118,12 @@ func (c *controller) reconcileServiceAccountSecretUpdate(cluster, namespace, nam
 
 	needUpdate := false
 
-	if pSecret.Labels[conversion.SecretSyncStatusKey] != conversion.SecretSyncStatusReady {
+	if pSecret.Labels[constants.SyncStatusKey] != constants.SyncStatusReady {
 		needUpdate = true
 		if len(pSecret.Labels) == 0 {
 			pSecret.Labels = make(map[string]string)
 		}
-		pSecret.Labels[conversion.SecretSyncStatusKey] = conversion.SecretSyncStatusReady
+		pSecret.Labels[constants.SyncStatusKey] = constants.SyncStatusReady
 	}
 
 	if !equality.Semantic.DeepEqual(secret.Data, pSecret.Data) {
@@ -174,7 +175,7 @@ func (c *controller) reconcileNormalSecretUpdate(cluster, namespace, name string
 func (c *controller) reconcileSecretRemove(cluster, namespace, name string, secret *v1.Secret) error {
 	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
 	opts := &metav1.DeleteOptions{
-		PropagationPolicy: &conversion.DefaultDeletionPolicy,
+		PropagationPolicy: &constants.DefaultDeletionPolicy,
 	}
 	err := c.client.Secrets(targetNamespace).Delete(name, opts)
 	if errors.IsNotFound(err) {

--- a/incubator/virtualcluster/pkg/syncer/controllers/secret/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/secret/controller.go
@@ -29,7 +29,6 @@ import (
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/cluster"
 	sc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/controller"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/listener"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/utils"
@@ -59,10 +58,16 @@ func Register(
 		return
 	}
 	c.multiClusterSecretController = multiClusterSecretController
-	controllerManager.AddController(multiClusterSecretController)
 
-	// Register the controller as cluster change listener
-	listener.AddListener(c)
+	controllerManager.AddController(c)
+}
+
+func (c *controller) StartUWS(stopCh <-chan struct{}) error {
+	return nil
+}
+
+func (c *controller) StartDWS(stopCh <-chan struct{}) error {
+	return c.multiClusterSecretController.Start(stopCh)
 }
 
 func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {

--- a/incubator/virtualcluster/pkg/syncer/controllers/service/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/service/controller.go
@@ -20,26 +20,30 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	coreinformers "k8s.io/client-go/informers/core/v1"
-	clientset "k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
-	restclient "k8s.io/client-go/rest"
+	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/cluster"
 	sc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/controller"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/listener"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
-	"k8s.io/apimachinery/pkg/api/equality"
 )
 
 type controller struct {
 	serviceClient                 v1core.ServicesGetter
 	multiClusterServiceController *sc.MultiClusterController
+
+	workers       int
+	serviceLister listersv1.ServiceLister
+	queue         workqueue.RateLimitingInterface
+	serviceSynced cache.InformerSynced
 }
 
 func Register(
@@ -49,6 +53,8 @@ func Register(
 ) {
 	c := &controller{
 		serviceClient: serviceClient,
+		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "super_master_service"),
+		workers:       constants.DefaultControllerWorkers,
 	}
 
 	// Create the multi cluster service controller
@@ -59,11 +65,12 @@ func Register(
 		return
 	}
 	c.multiClusterServiceController = multiClusterServiceController
-	controllerManager.AddController(multiClusterServiceController)
 
+	c.serviceLister = serviceInformer.Lister()
+	c.serviceSynced = serviceInformer.Informer().HasSynced
 	serviceInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: c.backPopulate,
+			AddFunc: c.enqueueService,
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				newService := newObj.(*v1.Service)
 				oldService := oldObj.(*v1.Service)
@@ -73,59 +80,26 @@ func Register(
 					return
 				}
 
-				c.backPopulate(newObj)
+				c.enqueueService(newObj)
 			},
 		},
 	)
 
-	// Register the controller as cluster change listener
-	listener.AddListener(c)
+	controllerManager.AddController(c)
 }
 
-func (c *controller) backPopulate(obj interface{}) {
-	service := obj.(*v1.Service)
-	clusterName, namespace := conversion.GetOwner(service)
-	if len(clusterName) == 0 {
+func (c *controller) enqueueService(obj interface{}) {
+	var key string
+	var err error
+	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
+		utilruntime.HandleError(err)
 		return
 	}
-	klog.Infof("back populate service %s/%s in cluster %s", service.Name, namespace, clusterName)
-	vServiceObj, err := c.multiClusterServiceController.Get(clusterName, namespace, service.Name)
-	if errors.IsNotFound(err) {
-		klog.Errorf("could not find service %s/%s pod in controller cache %v", service.Name, namespace, err)
-		return
-	}
-	var client *clientset.Clientset
-	innerCluster := c.multiClusterServiceController.GetCluster(clusterName)
-	if innerCluster == nil {
-		return
-	}
-	client, err = clientset.NewForConfig(restclient.AddUserAgent(innerCluster.GetClientInfo().Config, "syncer"))
-	if err != nil {
-		return
-	}
+	c.queue.Add(key)
+}
 
-	vService := vServiceObj.(*v1.Service)
-	if vService.Spec.ClusterIP != service.Spec.ClusterIP || !equality.Semantic.DeepEqual(vService.Spec.Ports, service.Spec.Ports) {
-		newService := vService.DeepCopy()
-		newService.Spec.ClusterIP = service.Spec.ClusterIP
-		newService.Spec.Ports = service.Spec.Ports
-		_, err = client.CoreV1().Services(vService.Namespace).Update(newService)
-		if err != nil {
-			klog.Errorf("failed to update service %s/%s of cluster %s %v", vService.Namespace, vService.Name, clusterName, err)
-			return
-		}
-		return
-	}
-
-	if !equality.Semantic.DeepEqual(vService.Status, service.Status) {
-		newService := vService.DeepCopy()
-		newService.Status = service.Status
-		_, err = client.CoreV1().Services(vService.Namespace).UpdateStatus(newService)
-		if err != nil {
-			klog.Errorf("failed to update service %s/%s of cluster %s %v", vService.Namespace, vService.Name, clusterName, err)
-			return
-		}
-	}
+func (c *controller) StartDWS(stopCh <-chan struct{}) error {
+	return c.multiClusterServiceController.Start(stopCh)
 }
 
 func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {

--- a/incubator/virtualcluster/pkg/syncer/controllers/service/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/service/controller.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/cluster"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	sc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/controller"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
@@ -153,7 +154,7 @@ func (c *controller) reconcileServiceUpdate(cluster, namespace, name string, ser
 func (c *controller) reconcileServiceRemove(cluster, namespace, name string, service *v1.Service) error {
 	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
 	opts := &metav1.DeleteOptions{
-		PropagationPolicy: &conversion.DefaultDeletionPolicy,
+		PropagationPolicy: &constants.DefaultDeletionPolicy,
 	}
 	err := c.serviceClient.Services(targetNamespace).Delete(name, opts)
 	if errors.IsNotFound(err) {

--- a/incubator/virtualcluster/pkg/syncer/controllers/service/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/service/uws.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+)
+
+// StartUWS starts the upward syncer
+// and blocks until an empty struct is sent to the stop channel.
+func (c *controller) StartUWS(stopCh <-chan struct{}) error {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	klog.Infof("starting service upward syncer")
+
+	if !cache.WaitForCacheSync(stopCh, c.serviceSynced) {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+
+	klog.V(5).Infof("starting workers")
+	for i := 0; i < c.workers; i++ {
+		go wait.Until(c.run, 1*time.Second, stopCh)
+	}
+	<-stopCh
+	klog.V(1).Infof("shutting down")
+
+	return nil
+}
+
+// run runs a run thread that just dequeues items, processes them, and marks them done.
+// It enforces that the syncHandler is never invoked concurrently with the same key.
+func (c *controller) run() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *controller) processNextWorkItem() bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	err := c.backPopulate(key.(string))
+	if err == nil {
+		c.queue.Forget(key)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("error processing pod %v (will retry): %v", key, err))
+	c.queue.AddRateLimited(key)
+	return true
+}
+
+func (c *controller) backPopulate(key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("invalid resource key: %s", key))
+		return nil
+	}
+
+	service, err := c.serviceLister.Services(namespace).Get(name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	clusterName, vNamespace := conversion.GetOwner(service)
+	if len(clusterName) == 0 {
+		return nil
+	}
+	klog.Infof("back populate service %s/%s in cluster %s", vNamespace, service.Name, clusterName)
+	vServiceObj, err := c.multiClusterServiceController.Get(clusterName, namespace, service.Name)
+	if errors.IsNotFound(err) {
+		return fmt.Errorf("could not find service %s/%s pod in controller cache %v", service.Name, namespace, err)
+	}
+	var client *clientset.Clientset
+	innerCluster := c.multiClusterServiceController.GetCluster(clusterName)
+	if innerCluster == nil {
+		return nil
+	}
+	client, err = clientset.NewForConfig(restclient.AddUserAgent(innerCluster.GetClientInfo().Config, "syncer"))
+	if err != nil {
+		return fmt.Errorf("failed to create client from cluster %s config: %v", clusterName, err)
+	}
+
+	vService := vServiceObj.(*v1.Service)
+	if vService.Spec.ClusterIP != service.Spec.ClusterIP || !equality.Semantic.DeepEqual(vService.Spec.Ports, service.Spec.Ports) {
+		newService := vService.DeepCopy()
+		newService.Spec.ClusterIP = service.Spec.ClusterIP
+		newService.Spec.Ports = service.Spec.Ports
+		_, err = client.CoreV1().Services(vService.Namespace).Update(newService)
+		if err != nil {
+			return fmt.Errorf("failed to update service %s/%s of cluster %s %v", vService.Namespace, vService.Name, clusterName, err)
+		}
+		// service has been updated, return and waiting for next loop.
+		return nil
+	}
+
+	if !equality.Semantic.DeepEqual(vService.Status, service.Status) {
+		newService := vService.DeepCopy()
+		newService.Status = service.Status
+		_, err = client.CoreV1().Services(vService.Namespace).UpdateStatus(newService)
+		if err != nil {
+			return fmt.Errorf("failed to update service %s/%s of cluster %s %v", vService.Namespace, vService.Name, clusterName, err)
+		}
+	}
+
+	return nil
+}

--- a/incubator/virtualcluster/pkg/syncer/controllers/serviceaccount/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/serviceaccount/controller.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/cluster"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	sc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/controller"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
@@ -106,7 +107,7 @@ func (c *controller) reconcileServiceAccountCreate(cluster, namespace, name stri
 		if len(sa.Annotations) == 0 {
 			sa.Annotations = make(map[string]string)
 		}
-		sa.Annotations[conversion.LabelCluster] = cluster
+		sa.Annotations[constants.LabelCluster] = cluster
 		_, err = c.client.ServiceAccounts(targetNamespace).Update(sa)
 		return err
 	}
@@ -135,7 +136,7 @@ func (c *controller) reconcileServiceAccountUpdate(cluster, namespace, name stri
 func (c *controller) reconcileServiceAccountRemove(cluster, namespace, name string, secret *v1.ServiceAccount) error {
 	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
 	opts := &metav1.DeleteOptions{
-		PropagationPolicy: &conversion.DefaultDeletionPolicy,
+		PropagationPolicy: &constants.DefaultDeletionPolicy,
 	}
 	err := c.client.ServiceAccounts(targetNamespace).Delete(name, opts)
 	if errors.IsNotFound(err) {

--- a/incubator/virtualcluster/pkg/syncer/controllers/serviceaccount/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/serviceaccount/controller.go
@@ -27,7 +27,6 @@ import (
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/cluster"
 	sc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/controller"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/listener"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
 )
@@ -55,10 +54,16 @@ func Register(
 		return
 	}
 	c.multiClusterServiceAccountController = multiClusterSecretController
-	controllerManager.AddController(multiClusterSecretController)
 
-	// Register the controller as cluster change listener
-	listener.AddListener(c)
+	controllerManager.AddController(c)
+}
+
+func (c *controller) StartUWS(stopCh <-chan struct{}) error {
+	return nil
+}
+
+func (c *controller) StartDWS(stopCh <-chan struct{}) error {
+	return c.multiClusterServiceAccountController.Start(stopCh)
 }
 
 func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {

--- a/incubator/virtualcluster/pkg/syncer/conversion/helper.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/helper.go
@@ -30,23 +30,15 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/kubelet/envvars"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 )
 
 const (
-	LabelCluster = "tenancy.x-k8s.io/cluster"
-	LabelUID     = "tenancy.x-k8s.io/uid"
-
-	SecretSyncStatusKey      = "tenancy.x-k8s.io/secret.sync.status"
-	SecretSyncStatusNotReady = "NotReady"
-	SecretSyncStatusReady    = "Ready"
-
 	masterServiceNamespace = metav1.NamespaceDefault
 )
 
-var (
-	DefaultDeletionPolicy = metav1.DeletePropagationBackground
-	masterServices        = sets.NewString("kubernetes")
-)
+var masterServices = sets.NewString("kubernetes")
 
 func ToSuperMasterNamespace(cluster, ns string) string {
 	targetNamespace := strings.Join([]string{cluster, ns}, "-")
@@ -63,7 +55,7 @@ func GetOwner(obj runtime.Object) (cluster, namespace string) {
 		return "", ""
 	}
 
-	cluster = meta.GetAnnotations()[LabelCluster]
+	cluster = meta.GetAnnotations()[constants.LabelCluster]
 	namespace = strings.TrimPrefix(meta.GetNamespace(), cluster+"-")
 	return cluster, namespace
 }
@@ -86,8 +78,8 @@ func BuildMetadata(cluster, targetNamespace string, obj runtime.Object) (runtime
 	if anno == nil {
 		anno = map[string]string{}
 	}
-	anno[LabelCluster] = cluster
-	anno[LabelUID] = string(uid)
+	anno[constants.LabelCluster] = cluster
+	anno[constants.LabelUID] = string(uid)
 	m.SetAnnotations(anno)
 
 	return target, nil

--- a/incubator/virtualcluster/pkg/syncer/manager/manager.go
+++ b/incubator/virtualcluster/pkg/syncer/manager/manager.go
@@ -70,9 +70,15 @@ func (m *ControllerManager) Start(stop <-chan struct{}) error {
 		}(co)
 	}
 
-	wg.Wait()
+	doneCh := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(doneCh)
+	}()
 
 	select {
+	case <-doneCh:
+		return nil
 	case <-stop:
 		return nil
 	case err := <-errCh:

--- a/incubator/virtualcluster/pkg/syncer/manager/manager.go
+++ b/incubator/virtualcluster/pkg/syncer/manager/manager.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package manager
 
-import "sync"
+import (
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/listener"
+	"sync"
+)
 
 // ControllerManager manages number of controllers. It starts their caches, waits for those to sync,
 // then starts the controllers.
@@ -32,12 +35,15 @@ func New() *ControllerManager {
 
 // Controller is the interface used by ControllerManager to start the controllers and get their caches (beforehand).
 type Controller interface {
-	Start(stop <-chan struct{}) error
+	listener.ClusterChangeListener
+	StartUWS(stopCh <-chan struct{}) error
+	StartDWS(stopCh <-chan struct{}) error
 }
 
 // AddController adds a controller to the ControllerManager.
 func (m *ControllerManager) AddController(c Controller) {
 	m.controllers[c] = struct{}{}
+	listener.AddListener(c)
 }
 
 // Start gets all the unique caches of the controllers it manages, starts them,
@@ -47,12 +53,18 @@ func (m *ControllerManager) Start(stop <-chan struct{}) error {
 	errCh := make(chan error)
 
 	wg := &sync.WaitGroup{}
-	wg.Add(len(m.controllers))
+	wg.Add(len(m.controllers) * 2)
 
 	for co := range m.controllers {
 		go func(co Controller) {
 			defer wg.Done()
-			if err := co.Start(stop); err != nil {
+			if err := co.StartDWS(stop); err != nil {
+				errCh <- err
+			}
+		}(co)
+		go func(co Controller) {
+			defer wg.Done()
+			if err := co.StartUWS(stop); err != nil {
 				errCh <- err
 			}
 		}(co)

--- a/incubator/virtualcluster/pkg/syncer/syncer.go
+++ b/incubator/virtualcluster/pkg/syncer/syncer.go
@@ -81,7 +81,9 @@ func New(
 // Run begins watching and downward&upward syncing.
 func (s *Syncer) Run() {
 	go func() {
-		s.controllerManager.Start(s.stopChan)
+		if err := s.controllerManager.Start(s.stopChan); err != nil {
+			klog.V(1).Infof("controller manager exit: %v", err)
+		}
 	}()
 }
 


### PR DESCRIPTION
distinguish StartUWS and StartDWS method in controller interface

Signed-off-by: jerryzhuang <zhuangqhc@gmail.com>

fixes #251 

notes for reviewer:
1. refactor controller interface
```go
type Controller interface {
	listener.ClusterChangeListener
	StartUWS(stopCh <-chan struct{}) error
	StartDWS(stopCh <-chan struct{}) error
}
```
Actually, every controller should implement this interface. And we register the listener when adding the controller to controller manager.

**How about start UWS and DWS in a method named `Start(stopCh <-chan struct{}) error`.**
 Both looks good for me. Distinguish these two method will more clear to control the concurrent problem.

2. the workqueue code for each controller is mostly the same.
Yes, the work queue part is mostly the same. But we may have different business logic for each controller later. I left this part the same now.

3. this PR just add the work queue mechanism. I do not want to correct any business logic