### PR TITLE
[incubator][VC] create tenant master under clusername namespace

### DIFF
--- a/incubator/virtualcluster/config/setup/all_in_one.yaml
+++ b/incubator/virtualcluster/config/setup/all_in_one.yaml
@@ -90,6 +90,18 @@ rules:
   - update
   - patch
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
   - tenancy.x-k8s.io
   resources:
   - virtualclusters
@@ -128,30 +140,6 @@ rules:
   resources:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - services
   verbs:
   - get
   - list

--- a/incubator/virtualcluster/pkg/controller/pki/pki.go
+++ b/incubator/virtualcluster/pkg/controller/pki/pki.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 
 	tenancyv1alpha1 "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
 )
 
 const (
@@ -70,7 +71,7 @@ func NewAPIServerCrtAndKey(ca *CrtKeyPair, vc *tenancyv1alpha1.Virtualcluster, a
 	}
 
 	config := &cert.Config{
-		CommonName: vc.Name,
+		CommonName: conversion.ToClusterKey(vc),
 		AltNames:   *altNames,
 		Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 	}

--- a/incubator/virtualcluster/pkg/syncer/syncer.go
+++ b/incubator/virtualcluster/pkg/syncer/syncer.go
@@ -242,7 +242,9 @@ func (s *Syncer) addCluster(key string, vc *v1alpha1.Virtualcluster) error {
 	}
 	s.mu.Unlock()
 
-	adminKubeConfigSecret, err := s.secretClient.Secrets(vc.Namespace).Get(KubeconfigAdmin, metav1.GetOptions{})
+	clusterName := conversion.ToClusterKey(vc)
+
+	adminKubeConfigSecret, err := s.secretClient.Secrets(clusterName).Get(KubeconfigAdmin, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to get secret (%s) for virtual cluster %s/%s: %v", KubeconfigAdmin, vc.Namespace, vc.Name, err)
 	}
@@ -250,7 +252,7 @@ func (s *Syncer) addCluster(key string, vc *v1alpha1.Virtualcluster) error {
 	if err != nil {
 		return fmt.Errorf("failed to build rest config for virtual cluster %s/%s: %v", vc.Namespace, vc.Name, err)
 	}
-	innerCluster := cluster.New(conversion.ToClusterKey(vc), clusterRestConfig, cluster.Options{})
+	innerCluster := cluster.New(clusterName, clusterRestConfig, cluster.Options{})
 
 	s.mu.Lock()
 	if _, exist := s.clusterSet[key]; exist {


### PR DESCRIPTION
Signed-off-by: zhuangqh <zhuangqhc@gmail.com>

cluster should be identify by `<namespace>-<name>`, creating tenant component in their own namespace.

before
```bash
[root@vm vc]# kubectl get pod -A
NAMESPACE                          NAME                               READY   STATUS    RESTARTS   AGE
default                            test-deploy-6bdc6484-8czwk         1/1     Running   103        4d3h
kube-system                        coredns-6dcc67dcbc-4644w           1/1     Running   9          12d
kube-system                        coredns-6dcc67dcbc-rwk42           1/1     Running   9          12d
kube-system                        etcd-minikube                      1/1     Running   9          12d
kube-system                        kube-addon-manager-minikube        1/1     Running   9          12d
kube-system                        kube-apiserver-minikube            1/1     Running   9          12d
kube-system                        kube-controller-manager-minikube   1/1     Running   9          12d
kube-system                        kube-proxy-7mv5q                   1/1     Running   9          12d
kube-system                        kube-scheduler-minikube            1/1     Running   9          12d
kube-system                        storage-provisioner                1/1     Running   16         12d
tenant1admin-vc-sample-1-default   test-deploy-f5dbf6b69-cbrjz        1/1     Running   0          43m
tenant1admin                       apiserver-0                        1/1     Running   0          44m
tenant1admin                       controller-manager-0               1/1     Running   0          44m
tenant1admin                       etcd-0                             1/1     Running   0          44m
vc-manager                         vc-manager-779d8c7f5f-jpmn4        1/1     Running   4          43h
vc-manager                         vc-syncer-5549755cb5-gx8rg         1/1     Running   0          42m
vc-manager                         vn-agent-9x247                     1/1     Running   0          41m
```

after
```bash
NAMESPACE                          NAME                               READY   STATUS    RESTARTS   AGE
kube-system                        coredns-6dcc67dcbc-4644w           1/1     Running   9          12d
kube-system                        coredns-6dcc67dcbc-rwk42           1/1     Running   9          12d
kube-system                        etcd-minikube                      1/1     Running   9          12d
kube-system                        kube-addon-manager-minikube        1/1     Running   9          12d
kube-system                        kube-apiserver-minikube            1/1     Running   9          12d
kube-system                        kube-controller-manager-minikube   1/1     Running   9          12d
kube-system                        kube-proxy-7mv5q                   1/1     Running   9          12d
kube-system                        kube-scheduler-minikube            1/1     Running   9          12d
kube-system                        storage-provisioner                1/1     Running   16         12d
tenant1admin-vc-sample-1-default   test-deploy-f5dbf6b69-9qj52        1/1     Running   0          107s
tenant1admin-vc-sample-1           apiserver-0                        1/1     Running   0          6m45s
tenant1admin-vc-sample-1           controller-manager-0               1/1     Running   0          6m25s
tenant1admin-vc-sample-1           etcd-0                             1/1     Running   0          7m11s
vc-manager                         vc-manager-7dc48fdbb5-pb4jm        1/1     Running   0          10m
vc-manager                         vc-syncer-5549755cb5-94d2w         1/1     Running   0          2m16s
vc-manager                         vn-agent-24p9c                     1/1     Running   0          7m58s
```