### PR TITLE
Improve kubectl subcommands to match naming doc

### DIFF
--- a/incubator/hnc/pkg/kubectl/create.go
+++ b/incubator/hnc/pkg/kubectl/create.go
@@ -1,0 +1,45 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var createCmd = &cobra.Command{
+	Use:   "create -n parent child1 [child2 ...]",
+	Short: "Creates a subnamespace under the given parent. Synonym for `set parent --requiredChild child1[,child2,...]`.",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		parent, _ := cmd.Flags().GetString("namespace")
+		if parent == "" {
+			fmt.Println("Error: parent must be set via --namespace or -n")
+			os.Exit(1)
+		}
+		// TODO: ensure the specified children don't already exist. If they do exist and are assigned to
+		// another namespace, this will be caught by the admission controller.
+		updates := hcUpdates{requiredChildren: args}
+		updateHC(client, updates, parent)
+	},
+}
+
+func newCreateCmd() *cobra.Command {
+	createCmd.Flags().StringP("namespace", "n", "", "The parent namespace for the new child namespace(s)")
+	return createCmd
+}

--- a/incubator/hnc/pkg/kubectl/describe.go
+++ b/incubator/hnc/pkg/kubectl/describe.go
@@ -23,8 +23,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var showCmd = &cobra.Command{
-	Use:   "show",
+var describeCmd = &cobra.Command{
+	Use:   "describe",
 	Short: "Displays information about the hierarchy configuration",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -94,6 +94,6 @@ var showCmd = &cobra.Command{
 	},
 }
 
-func newShowCmd() *cobra.Command {
-	return showCmd
+func newDescribeCmd() *cobra.Command {
+	return describeCmd
 }

--- a/incubator/hnc/pkg/kubectl/root.go
+++ b/incubator/hnc/pkg/kubectl/root.go
@@ -84,8 +84,9 @@ func init() {
 	kubecfgFlags.AddFlags(rootCmd.PersistentFlags())
 
 	rootCmd.AddCommand(newSetCmd())
-	rootCmd.AddCommand(newShowCmd())
+	rootCmd.AddCommand(newDescribeCmd())
 	rootCmd.AddCommand(newTreeCmd())
+	rootCmd.AddCommand(newCreateCmd())
 }
 
 func Execute() {
@@ -127,7 +128,7 @@ func (cl *realClient) updateHierarchy(hier *api.HierarchyConfiguration, reason s
 		err = hncClient.Put().Resource(api.Resource).Namespace(nnm).Name(api.Singleton).Body(hier).Do().Error()
 	}
 	if err != nil {
-		fmt.Printf("Error %s: %s\n", reason, err)
+		fmt.Printf("\nCould not %s.\nReason: %s\n", reason, err)
 		os.Exit(1)
 	}
 }

--- a/incubator/hnc/pkg/kubectl/set.go
+++ b/incubator/hnc/pkg/kubectl/set.go
@@ -16,77 +16,76 @@ limitations under the License.
 package kubectl
 
 import (
-	"errors"
 	"fmt"
 	"os"
+	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
 )
 
-//flagValues struct stores name of namespaces against type of flag passed
-type flagValues struct {
+//hcUpdates struct stores name of namespaces against type of flag passed
+type hcUpdates struct {
 	root             bool
 	parent           string
 	requiredChildren []string
-	optionalChild    string
+	optionalChildren []string
 }
 
 var setCmd = &cobra.Command{
-	Use:     "set",
-	Short:   "Allows setting namespace hierarchy",
-	Aliases: []string{"set"},
-	Args:    cobra.MinimumNArgs(1),
+	Use:   "set <namespace>",
+	Short: "Sets hierarchical properties of the given namespace",
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		nnm := args[0]
 		flags := cmd.Flags()
 		parent, _ := flags.GetString("parent")
 		requiredChildren, _ := flags.GetStringArray("requiredChild")
-		optionalChild, _ := flags.GetString("optionalChild")
+		optionalChildren, _ := flags.GetStringArray("optionalChild")
+		requiredChildren = normalizeStringArray(requiredChildren)
+		optionalChildren = normalizeStringArray(optionalChildren)
 
-		flagValues := flagValues{
+		updates := hcUpdates{
 			root:             flags.Changed("root"),
 			parent:           parent,
 			requiredChildren: requiredChildren,
-			optionalChild:    optionalChild,
+			optionalChildren: optionalChildren,
 		}
 
-		err := setCmdFunc(client, flagValues, nnm)
-		if err != nil {
-			fmt.Println(err.Error())
-			os.Exit(1)
-		}
+		updateHC(client, updates, nnm)
 	},
 }
 
-func setCmdFunc(cl Client, flagValues flagValues, nnm string) error {
+func updateHC(cl Client, updates hcUpdates, nnm string) {
 	hc := cl.getHierarchy(nnm)
 	oldpnm := hc.Spec.Parent
 	numChanges := 0
 
-	if flagValues.root && flagValues.parent != "" {
-		return errors.New("Cannot set both --root and --parent at the same time \n")
+	if updates.root && updates.parent != "" {
+		fmt.Println("Cannot give the namespace a parent and make it a root at the same time")
+		os.Exit(1)
 	}
 
-	if flagValues.root {
+	if updates.root {
 		setRoot(hc, oldpnm, nnm, &numChanges)
 	}
 
-	if flagValues.parent != "" {
-		setParent(hc, oldpnm, flagValues.parent, nnm, &numChanges)
+	if updates.parent != "" {
+		setParent(hc, oldpnm, updates.parent, nnm, &numChanges)
 	}
 
-	if len(flagValues.requiredChildren) != 0 {
-		setRequiredChildren(hc, flagValues.requiredChildren, nnm, &numChanges)
+	if len(updates.requiredChildren) != 0 {
+		setRequiredChildren(hc, updates.requiredChildren, nnm, &numChanges)
 	}
 
-	if flagValues.optionalChild != "" {
-		setOptionalChild(hc, flagValues.optionalChild, nnm, &numChanges)
+	if len(updates.optionalChildren) != 0 {
+		setOptionalChildren(hc, updates.optionalChildren, nnm, &numChanges)
 	}
 
 	if numChanges > 0 {
-		cl.updateHierarchy(hc, fmt.Sprintf("setting hierarchical configuration of %s", nnm))
+		cl.updateHierarchy(hc, fmt.Sprintf("update the hierarchical configuration of %s", nnm))
 		word := "property"
 		if numChanges > 1 {
 			word = "properties"
@@ -95,7 +94,6 @@ func setCmdFunc(cl Client, flagValues flagValues, nnm string) error {
 	} else {
 		fmt.Printf("No changes made\n")
 	}
-	return nil
 }
 
 func setRoot(hc *api.HierarchyConfiguration, oldpnm, nnm string, numChanges *int) {
@@ -129,35 +127,54 @@ func setRequiredChildren(hc *api.HierarchyConfiguration, rcns []string, nnm stri
 			continue
 		}
 		hc.Spec.RequiredChildren = append(hc.Spec.RequiredChildren, rcn)
-		fmt.Printf("Adding required child %s\n", rcn)
+		fmt.Printf("Adding required child (subnamespace) %s to %s\n", rcn, nnm)
 		*numChanges++
+	}
+	sort.Strings(hc.Spec.RequiredChildren)
+}
+
+func setOptionalChildren(hc *api.HierarchyConfiguration, ocns []string, nnm string, numChanges *int) {
+	existingRCs := map[string]bool{}
+	for _, rc := range hc.Spec.RequiredChildren {
+		existingRCs[rc] = true
+	}
+
+	for _, oc := range ocns {
+		if existingRCs[oc] {
+			fmt.Printf("Making %s a regular child of %s\n", oc, nnm)
+			delete(existingRCs, oc)
+			*numChanges++
+		} else {
+			fmt.Printf("%s is not a required child of %s\n", oc, nnm)
+		}
+	}
+
+	newRCs := []string{}
+	for k, _ := range existingRCs {
+		newRCs = append(newRCs, k)
+	}
+	if len(newRCs) == 0 {
+		hc.Spec.RequiredChildren = nil
+	} else {
+		sort.Strings(newRCs)
+		hc.Spec.RequiredChildren = newRCs
 	}
 }
 
-func setOptionalChild(hc *api.HierarchyConfiguration, cnm, nnm string, numChanges *int) {
-	found := false
-	newRCs := []string{}
-	for _, rc := range hc.Spec.RequiredChildren {
-		if rc == cnm {
-			found = true
-			continue
+func normalizeStringArray(in []string) []string {
+	out := []string{}
+	for _, val := range in {
+		for _, s := range strings.Split(val, ",") {
+			out = append(out, s)
 		}
-		newRCs = append(newRCs, rc)
 	}
-
-	if !found {
-		fmt.Printf("%s is not a required child of %s\n", cnm, nnm)
-	} else {
-		fmt.Printf("Making required child %s optional\n", cnm)
-		hc.Spec.RequiredChildren = newRCs
-		*numChanges++
-	}
+	return out
 }
 
 func newSetCmd() *cobra.Command {
 	setCmd.Flags().Bool("root", false, "Turns namespace into root namespace")
 	setCmd.Flags().String("parent", "", "Parent namespace")
-	setCmd.Flags().StringArray("requiredChild", []string{""}, "Required Child namespace")
-	setCmd.Flags().String("optionalChild", "", "Turns a required child namespace into an optional child namespace")
+	setCmd.Flags().StringArray("requiredChild", []string{""}, "Specifies a required child (subnamespace). If the child does not exist, it will be created. Multiple values may be comma delimited.")
+	setCmd.Flags().StringArray("optionalChild", []string{""}, "Turns a required child namespaces into optional child namespaces. Multiple values may be comma delimited.")
 	return setCmd
 }


### PR DESCRIPTION
See http://bit.ly/hnc-cli-naming for details. The two major changes here are
to rename `show` to `describe`, and to add a `create` subcommand as a
synonym for `set --requiredChild`.

In addition, this change allows both `set --requiredChild` and `set
--optionalChild` to take multiple values, either comma-delimited or with
repeated flags. It also slightly improves error messages.

Tested:
* Tried both --requiredChild and --optionalChild with a combination of
comma-delimited and repeated flags.
* Manually tried the `create` command.
* Manually tried the `describe` command.

Fixes #302