### PR TITLE
Change name of kubectl plugin and fix krew.

### DIFF
--- a/incubator/hnc/Makefile
+++ b/incubator/hnc/Makefile
@@ -33,7 +33,7 @@ NOC=0
 endif
 
 # Get check sum value of krew archive
-KREW_CKSM=$(shell sha256sum bin/kubectl-hnc.tar.gz | cut -d " " -f 1)
+KREW_CKSM=$(shell sha256sum bin/kubectl-hierarchical_namespaces.tar.gz | cut -d " " -f 1)
 
 
 all: test docker-build
@@ -52,37 +52,44 @@ test: build
 # Builds all binaries (manager and kubectl) and manifests
 build: generate fmt vet manifests
 	go build -o bin/manager ./cmd/manager/main.go
-	go build -o bin/kubectl/kubectl-hnc ./cmd/kubectl/main.go
+	go build -o bin/kubectl/kubectl-hierarchical_namespaces ./cmd/kubectl/main.go
 
 # Clean all binaries (manager and kubectl)
-clean:
-	rm -r bin/kubectl/kubectl-hnc
-	rm -f bin/manager
-	
+clean: krew-uninstall
+	-rm -rf bin/*
+	-rm -rf manifests/*
+	-rm -f ${GOPATH}/bin/kubectl-hierarchical_namespaces
+	-rm -f ${GOPATH}/bin/kubectl-hns
+
 # Install kubectl plugin
 kubectl: build
-	cp bin/kubectl/kubectl-hnc ${GOPATH}/bin/kubectl-hnc
-	@echo "Installed kubectl-hnc to GOPATH/bin"
+	cp bin/kubectl/kubectl-hierarchical_namespaces ${GOPATH}/bin/kubectl-hierarchical_namespaces
+	ln -fs ${GOPATH}/bin/kubectl-hierarchical_namespaces ${GOPATH}/bin/kubectl-hns
+	@echo "Installed kubectl-hierarchical_namespaces and kubectl-hns to GOPATH/bin"
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: build
 	go run ./cmd/manager/main.go --novalidation
 
 # Install kubectl plugin locally using krew.
-krew-build: build tar
+krew-build: krew-tar
+	cp hack/krew-hierarchical-namespaces.yaml manifests/krew-hierarchical-namespaces.yaml
 	sed -i 's/^\(\s*sha256\s*:\s*\).*/\1"$(KREW_CKSM)"/' \
-		hack/hnc.yaml
+		manifests/krew-hierarchical-namespaces.yaml
 	sed -i 's/^\(\s*version\s*:\s*\).*/\1"$(VERSION)"/' \
-		hack/hnc.yaml
-	kubectl krew install --manifest=hack/hnc.yaml --archive=bin/kubectl-hnc.tar.gz
+		manifests/krew-hierarchical-namespaces.yaml
+
+# Install kubectl plugin locally using krew.
+krew-install: krew-build
+	kubectl krew install --manifest=manifests/krew-hierarchical-namespaces.yaml --archive=bin/kubectl-hierarchical_namespaces.tar.gz
 
 # Make krew archive and put into /hack
-tar:
-	tar -zcvf bin/kubectl-hnc.tar.gz bin/kubectl
+krew-tar: build
+	tar -zcvf bin/kubectl-hierarchical_namespaces.tar.gz bin/kubectl
 
 # Uninstall krew
-krew-uninstall: 
-	kubectl krew uninstall hnc
+krew-uninstall:
+	-kubectl krew uninstall hierarchical-namespaces
 
 # Generate manifests e.g. CRD, RBAC etc. This can both update the generated
 # files in /config (which should be checked into Git) as well as the kustomized

--- a/incubator/hnc/README.md
+++ b/incubator/hnc/README.md
@@ -52,9 +52,9 @@ To deploy to a cluster:
       so and then try again. The certificate manager takes a few moments for its
       webhook to become available. This should only happen the first time you
       deploy this way, or if we change the recommended version of cert-manager.
-    - This will also install the `kubectl-hnc` plugin into `$GOPATH/bin`, so
-      make sure that's in your path if you want to use commands like `kubectl
-      hnc tree`.
+    - This will also install the `kubectl-hierarchical_namespaces` plugin into
+      `$GOPATH/bin` (as well as its alias, `kubectl-hns`), so make sure that's
+      in your path if you want to use commands like `kubectl hns tree`.
     - The manifests that get deployed will be output to
       `/manifests/hnc-controller.yaml` if you want to check them out.
   - To view logs, say `make deploy-watch`

--- a/incubator/hnc/hack/krew-hierarchical-namespaces.yaml
+++ b/incubator/hnc/hack/krew-hierarchical-namespaces.yaml
@@ -3,11 +3,11 @@
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
-  name: hnc
+  name: hierarchical-namespaces
 spec:
-  shortDescription: Implement hierarchy concept on namespaces.
+  shortDescription: Manipulates hierarchical namespaces.
   description: |
-    Hierarchical Namespace Controller (HNC).
+    Manipulates hierarchical namespaces provided by the Hierarchical Namespace Controller (HNC).
   version: --- will be populated by make krew-build ---
   homepage: https://github.com/kubernetes-sigs/multi-tenancy/incubator/hnc
   platforms:
@@ -18,6 +18,6 @@ spec:
           arch: amd64
       sha256: --- will be populated by make krew-build ---
       files:
-        - from: "bin/kubectl/kubectl-hnc"
+        - from: "bin/kubectl/kubectl-hierarchical_namespaces"
           to: "."
-      bin: "./kubectl-hnc"
+      bin: "./kubectl-hierarchical_namespaces"

--- a/incubator/hnc/pkg/kubectl/root.go
+++ b/incubator/hnc/pkg/kubectl/root.go
@@ -53,8 +53,8 @@ func init() {
 	kubecfgFlags := genericclioptions.NewConfigFlags(false)
 
 	rootCmd = &cobra.Command{
-		Use:   "kubectl-hnc",
-		Short: "Manipulate the hierarchy",
+		Use:   "kubectl hierarchical-namespaces",
+		Short: "Manipulates hierarchical namespaces provided by HNC",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			config, err := kubecfgFlags.ToRESTConfig()
 			if err != nil {


### PR DESCRIPTION
See http://bit.ly/hnc-cli-naming for details on the rename. I also fixed
various Krew issues, most importantly that the source file
(hack/krew-hierarchical-namespaces.yaml) was being modified by the build
process.

Tested: manually verified that `kubectl hierarchical-namespaces tree`
and `kubectl hns tree` both work as expected after this change. Ran both
krew-install and krew-uninstall.

Addresses #302 but doesn't change the subcommands.

/assign @srampal 
/assign @rjbez17 