### PR TITLE
Add conditions for object problems

### DIFF
--- a/incubator/hnc/api/v1alpha1/hierarchy_types.go
+++ b/incubator/hnc/api/v1alpha1/hierarchy_types.go
@@ -37,6 +37,8 @@ const (
 	CritParentInvalid     Code = "CRIT_PARENT_INVALID"
 	CritAncestor          Code = "CRIT_ANCESTOR"
 	RequiredChildConflict Code = "REQUIRED_CHILD_CONFLICT"
+	CannotUpdate          Code = "CANNOT_UPDATE_OBJECT"
+	CannotPropagate       Code = "CANNOT_PROPAGATE_OBJECT"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!


### PR DESCRIPTION
Also prevent HC controller from invoking object controllers; since
object controllers can now invoke the HC controller, this was causing an
infinite loop.

Tested: manually create a namespace both with an uncopyable rolebinding
to cause a problem during the "write" stage and a secret with a
finalizer to cause a problem during the "sync" stage. Observed that all
expected conditions were applied to all namespaces, albeit with some
funny transient states that I should dig into. I also added a unit test
for objects with finalizers, but I can't stub out the "write" function
yet. This will come in a later PR.

Fixes #201 