### PR TITLE
change the vc setting for ACK 

### DIFF
--- a/incubator/virtualcluster/config/setup/all_in_one.yaml
+++ b/incubator/virtualcluster/config/setup/all_in_one.yaml
@@ -7,7 +7,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: vc-manager-role
 rules:
 - apiGroups:
   - tenancy.x-k8s.io
@@ -152,11 +152,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: manager-rolebinding
+  name: vc-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: vc-manager-role
 subjects:
 - kind: ServiceAccount
   name: vc-manager

--- a/incubator/virtualcluster/pkg/controller/virtualcluster/virtualcluster_controller.go
+++ b/incubator/virtualcluster/pkg/controller/virtualcluster/virtualcluster_controller.go
@@ -54,7 +54,7 @@ const (
 	// frequency of polling apiserver for readiness of each component
 	ComponentPollPeriod = 2 * time.Second
 	// timeout for components deployment
-	DeployTimeOut = 120 * time.Second
+	DeployTimeOut = 180 * time.Second
 )
 
 var log = logf.Log.WithName("virtualcluster-controller")


### PR DESCRIPTION
1. change the clusterrolebinding's name of the vc-manager's service account to avoid the privilege problem on ACK.
2. increase the polling timeout to 180 seconds (i.e. pulling image from docker on ack may take longer).