### PR TITLE
Check Crit condition in object controller

### DIFF
--- a/incubator/hnc/pkg/controllers/hierarchy_controller.go
+++ b/incubator/hnc/pkg/controllers/hierarchy_controller.go
@@ -157,7 +157,7 @@ func (r *HierarchyReconciler) syncWithForest(log logr.Logger, nsInst *corev1.Nam
 	}
 
 	// Clear locally-set conditions in the forest so we can set them to the latest.
-	hadCrit := ns.HasCritCondition()
+	hadCrit := ns.HasLocalCritCondition()
 	ns.ClearConditions(forest.Local)
 
 	r.markExisting(log, ns)
@@ -369,7 +369,7 @@ func (r *HierarchyReconciler) syncConditions(log logr.Logger, inst *api.Hierarch
 // syncCritConditions enqueues the children of a namespace if the existing critical conditions in the
 // namespace are gone or critical conditions are newly found.
 func (r *HierarchyReconciler) syncCritConditions(log logr.Logger, ns *forest.Namespace, hadCrit bool) {
-	hasCrit := ns.HasCritCondition()
+	hasCrit := ns.HasLocalCritCondition()
 
 	// Early exit if there's no need to enqueue relatives.
 	if hadCrit == hasCrit {
@@ -387,7 +387,7 @@ func (r *HierarchyReconciler) syncCritConditions(log logr.Logger, ns *forest.Nam
 func setCritAncestorCondition(log logr.Logger, inst *api.HierarchyConfiguration, ns *forest.Namespace) {
 	ans := ns.Parent()
 	for ans != nil {
-		if !ans.HasCritCondition() {
+		if !ans.HasLocalCritCondition() {
 			ans = ans.Parent()
 			continue
 		}

--- a/incubator/hnc/pkg/forest/forest.go
+++ b/incubator/hnc/pkg/forest/forest.go
@@ -317,11 +317,20 @@ func (ns *Namespace) HasCondition() bool {
 	return len(ns.conditions) > 0
 }
 
+// HasLocalCritCondition returns if the namespace has any local critical condition.
+func (ns *Namespace) HasLocalCritCondition() bool {
+	return ns.GetCondition(Local) != nil
+}
+
 // HasCritCondition returns if the namespace has any critical condition.
 func (ns *Namespace) HasCritCondition() bool {
-	// For now, all the critical conditions are set locally. It may not be true for
-	// future critical conditions. We may not want to just use local conditions.
-	return ns.GetCondition(Local) != nil
+	if ns.HasLocalCritCondition() {
+		return true
+	}
+	if ns.Parent() == nil {
+		return false
+	}
+	return ns.Parent().HasCritCondition()
 }
 
 // ClearConditions clears local conditions in the namespace.


### PR DESCRIPTION
This is part of #282 and #195

This commit stops the object controller for further action if any
critical condition is found in the namespace. The object controller will
propagate/delete objects after the critical conditions are gone.

Tested with "make test NOC=1" with additional tests. It passed both
"make test" and "make test NOC=1". When commenting out the "create
missing parent" code in the test and some of the following expectations,
the test failed at expectations that we expect it to fail.