### PR TITLE
Fix flaky object controller test

### DIFF
--- a/incubator/hnc/pkg/controllers/object_controller_test.go
+++ b/incubator/hnc/pkg/controllers/object_controller_test.go
@@ -108,7 +108,9 @@ var _ = Describe("Secret", func() {
 		setParent(ctx, barName, fooName)
 		setParent(ctx, bazName, barName)
 		Eventually(isModified(ctx, fooName, "foo-sec")).Should(BeFalse())
+		Eventually(hasSecret(ctx, barName, "foo-sec")).Should(BeTrue())
 		Eventually(isModified(ctx, barName, "foo-sec")).Should(BeFalse())
+		Eventually(hasSecret(ctx, bazName, "foo-sec")).Should(BeTrue())
 		Eventually(isModified(ctx, bazName, "foo-sec")).Should(BeFalse())
 
 		modifySecret(ctx, fooName, "foo-sec")


### PR DESCRIPTION
Fixed the flaky test mentioned in #282 

The flaky test was caused by the design of the test. We need to make
sure the objects get propagated before checking if it's modified from
the source object.

Tested with "make test NOC=1" and it's not flaky any more.