### PR TITLE
Set v0.2 object controller as default

### DIFF
--- a/incubator/hnc/Makefile
+++ b/incubator/hnc/Makefile
@@ -27,9 +27,9 @@ ifeq (,${VERSION})
 VERSION=v0.1.0
 endif
 
-# Set default object controller to the old one
+# Set default object controller to the new one
 ifeq (,${NOC})
-NOC=0
+NOC=1
 endif
 
 # Get check sum value of krew archive
@@ -45,8 +45,8 @@ test: build
 	# run tests in all directories except ./pkg/controllers/
 	go test ./api/... ./cmd/... `go list ./pkg/... | grep -v controllers` -coverprofile cover.out
 	# separately run tests in ./pkg/controllers/
-	# by default it will use the old object controller
-	# with NOC=1 it will use the new object controller
+	# by default it will use the new object controller
+	# with NOC=0 it will use the old object controller
 	go test ./pkg/controllers/... -enable-new-object-controller=${NOC} -coverprofile cover.out
 
 # Builds all binaries (manager and kubectl) and manifests

--- a/incubator/hnc/config/default/manager_auth_proxy_patch.yaml
+++ b/incubator/hnc/config/default/manager_auth_proxy_patch.yaml
@@ -23,4 +23,5 @@ spec:
         args:
         - "--metrics-addr=127.0.0.1:8080"
         - "--enable-leader-election"
+        - "--enable-new-object-controller"
         - "--max-reconciles=10"

--- a/incubator/hnc/pkg/controllers/suite_test.go
+++ b/incubator/hnc/pkg/controllers/suite_test.go
@@ -53,7 +53,7 @@ func init() {
 	// This is a temporary flag to toggle the new/old object controller for testing. It will be removed
 	// after the GitHub issue "restructure object controller to allow explicit enqueuing" is resolved
 	// (https://github.com/kubernetes-sigs/multi-tenancy/issues/195)
-	flag.BoolVar(&newObjectController, "enable-new-object-controller", false, "Enables new object controller.")
+	flag.BoolVar(&newObjectController, "enable-new-object-controller", true, "Enables new object controller.")
 }
 
 func TestAPIs(t *testing.T) {


### PR DESCRIPTION
Part of #195 

Set v0.2 object controller as default in both controller manager and
tests.

Tested with "make test" by commenting out the if/else statement in the
object controller test for different behaviours of new/old object
controller handling a modified propagated object and leaving only the
expected behaviour of the new object controller. The "make test" passed
and "make test NOC=0" failed.

Then manually removed "-enable-new-object-controller=${NOC}" in go test
in Makefile and run "make test" again. It passed/failed with the default
value of newObjectController set to true/false in suite_test.go.

Finally tested manually to make sure the controller manager is using the
new object controller. The results were as expected.