### PR TITLE
[incubator][VC] back populate pod related event to tenant

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/constants/constants.go
+++ b/incubator/virtualcluster/pkg/syncer/constants/constants.go
@@ -25,6 +25,8 @@ const (
 	LabelCluster = "tenancy.x-k8s.io/cluster"
 	// LabelUID is the uid in the tenant namespace.
 	LabelUID = "tenancy.x-k8s.io/uid"
+	// LabelNamespace records which cluster namespace this resource belongs to.
+	LabelNamespace = "tenancy.x-k8s.io/namespace"
 
 	// SyncStatusKey is a label key records the sync status of the resource.
 	SyncStatusKey = "tenancy.x-k8s.io/sync.status"

--- a/incubator/virtualcluster/pkg/syncer/controllers/event/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/event/controller.go
@@ -61,7 +61,7 @@ func Register(
 
 	// Create the multi cluster pod controller
 	options := mc.Options{Reconciler: c}
-	multiClusterEventController, err := mc.NewMCController("tenant-masters-event-controller", &v1.Namespace{}, options)
+	multiClusterEventController, err := mc.NewMCController("tenant-masters-event-controller", nil, options)
 	if err != nil {
 		klog.Errorf("failed to create multi cluster event controller %v", err)
 		return
@@ -112,7 +112,7 @@ func (c *controller) enqueueEvent(obj interface{}) {
 }
 
 func (c *controller) StartDWS(stopCh <-chan struct{}) error {
-	return c.multiClusterEventController.Start(stopCh)
+	return nil
 }
 
 func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
@@ -120,7 +120,7 @@ func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, e
 }
 
 func (c *controller) AddCluster(cluster mc.ClusterInterface) {
-	klog.Infof("tenant-masters-pod-controller watch cluster %s for pod resource", cluster.GetClusterName())
+	klog.Infof("tenant-masters-event-controller watch cluster %s for event resource", cluster.GetClusterName())
 	err := c.multiClusterEventController.WatchClusterResource(cluster, mc.WatchOptions{})
 	if err != nil {
 		klog.Errorf("failed to watch cluster %s event event: %v", cluster.GetClusterName(), err)

--- a/incubator/virtualcluster/pkg/syncer/controllers/event/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/event/controller.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package event
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	listersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
+	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
+)
+
+type controller struct {
+	client                      v1core.EventsGetter
+	multiClusterEventController *mc.MultiClusterController
+	informer                    coreinformers.Interface
+
+	workers     int
+	eventLister listersv1.EventLister
+	eventSynced cache.InformerSynced
+	nsLister    listersv1.NamespaceLister
+	nsSynced    cache.InformerSynced
+	queue       workqueue.RateLimitingInterface
+}
+
+func Register(
+	client v1core.EventsGetter,
+	informer coreinformers.Interface,
+	controllerManager *manager.ControllerManager,
+) {
+	c := &controller{
+		client:   client,
+		informer: informer,
+		queue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "super_master_event"),
+		workers:  constants.DefaultControllerWorkers,
+	}
+
+	// Create the multi cluster pod controller
+	options := mc.Options{Reconciler: c}
+	multiClusterEventController, err := mc.NewMCController("tenant-masters-event-controller", &v1.Namespace{}, options)
+	if err != nil {
+		klog.Errorf("failed to create multi cluster event controller %v", err)
+		return
+	}
+	c.multiClusterEventController = multiClusterEventController
+
+	c.nsLister = informer.Namespaces().Lister()
+	c.nsSynced = informer.Namespaces().Informer().HasSynced
+
+	c.eventLister = informer.Events().Lister()
+	c.eventSynced = informer.Events().Informer().HasSynced
+	informer.Events().Informer().AddEventHandler(
+		cache.FilteringResourceEventHandler{
+			FilterFunc: func(obj interface{}) bool {
+				switch t := obj.(type) {
+				case *v1.Event:
+					return assignPodEvent(t)
+				case cache.DeletedFinalStateUnknown:
+					if e, ok := t.Obj.(*v1.Event); ok {
+						return assignPodEvent(e)
+					}
+					utilruntime.HandleError(fmt.Errorf("unable to convert object %v to *v1.Event", obj))
+					return false
+				default:
+					utilruntime.HandleError(fmt.Errorf("unable to handle object in super master event controller: %v", obj))
+					return false
+				}
+			},
+			Handler: cache.ResourceEventHandlerFuncs{
+				AddFunc: c.enqueueEvent,
+			},
+		})
+
+	controllerManager.AddController(c)
+}
+
+func assignPodEvent(e *v1.Event) bool {
+	return e.InvolvedObject.Kind == "Pod"
+}
+
+func (c *controller) enqueueEvent(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %v: %v", obj, err))
+		return
+	}
+	c.queue.Add(key)
+}
+
+func (c *controller) StartDWS(stopCh <-chan struct{}) error {
+	return c.multiClusterEventController.Start(stopCh)
+}
+
+func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
+	return reconciler.Result{}, nil
+}
+
+func (c *controller) AddCluster(cluster mc.ClusterInterface) {
+	klog.Infof("tenant-masters-pod-controller watch cluster %s for pod resource", cluster.GetClusterName())
+	err := c.multiClusterEventController.WatchClusterResource(cluster, mc.WatchOptions{})
+	if err != nil {
+		klog.Errorf("failed to watch cluster %s event event: %v", cluster.GetClusterName(), err)
+	}
+}
+
+func (c *controller) RemoveCluster(cluster mc.ClusterInterface) {
+	klog.Infof("tenant-masters-event-controller stop watching cluster %s for event resource", cluster.GetClusterName())
+	c.multiClusterEventController.TeardownClusterResource(cluster)
+}

--- a/incubator/virtualcluster/pkg/syncer/controllers/event/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/event/uws.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package event
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+)
+
+// StartUWS starts the upward syncer
+// and blocks until an empty struct is sent to the stop channel.
+func (c *controller) StartUWS(stopCh <-chan struct{}) error {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	klog.Infof("starting pod upward syncer")
+
+	if !cache.WaitForCacheSync(stopCh, c.eventSynced, c.nsSynced) {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+
+	klog.V(5).Infof("starting workers")
+	for i := 0; i < c.workers; i++ {
+		go wait.Until(c.run, 1*time.Second, stopCh)
+	}
+	<-stopCh
+	klog.V(1).Infof("shutting down")
+
+	return nil
+}
+
+// run runs a run thread that just dequeues items, processes them, and marks them done.
+// It enforces that the syncHandler is never invoked concurrently with the same key.
+func (c *controller) run() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *controller) processNextWorkItem() bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	klog.Infof("back populate event %+v", key)
+	err := c.backPopulate(key.(string))
+	if err == nil {
+		c.queue.Forget(key)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("error processing event %v (will retry): %v", key, err))
+	c.queue.AddRateLimited(key)
+	return true
+}
+
+func (c *controller) backPopulate(key string) error {
+	pNamespace, pName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("invalid resource key %v: %v", key, err))
+		return nil
+	}
+
+	pEvent, err := c.eventLister.Events(pNamespace).Get(pName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("could not find pEvent %s/%s in controller cache: %v", pNamespace, pName, err)
+	}
+
+	clusterName, tenantNS, err := conversion.GetVirtualOwner(c.nsLister, pNamespace)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("could not find ns %s in controller cache: %v", pNamespace, err)
+	}
+	if clusterName == "" || tenantNS == "" {
+		klog.Infof("drop event %s/%s which is not belongs to any tenant", pNamespace, pName)
+		return nil
+	}
+
+	tenantCluster := c.multiClusterEventController.GetCluster(clusterName)
+	if tenantCluster == nil {
+		// TODO: just return nil if periodic check if ready.
+		return fmt.Errorf("cluster %s not found", clusterName)
+	}
+	tenantClient, err := tenantCluster.GetClient()
+	if err != nil {
+		return fmt.Errorf("failed to create client from cluster %s config: %v", clusterName, err)
+	}
+
+	vPod, err := tenantClient.CoreV1().Pods(tenantNS).Get(pEvent.InvolvedObject.Name, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			klog.Infof("back populate event: failed to find pod %s/%s in cluster %s", tenantNS, pEvent.InvolvedObject.Name, clusterName)
+			return nil
+		}
+		return err
+	}
+
+	vEvent := conversion.BuildVirtualPodEvent(clusterName, pEvent, vPod)
+	_, err = tenantClient.CoreV1().Events(tenantNS).Create(vEvent)
+	return err
+}

--- a/incubator/virtualcluster/pkg/syncer/controllers/event/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/event/uws.go
@@ -36,7 +36,7 @@ func (c *controller) StartUWS(stopCh <-chan struct{}) error {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()
 
-	klog.Infof("starting pod upward syncer")
+	klog.Infof("starting event upward syncer")
 
 	if !cache.WaitForCacheSync(stopCh, c.eventSynced, c.nsSynced) {
 		return fmt.Errorf("failed to wait for caches to sync")
@@ -93,7 +93,7 @@ func (c *controller) backPopulate(key string) error {
 		return fmt.Errorf("could not find pEvent %s/%s in controller cache: %v", pNamespace, pName, err)
 	}
 
-	clusterName, tenantNS, err := conversion.GetVirtualOwner(c.nsLister, pNamespace)
+	clusterName, tenantNS, err := conversion.GetVirtualNamespace(c.nsLister, pNamespace)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil

--- a/incubator/virtualcluster/pkg/syncer/controllers/register.go
+++ b/incubator/virtualcluster/pkg/syncer/controllers/register.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/controllers/configmap"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/controllers/endpoints"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/controllers/event"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/controllers/namespace"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/controllers/node"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/controllers/pod"
@@ -40,4 +41,5 @@ func Register(client clientset.Interface, informerFactory informers.SharedInform
 	node.Register(client.CoreV1(), informerFactory.Core().V1().Nodes(), controllerManager)
 	service.Register(client.CoreV1(), informerFactory.Core().V1().Services(), controllerManager)
 	endpoints.Register(client.CoreV1(), informerFactory.Core().V1().Endpoints(), controllerManager)
+	event.Register(client.CoreV1(), informerFactory.Core().V1(), controllerManager)
 }

--- a/incubator/virtualcluster/pkg/syncer/conversion/helper.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/helper.go
@@ -61,7 +61,7 @@ func ToSuperMasterNamespace(cluster, ns string) string {
 	return targetNamespace
 }
 
-func GetVirtualOwner(nsLister listersv1.NamespaceLister, pNamespace string) (cluster, namespace string, err error) {
+func GetVirtualNamespace(nsLister listersv1.NamespaceLister, pNamespace string) (cluster, namespace string, err error) {
 	vcInfo, err := nsLister.Get(pNamespace)
 	if err != nil {
 		return
@@ -76,15 +76,14 @@ func GetVirtualOwner(nsLister listersv1.NamespaceLister, pNamespace string) (clu
 	return
 }
 
-func GetOwner(obj runtime.Object) (cluster, namespace string) {
+func GetVirtualOwner(obj runtime.Object) (cluster string) {
 	meta, err := meta.Accessor(obj)
 	if err != nil {
-		return "", ""
+		return ""
 	}
 
 	cluster = meta.GetAnnotations()[constants.LabelCluster]
-	namespace = strings.TrimPrefix(meta.GetNamespace(), cluster+"-")
-	return cluster, namespace
+	return cluster
 }
 
 func BuildMetadata(cluster, targetNamespace string, obj runtime.Object) (runtime.Object, error) {

--- a/incubator/virtualcluster/pkg/syncer/conversion/helper.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/helper.go
@@ -87,7 +87,7 @@ func BuildMetadata(cluster, targetNamespace string, obj runtime.Object) (runtime
 
 	anno := m.GetAnnotations()
 	if anno == nil {
-		anno = map[string]string{}
+		anno = make(map[string]string)
 	}
 	anno[constants.LabelCluster] = cluster
 	anno[constants.LabelUID] = string(uid)
@@ -102,6 +102,15 @@ func BuildSuperMasterNamespace(cluster string, obj runtime.Object) (runtime.Obje
 	if err != nil {
 		return nil, err
 	}
+
+	anno := m.GetAnnotations()
+	if anno == nil {
+		anno = make(map[string]string)
+	}
+	anno[constants.LabelCluster] = cluster
+	anno[constants.LabelUID] = string(m.GetUID())
+	anno[constants.LabelNamespace] = m.GetName()
+	m.SetAnnotations(anno)
 
 	resetMetadata(m)
 

--- a/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
+++ b/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
@@ -138,6 +138,11 @@ func (c *MultiClusterController) WatchClusterResource(cluster ClusterInterface, 
 		return nil
 	}
 	c.clusters[cluster.GetClusterName()] = cluster
+
+	if c.objectType == nil {
+		return nil
+	}
+
 	h := &handler.EnqueueRequestForObject{Cluster: cluster.GetClientInfo(), Queue: c.Queue}
 	return cluster.AddEventHandler(c.objectType, h)
 }


### PR DESCRIPTION
related #250 

lookup virtual ns from super ns when back pop pod

fix test

```
[Fail] [k8s.io] [sig-node] Events [It] should be sent by kubelets and the scheduler about pods scheduling and running [Conformance]
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/node/events.go:96
```

Signed-off-by: zhuangqh <zhuangqhc@gmail.com>