### PR TITLE
[incubator][VC] setup prometheus metrics framework

### DIFF
--- a/incubator/virtualcluster/cmd/syncer/app/config/config.go
+++ b/incubator/virtualcluster/cmd/syncer/app/config/config.go
@@ -53,6 +53,12 @@ type Config struct {
 
 	// LeaderElection is optional.
 	LeaderElection *leaderelection.LeaderElectionConfig
+
+	// server config.
+	Address  string
+	Port     string
+	CertFile string
+	KeyFile  string
 }
 
 type completedConfig struct {

--- a/incubator/virtualcluster/cmd/syncer/app/options/options.go
+++ b/incubator/virtualcluster/cmd/syncer/app/options/options.go
@@ -52,6 +52,11 @@ type ResourceSyncerOptions struct {
 
 	SuperMaster           string
 	SuperMasterKubeconfig string
+
+	Address  string
+	Port     string
+	CertFile string
+	KeyFile  string
 }
 
 // NewResourceSyncerOptions creates a new resource syncer with a default config.
@@ -70,6 +75,12 @@ func (o *ResourceSyncerOptions) Flags() cliflag.NamedFlagSets {
 	fs := fss.FlagSet("misc")
 	fs.StringVar(&o.SuperMaster, "super-master", o.SuperMaster, "The address of the super master Kubernetes API server (overrides any value in super-master-kubeconfig).")
 	fs.StringVar(&o.ComponentConfig.ClientConnection.Kubeconfig, "super-master-kubeconfig", o.ComponentConfig.ClientConnection.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
+
+	serverFlags := fss.FlagSet("server")
+	serverFlags.StringVar(&o.Address, "address", "", "The server address.")
+	serverFlags.StringVar(&o.Port, "port", "80", "The server port.")
+	serverFlags.StringVar(&o.CertFile, "cert-file", "", "CertFile is the file containing x509 Certificate for HTTPS.")
+	serverFlags.StringVar(&o.KeyFile, "key-file", "", "KeyFile is the file containing x509 private key matching certFile.")
 
 	BindFlags(&o.ComponentConfig.LeaderElection, fss.FlagSet("leader election"))
 
@@ -100,7 +111,6 @@ func BindFlags(l *syncerconfig.SyncerLeaderElectionConfiguration, fs *pflag.Flag
 		"leader election. Supported options are `endpoints` (default) and `configmaps`.")
 	fs.StringVar(&l.LockObjectNamespace, "lock-object-namespace", l.LockObjectNamespace, "DEPRECATED: define the namespace of the lock object.")
 	fs.StringVar(&l.LockObjectName, "lock-object-name", l.LockObjectName, "DEPRECATED: define the name of the lock object.")
-
 }
 
 // Config return a syncer config object
@@ -137,6 +147,11 @@ func (o *ResourceSyncerOptions) Config() (*syncerappconfig.Config, error) {
 	c.Recorder = recorder
 	c.LeaderElectionClient = leaderElectionClient
 	c.LeaderElection = leaderElectionConfig
+
+	c.Address = o.Address
+	c.Port = o.Port
+	c.CertFile = o.CertFile
+	c.KeyFile = o.KeyFile
 
 	return c, nil
 }

--- a/incubator/virtualcluster/go.mod
+++ b/incubator/virtualcluster/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/onsi/ginkgo v1.8.0 // indirect
 	github.com/onsi/gomega v1.5.0
 	github.com/pkg/errors v0.8.1
+	github.com/prometheus/client_golang v0.9.2
 	github.com/spf13/cobra v0.0.0-20180319062004-c439c4fa0937
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.4.0

--- a/incubator/virtualcluster/pkg/syncer/metrics/metrics.go
+++ b/incubator/virtualcluster/pkg/syncer/metrics/metrics.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	ResourceSyncerSubsystem  = "syncer"
+	PodOperationsKey         = "pod_operations_total"
+	PodOperationsDurationKey = "pod_operations_duration_seconds"
+	PodOperationsErrorsKey   = "pod_operations_errors_total"
+)
+
+var (
+	PodOperations = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: ResourceSyncerSubsystem,
+			Name:      PodOperationsKey,
+			Help:      "Cumulative number of pod operations by operation type.",
+		},
+		[]string{"operation_type"},
+	)
+	PodOperationsDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: ResourceSyncerSubsystem,
+			Name:      PodOperationsDurationKey,
+			Help:      "Duration in seconds of pod operations. Broken down by operation type.",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{"operation_type"},
+	)
+	PodOperationsErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: ResourceSyncerSubsystem,
+			Name:      PodOperationsErrorsKey,
+			Help:      "Cumulative number of pod operation errors by operation type.",
+		},
+		[]string{"operation_type"},
+	)
+)
+
+var registerMetrics sync.Once
+
+// Register all metrics.
+func Register() {
+	registerMetrics.Do(func() {
+		prometheus.MustRegister(PodOperations)
+		prometheus.MustRegister(PodOperationsDuration)
+		prometheus.MustRegister(PodOperationsErrors)
+	})
+}
+
+// Gets the time since the specified start in microseconds.
+func SinceInMicroseconds(start time.Time) float64 {
+	return float64(time.Since(start).Nanoseconds() / time.Microsecond.Nanoseconds())
+}
+
+// SinceInSeconds gets the time since the specified start in seconds.
+func SinceInSeconds(start time.Time) float64 {
+	return time.Since(start).Seconds()
+}


### PR DESCRIPTION
1. export metric endpoint to http server
2. add metric for pod operation counts, durations and errors

Signed-off-by: zhuangqh <zhuangqhc@gmail.com>

fixes #329 

```bash
curl 172.17.0.8/metrics
syncer_pod_operations_duration_seconds_count{operation_type="pod_delete"} 1
syncer_pod_operations_duration_seconds_bucket{operation_type="pod_update",le="0.005"} 10
syncer_pod_operations_duration_seconds_bucket{operation_type="pod_update",le="0.01"} 10
syncer_pod_operations_duration_seconds_bucket{operation_type="pod_update",le="0.025"} 11
syncer_pod_operations_duration_seconds_bucket{operation_type="pod_update",le="0.05"} 11
syncer_pod_operations_duration_seconds_bucket{operation_type="pod_update",le="0.1"} 11
syncer_pod_operations_duration_seconds_bucket{operation_type="pod_update",le="0.25"} 11
syncer_pod_operations_duration_seconds_bucket{operation_type="pod_update",le="0.5"} 11
syncer_pod_operations_duration_seconds_bucket{operation_type="pod_update",le="1"} 11
syncer_pod_operations_duration_seconds_bucket{operation_type="pod_update",le="2.5"} 11
syncer_pod_operations_duration_seconds_bucket{operation_type="pod_update",le="5"} 11
syncer_pod_operations_duration_seconds_bucket{operation_type="pod_update",le="10"} 11
syncer_pod_operations_duration_seconds_bucket{operation_type="pod_update",le="+Inf"} 11
syncer_pod_operations_duration_seconds_sum{operation_type="pod_update"} 0.02441573
syncer_pod_operations_duration_seconds_count{operation_type="pod_update"} 11
# HELP syncer_pod_operations_total Cumulative number of pod operations by operation type.
# TYPE syncer_pod_operations_total counter
syncer_pod_operations_total{operation_type="pod_add"} 2
syncer_pod_operations_total{operation_type="pod_delete"} 1
syncer_pod_operations_total{operation_type="pod_update"} 11
```