### PR TITLE
Fix HNC to work with cert-manager v0.11.0

### DIFF
--- a/incubator/hnc/Makefile
+++ b/incubator/hnc/Makefile
@@ -138,7 +138,7 @@ deploy-watch:
 deploy-prereq:
 	@kubectl cluster-info
 	-kubectl create namespace cert-manager
-	kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true --overwrite
+	kubectl label namespace cert-manager cert-manager.io/disable-validation=true --overwrite
 	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.11.0/cert-manager.yaml
 
 # Push the docker image

--- a/incubator/hnc/config/certmanager/certificate.yaml
+++ b/incubator/hnc/config/certmanager/certificate.yaml
@@ -18,6 +18,7 @@ spec:
   commonName: $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   dnsNames:
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/incubator/hnc/config/certmanager/kustomizeconfig.yaml
+++ b/incubator/hnc/config/certmanager/kustomizeconfig.yaml
@@ -1,16 +1,16 @@
 # This configuration is for teaching kustomize how to update name ref and var substitution 
 nameReference:
 - kind: Issuer
-  group: certmanager.k8s.io
+  group: cert-manager.io
   fieldSpecs:
   - kind: Certificate
-    group: certmanager.k8s.io
+    group: cert-manager.io
     path: spec/issuerRef/name
 
 varReference:
 - kind: Certificate
-  group: certmanager.k8s.io
+  group: cert-manager.io
   path: spec/commonName
 - kind: Certificate
-  group: certmanager.k8s.io
+  group: cert-manager.io
   path: spec/dnsNames

--- a/incubator/hnc/config/crd/patches/cainjection_in_hierarchies.yaml
+++ b/incubator/hnc/config/crd/patches/cainjection_in_hierarchies.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: hierarchies.hnc.x-k8s.io

--- a/incubator/hnc/config/default/webhookcainjection_patch.yaml
+++ b/incubator/hnc/config/default/webhookcainjection_patch.yaml
@@ -5,11 +5,11 @@
 # metadata:
 #   name: mutating-webhook-configuration
 #   annotations:
-#     certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+#     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 # ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)


### PR DESCRIPTION
Applied several changes in the wake of #276:

* Followed instructions in
https://cert-manager.io/docs/installation/upgrading/upgrading-0.10-0.11/,
most importantly to change *all* the group API versions.
* Added hnc-webhook-service.hnc-system.svc as well as
hnc-webhook-service.hnc-system.svc.cluster.local as the allowed DNS
names for the HNC certificate - otherwise, connections from the
apiserver were rejected with a (surprisingly helpful) TLS connection
error message.

Tested: before this change, HNC was never coming up correctly (GKE
1.15). After this change, it comes up and I can create subnamespaces.

/assign @rjbez17 
/cc @smileisak 