### PR TITLE
Fully automated builds with all binaries on Cloud Build

### DIFF
--- a/incubator/hnc/Makefile
+++ b/incubator/hnc/Makefile
@@ -3,38 +3,33 @@
 
 # If CONFIG is `kind`, various defaults will be optimized for deploying locally to Kind
 CONFIG ?= "default"
+
+PROJECT_ID=$(shell gcloud config get-value project)
+
+# Set default version tag for krew build and Docker image (unless version is set)
+HNC_IMG_TAG ?= latest
+
 # Image URL to use all building/pushing image targets
 ifeq ($(CONFIG),kind)
 	# The tag is `kind-local` since K8s always attempst to re-pull an image with the
 	# `latest` tag, and this doesn't work when we're testing locally (we rely on the
 	# docker-push target, below, to push the image into Kind).
-	IMG ?= controller:kind-local
+	HNC_IMG ?= controller:kind-local
 else
-	IMG ?= controller:latest
+	HNC_IMG ?= "gcr.io/${PROJECT_ID}/hnc/controller:${HNC_IMG_TAG}"
 endif
+
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
-endif
-
-# Set default version tag for krew build (unless version is set)
-ifeq (,${VERSION})
-VERSION=v0.1.0
-endif
+GOBIN ?= $(shell go env GOPATH)/bin
 
 # Set default object controller to the new one
-ifeq (,${NOC})
-NOC=1
-endif
+NOC ?= 1
 
 # Get check sum value of krew archive
 KREW_CKSM=$(shell sha256sum bin/kubectl-hierarchical_namespaces.tar.gz | cut -d " " -f 1)
-
 
 all: test docker-build
 
@@ -76,7 +71,7 @@ krew-build: krew-tar
 	cp hack/krew-hierarchical-namespaces.yaml manifests/krew-hierarchical-namespaces.yaml
 	sed -i 's/^\(\s*sha256\s*:\s*\).*/\1"$(KREW_CKSM)"/' \
 		manifests/krew-hierarchical-namespaces.yaml
-	sed -i 's/^\(\s*version\s*:\s*\).*/\1"$(VERSION)"/' \
+	sed -i 's/^\(\s*version\s*:\s*\).*/\1"$(HNC_IMG_TAG)"/' \
 		manifests/krew-hierarchical-namespaces.yaml
 
 # Install kubectl plugin locally using krew.
@@ -95,13 +90,14 @@ krew-uninstall:
 # files in /config (which should be checked into Git) as well as the kustomized
 # files in /manifest (which are not checked into Git).
 manifests: controller-gen
+	@echo "Building manifests with image ${HNC_IMG}"
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 	-rm -rf manifests/
 	mkdir manifests
 	cd manifests && \
 		touch kustomization.yaml && \
 		kustomize edit add resource ../config/default && \
-		kustomize edit set image controller=${IMG}
+		kustomize edit set image controller=${HNC_IMG}
 	kustomize build manifests/ -o manifests/hnc-manager.yaml
 
 # Run go fmt against code
@@ -149,16 +145,17 @@ deploy-prereq:
 
 # Push the docker image
 docker-push: docker-build
+	@echo "Pushing ${HNC_IMG}"
 ifeq ($(CONFIG),kind)
-	kind load docker-image ${IMG}
+	kind load docker-image ${HNC_IMG}
 else
-	docker push ${IMG}
+	docker push ${HNC_IMG}
 endif
 
 # Build the docker image
 docker-build: generate fmt vet
 	@echo "Warning: this does not run tests. Run 'make test' to ensure tests are passing."
-	docker build . -t ${IMG}
+	docker build . -t ${HNC_IMG}
 
 ###################### KIND ACTIONS #########################
 
@@ -180,5 +177,34 @@ kind-deploy:
 
 ###################### RELEASE ACTIONS #########################
 # Build the container image by Cloud Build and build YAMLs locally
-release: manifests
-	gcloud builds submit --config cloudbuild.yaml .
+#
+# ALL COMMANDS THAT INCLUDE THE PERSONAL ACCESS TOKEN ARE HIDDEN
+release: check-release-env test
+	@echo "*********************************************"
+	@echo "*********************************************"
+	@echo "Releasing HNC using GCP project ${PROJECT_ID}"
+	@echo "*********************************************"
+	@echo "*********************************************"
+	@echo "Uploading manifests to Github"
+	@curl -X POST -H "Content-Type: application/yaml" --data-binary @manifests/hnc-manager.yaml -u "${HNC_USER}:${HNC_PAT}" https://uploads.github.com/repos/kubernetes-sigs/multi-tenancy/releases/${HNC_RELEASE_ID}/assets?name=hnc-manager.yaml
+	@echo "\n\nInvoking Cloud Build to build image and kubectl plugin"
+	@gcloud builds submit --config cloudbuild.yaml --no-source --substitutions=_HNC_IMG_TAG=${HNC_IMG_TAG},_HNC_USER=${HNC_USER},_HNC_PERSONAL_ACCESS_TOKEN=${HNC_PAT},_HNC_RELEASE_ID=${HNC_RELEASE_ID}
+	@echo "Pushing image to K8s staging"
+	docker pull "gcr.io/${PROJECT_ID}/hnc/controller:${HNC_IMG_TAG}"
+	docker tag "gcr.io/${PROJECT_ID}/hnc/controller:${HNC_IMG_TAG}" "gcr.io/k8s-staging-multitenancy/hnc/controller:${HNC_IMG_TAG}"
+	docker push "gcr.io/k8s-staging-multitenancy/hnc/controller:${HNC_IMG_TAG}"
+
+check-release-env:
+	@echo "Verifying that HNC_IMG_TAG, HNC_USER, HNC_PAT and HNC_RELEASE_ID are set"
+ifndef HNC_IMG_TAG
+	$(error HNC_IMG_TAG is undefined, eg v0.1.0)
+endif
+ifndef HNC_USER
+	$(error HNC_USER is undefinied, use you github username)
+endif
+ifndef HNC_PAT
+	$(error HNC_PAT is undefined, use your Github personal access token)
+endif
+ifndef HNC_RELEASE_ID
+	$(error HNC_RELEASE_ID is undefinied, use the Github numeric release ID)
+endif

--- a/incubator/hnc/cloudbuild.yaml
+++ b/incubator/hnc/cloudbuild.yaml
@@ -1,7 +1,35 @@
 steps:
-# TODO: pull the code directly from Github
 # Build release container image
-- name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/hnc/controller', '.']
+- name: gcr.io/cloud-builders/git      # pull source
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    git clone https://github.com/kubernetes-sigs/multi-tenancy
+    cd multi-tenancy
+    git checkout hnc-$_HNC_IMG_TAG
+- name: gcr.io/cloud-builders/docker   # build docker image
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/hnc/controller:$_HNC_IMG_TAG', 'multi-tenancy/incubator/hnc']
+- name: mirror.gcr.io/library/golang   # build kubectl plugin
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    cd multi-tenancy/incubator/hnc
+    mkdir bin
+    mkdir manifests
+    touch manifests/kustomization.yaml
+    go build -o bin/kubectl-hierarchical_namespaces ./cmd/kubectl/main.go
+- name: gcr.io/cloud-builders/curl     # upload kubectl plugin
+  args:
+  - '-X'
+  - 'POST'
+  - '-H'
+  - 'Content-Type: application/x-application'
+  - '--data-binary'
+  - '@multi-tenancy/incubator/hnc/bin/kubectl-hierarchical_namespaces'
+  - '-u'
+  - '$_HNC_USER:$_HNC_PERSONAL_ACCESS_TOKEN'
+  - 'https://uploads.github.com/repos/kubernetes-sigs/multi-tenancy/releases/$_HNC_RELEASE_ID/assets?name=kubectl-hierarchical_namespaces'
 
-images: ['gcr.io/$PROJECT_ID/hnc/controller']
+images: ['gcr.io/$PROJECT_ID/hnc/controller:$_HNC_IMG_TAG']


### PR DESCRIPTION
This change updates `make release` so that as little as possible happens
on the host computer (only the manifests are built locally, and then
only because I haven't figured out how to get kustomize to run on Cloud
Build yet). Both the plugin and the image are now build on Cloud Build,
with nothing touching the builder's workstation - all code is pulled
directly from Github.

The image does still have to make a round-trip onto the builder's
workstation since the Cloud Build service account doesn't have
permission to push directly to the K8s staging GCR, but you can still
verify that the image built on Cloud Build is the same one on the
official GCR.

Tested: followed these instructions to create a new build and deployed
it.