### PR TITLE
Set flags to enable new object controller

### DIFF
--- a/incubator/hnc/Makefile
+++ b/incubator/hnc/Makefile
@@ -24,6 +24,11 @@ ifeq (,${VERSION})
 VERSION=v0.1.0
 endif
 
+# Set default object controller to the old one
+ifeq (,${NOC})
+NOC=0
+endif
+
 # Get check sum value of krew archive
 KREW_CKSM=$(shell sha256sum bin/kubectl-hnc.tar.gz | cut -d " " -f 1)
 
@@ -34,7 +39,12 @@ all: test docker-build
 
 # Run tests
 test: build
-	go test ./api/... ./cmd/... ./pkg/... -coverprofile cover.out
+	# run tests in all directories except ./pkg/controllers/
+	go test ./api/... ./cmd/... `go list ./pkg/... | grep -v controllers` -coverprofile cover.out
+	# separately run tests in ./pkg/controllers/
+	# by default it will use the old object controller
+	# with NOC=1 it will use the new object controller
+	go test ./pkg/controllers/... -enable-new-object-controller=${NOC} -coverprofile cover.out
 
 # Builds all binaries (manager and kubectl) and manifests
 build: generate fmt vet manifests

--- a/incubator/hnc/cmd/manager/main.go
+++ b/incubator/hnc/cmd/manager/main.go
@@ -55,12 +55,14 @@ func main() {
 		enableLeaderElection bool
 		novalidation         bool
 		debugLogs            bool
+		newObjectController  bool
 	)
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&novalidation, "novalidation", false, "Disables validating webhook")
 	flag.BoolVar(&debugLogs, "debug-logs", false, "Shows verbose logs in a human-friendly format.")
+	flag.BoolVar(&newObjectController, "enable-new-object-controller", false, "Enables new object controller.")
 	flag.IntVar(&maxReconciles, "max-reconciles", 1, "Number of concurrent reconciles to perform.")
 	flag.Parse()
 
@@ -79,7 +81,7 @@ func main() {
 	// Create all reconciling controllers
 	f := forest.NewForest()
 	setupLog.Info("Creating controllers", "maxReconciles", maxReconciles)
-	if err := controllers.Create(mgr, f, maxReconciles); err != nil {
+	if err := controllers.Create(mgr, f, maxReconciles, newObjectController); err != nil {
 		setupLog.Error(err, "cannot create controllers")
 		os.Exit(1)
 	}

--- a/incubator/hnc/pkg/controllers/object_controller_new.go
+++ b/incubator/hnc/pkg/controllers/object_controller_new.go
@@ -1,0 +1,62 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/forest"
+)
+
+// ObjectReconcilerNew reconciles generic propagated objects. You must create one for each
+// group/version/kind that needs to be propagated and set its `GVK` field appropriately.
+type ObjectReconcilerNew struct {
+	client.Client
+	Log logr.Logger
+
+	// Forest is the in-memory forest managed by the HierarchyReconciler.
+	Forest *forest.Forest
+
+	// GVK is the group/version/kind handled by this reconciler.
+	GVK schema.GroupVersionKind
+}
+
+// +kubebuilder:rbac:groups=*,resources=*,verbs=get;list;watch;create;update;patch;delete
+
+func (r *ObjectReconcilerNew) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	resp := ctrl.Result{}
+	log := r.Log.WithValues("trigger", req.NamespacedName)
+	log.Info("New object controller placeholder")
+	return resp, nil
+}
+
+// SyncNamespace can be called manually by the HierarchyReconciler when the hierarchy changes.
+func (r *ObjectReconcilerNew) SyncNamespace(ctx context.Context, log logr.Logger, ns string) error {
+	log.Info("SyncNamespace placeholder")
+	return nil
+}
+
+func (r *ObjectReconcilerNew) SetupWithManager(mgr ctrl.Manager) error {
+	target := &unstructured.Unstructured{}
+	target.SetGroupVersionKind(r.GVK)
+	return ctrl.NewControllerManagedBy(mgr).For(target).Complete(r)
+}

--- a/incubator/hnc/pkg/controllers/setup.go
+++ b/incubator/hnc/pkg/controllers/setup.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
@@ -13,17 +14,12 @@ import (
 // Create creates all reconcilers.
 //
 // This function is called both from main.go as well as from the integ tests.
-func Create(mgr ctrl.Manager, f *forest.Forest, maxReconciles int) error {
+func Create(mgr ctrl.Manager, f *forest.Forest, maxReconciles int, newObjectController bool) error {
 	// Create all object reconcillers
 	objReconcilers := []NamespaceSyncer{}
 	for _, gvk := range config.GVKs {
-		or := &ObjectReconciler{
-			Client: mgr.GetClient(),
-			Log:    ctrl.Log.WithName("controllers").WithName(gvk.Kind),
-			Forest: f,
-			GVK:    gvk,
-		}
-		if err := or.SetupWithManager(mgr); err != nil {
+		or, err := createObjectReconciler(newObjectController, mgr, f, gvk)
+		if err != nil {
 			return fmt.Errorf("cannot create %v controller: %s", gvk, err.Error())
 		}
 		objReconcilers = append(objReconcilers, or)
@@ -42,4 +38,24 @@ func Create(mgr ctrl.Manager, f *forest.Forest, maxReconciles int) error {
 	}
 
 	return nil
+}
+
+func createObjectReconciler(newObjectController bool, mgr ctrl.Manager, f *forest.Forest, gvk schema.GroupVersionKind) (NamespaceSyncer, error) {
+	if newObjectController {
+		or := &ObjectReconcilerNew{
+			Client: mgr.GetClient(),
+			Log:    ctrl.Log.WithName("controllers").WithName(gvk.Kind),
+			Forest: f,
+			GVK:    gvk,
+		}
+		return or, or.SetupWithManager(mgr)
+	}
+
+	or := &ObjectReconciler{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName(gvk.Kind),
+		Forest: f,
+		GVK:    gvk,
+	}
+	return or, or.SetupWithManager(mgr)
 }


### PR DESCRIPTION
This is setting flags to enable/disable the new object controller. Part of #195 

Tested manually by disabling the object propagation in the new object
controller and see if the propagation is enabled/disabled by
unsetting/setting the flag "--enable-new-object-controller" in
manager_auth_proxy_patch.yaml.

The test flag is tested by "make test NOC=1"