### PR TITLE
[incubator][VC] fix: assign node capacity to virtual node

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/controllers/node/node.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/node/node.go
@@ -58,6 +58,8 @@ func NewVirtualNode(superMasterNode *v1.Node) *v1.Node {
 	}
 	n.Status.Addresses = addresses
 	n.Status.NodeInfo = superMasterNode.Status.NodeInfo
+	n.Status.Capacity = superMasterNode.Status.Capacity
+	n.Status.Allocatable = superMasterNode.Status.Allocatable
 
 	return n
 }


### PR DESCRIPTION
Signed-off-by: zhuangqh <zhuangqhc@gmail.com>

fix test:

```bash
[Fail] [sig-cli] Kubectl client [k8s.io] Kubectl describe [It] should check if kubectl describe prints relevant information for rc and pods [Conformance]
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/kubectl/kubectl.go:2056
```

related to #250 