### PR TITLE
Create reconcile counters and a flag to enable it

### DIFF
--- a/incubator/hnc/cmd/manager/main.go
+++ b/incubator/hnc/cmd/manager/main.go
@@ -56,6 +56,7 @@ func main() {
 		novalidation         bool
 		debugLogs            bool
 		newObjectController  bool
+		testLog              bool
 	)
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
@@ -63,6 +64,7 @@ func main() {
 	flag.BoolVar(&novalidation, "novalidation", false, "Disables validating webhook")
 	flag.BoolVar(&debugLogs, "debug-logs", false, "Shows verbose logs in a human-friendly format.")
 	flag.BoolVar(&newObjectController, "enable-new-object-controller", false, "Enables new object controller.")
+	flag.BoolVar(&testLog, "enable-test-log", false, "Enables test log.")
 	flag.IntVar(&maxReconciles, "max-reconciles", 1, "Number of concurrent reconciles to perform.")
 	flag.Parse()
 
@@ -76,6 +78,10 @@ func main() {
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
+	}
+
+	if testLog {
+		controllers.LogActivity()
 	}
 
 	// Create all reconciling controllers

--- a/incubator/hnc/pkg/controllers/hierarchy_controller.go
+++ b/incubator/hnc/pkg/controllers/hierarchy_controller.go
@@ -85,6 +85,12 @@ type NamespaceSyncer interface {
 // Reconcile simply calls SyncNamespace, which can also be called if a namespace is created or
 // deleted.
 func (r *HierarchyReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	if !ex[req.Namespace] {
+		atomic.AddInt32(&hcTot, 1)
+		atomic.AddInt32(&hcCur, 1)
+		defer atomic.AddInt32(&hcCur, -1)
+	}
+
 	ctx := context.Background()
 	ns := req.NamespacedName.Namespace
 

--- a/incubator/hnc/pkg/controllers/object_controller.go
+++ b/incubator/hnc/pkg/controllers/object_controller.go
@@ -18,6 +18,7 @@ package controllers
 import (
 	"context"
 	"reflect"
+	"sync/atomic"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -49,6 +50,12 @@ type ObjectReconciler struct {
 // +kubebuilder:rbac:groups=*,resources=*,verbs=get;list;watch;create;update;patch;delete;deletecollection;use;impersonate
 
 func (r *ObjectReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	if !ex[req.Namespace] {
+		atomic.AddInt32(&obTot, 1)
+		atomic.AddInt32(&obCur, 1)
+		defer atomic.AddInt32(&obCur, -1)
+	}
+
 	resp := ctrl.Result{}
 	ctx := context.Background()
 	log := r.Log.WithValues("trigger", req.NamespacedName)

--- a/incubator/hnc/pkg/controllers/object_controller_new.go
+++ b/incubator/hnc/pkg/controllers/object_controller_new.go
@@ -18,6 +18,7 @@ package controllers
 import (
 	"context"
 	"reflect"
+	"sync/atomic"
 
 	"github.com/go-logr/logr"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/metadata"
@@ -87,6 +88,12 @@ func (r *ObjectReconcilerNew) SyncNamespace(ctx context.Context, log logr.Logger
 }
 
 func (r *ObjectReconcilerNew) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	if !ex[req.Namespace] {
+		atomic.AddInt32(&obTot, 1)
+		atomic.AddInt32(&obCur, 1)
+		defer atomic.AddInt32(&obCur, -1)
+	}
+
 	resp := ctrl.Result{}
 	ctx := context.Background()
 	log := r.Log.WithValues("trigger", req.NamespacedName)


### PR DESCRIPTION
This commit created a reconcile counter to count total hier and object
reconciles and current ongoing object reconciles. It generates logs with
these numbers so we can get better idea of the controller performance,
for example, how long it takes to propagate objects. It would be when
the current ongoing number of object reconciles becomes zero.

Manually tested on GKE cluster and looking through the logs.