### PR TITLE
Add ACK mode for VC

### DIFF
--- a/incubator/virtualcluster/README.md
+++ b/incubator/virtualcluster/README.md
@@ -61,6 +61,7 @@ We achieve this by serializing the ca into a secret that will be mounted on
 vn-agents.
 ```bash
 # if using minikube, the client CA (i.e. client.crt and client.key) is located in ~/.minikube/
+# if using other cloud platforms, please copy the kubelet-client-certificate from master node
 cp ~/.minikube/client.crt ~/.minikube/client.key .
 # create secret
 kubectl create secret generic vc-kubelet-client --from-file=./client.crt --from-file=./client.key --namespace vc-manager
@@ -78,14 +79,15 @@ kubectl apply -f config/setup/all_in_one.yaml
 9. Create the clusterversion (e.g. cv-sample), once the management 
 controllers are ready.
 ```bash 
-_output/bin/vcctl create -yaml config/sampleswithspec/clusterversion_v1.yaml
+_output/bin/vcctl create -yaml config/sampleswithspec/clusterversion_v1_nodeport.yaml
 ```
 <br />
 <br />
 
 10. If using minikube, create the tenant namespace and virtualcluster
 ```bash
-_output/bin/vcctl create -yaml config/sampleswithspec/virtualcluster_1.yaml -vckbcfg vc-1.kubeconfig -minikube
+# when using minikube, the tenant apiserver is exposed through nodeport service
+_output/bin/vcctl create -yaml config/sampleswithspec/virtualcluster_1_nodeport.yaml -vckbcfg vc-1.kubeconfig
 ```
 Once the tenant master is created, a kubeconfig file `vc-1.kubeconfig` will 
 be created

--- a/incubator/virtualcluster/cmd/vcctl/vcctl.go
+++ b/incubator/virtualcluster/cmd/vcctl/vcctl.go
@@ -30,7 +30,6 @@ func main() {
 	yaml := createCmd.String("yaml", "", "path to the yaml file of the object that will be created.")
 	vcKbCfg := createCmd.String("vckbcfg", "", "path to the kubeconfig that is used to access virtual cluster.")
 	crtKbCfg := createCmd.String("kubeconfig", "", "path to the kubeconfig of the meta cluster.")
-	minikube := createCmd.Bool("minikube", false, "if running with minikube. (default false)")
 
 	deleteCmd := flag.NewFlagSet("delete", flag.ExitOnError)
 	delYaml := deleteCmd.String("yaml", "", "path to the yaml file of the virtualcluster that will be deleted.")
@@ -49,7 +48,7 @@ func main() {
 				log.Fatalf("fail to set flag kubeconfig: %s", err)
 			}
 		}
-		if err := subcmd.Create(*yaml, *vcKbCfg, *minikube); err != nil {
+		if err := subcmd.Create(*yaml, *vcKbCfg); err != nil {
 			log.Fatalf("fail to create object: %s", err)
 		}
 	case "delete":

--- a/incubator/virtualcluster/config/sampleswithspec/clusterversion_v1_loadbalancer.yaml
+++ b/incubator/virtualcluster/config/sampleswithspec/clusterversion_v1_loadbalancer.yaml
@@ -3,7 +3,7 @@ kind: ClusterVersion
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: cv-sample 
+  name: cv-sample-lb
 spec:
   # a statefulset and service bundle for etcd
   etcd:
@@ -30,7 +30,7 @@ spec:
             subdomain: etcd
             containers:
             - name: etcd
-              image: virtualcluster/etcd-v3.4.0
+              image: registry.cn-hangzhou.aliyuncs.com/virtualcluster/etcd-v3.4.0
               imagePullPolicy: Always
               command: 
               - etcd
@@ -132,7 +132,7 @@ spec:
             subdomain: apiserver-svc
             containers:
             - name: apiserver
-              image: virtualcluster/apiserver-v1.15.4
+              image: registry.cn-hangzhou.aliyuncs.com/virtualcluster/apiserver-v1.15.4
               imagePullPolicy: Always
               command:
               - kube-apiserver
@@ -214,7 +214,7 @@ spec:
       spec:
         selector:
           component-name: apiserver
-        type: NodePort
+        type: LoadBalancer
         ports:
         - port: 6443
           protocol: TCP
@@ -242,7 +242,7 @@ spec:
           spec:
             containers:
             - name: controller-manager
-              image: virtualcluster/controller-manager-v1.15.4
+              image: registry.cn-hangzhou.aliyuncs.com/virtualcluster/controller-manager-v1.15.4
               imagePullPolicy: Always
               command:
               - kube-controller-manager

--- a/incubator/virtualcluster/config/sampleswithspec/clusterversion_v1_nodeport.yaml
+++ b/incubator/virtualcluster/config/sampleswithspec/clusterversion_v1_nodeport.yaml
@@ -1,0 +1,306 @@
+apiVersion: tenancy.x-k8s.io/v1alpha1
+kind: ClusterVersion
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: cv-sample-np
+spec:
+  # a statefulset and service bundle for etcd
+  etcd:
+    metadata:
+      name: etcd 
+    statefulset:
+      metadata:
+        name: etcd
+      spec:
+        replicas: 1
+        revisionHistoryLimit: 10
+        serviceName: etcd
+        selector:
+          matchLabels:
+            component-name: etcd
+        # etcd will not be updated, unless it is deleted
+        updateStrategy:
+          type: OnDelete
+        template:
+          metadata:
+            labels:
+              component-name: etcd
+          spec:
+            subdomain: etcd
+            containers:
+            - name: etcd
+              image: virtualcluster/etcd-v3.4.0
+              imagePullPolicy: Always
+              command: 
+              - etcd
+              # pass the pod name(hostname) to container for composing the advertise-urls args
+              env:
+              - name: HOSTNAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name 
+              args:
+              - --name=$(HOSTNAME)
+              - --trusted-ca-file=/etc/kubernetes/pki/root/tls.crt
+              - --client-cert-auth 
+              - --cert-file=/etc/kubernetes/pki/etcd/tls.crt
+              - --key-file=/etc/kubernetes/pki/etcd/tls.key
+              - --peer-client-cert-auth 
+              - --peer-trusted-ca-file=/etc/kubernetes/pki/root/tls.crt
+              - --peer-cert-file=/etc/kubernetes/pki/etcd/tls.crt
+              - --peer-key-file=/etc/kubernetes/pki/etcd/tls.key
+              - --listen-peer-urls=https://0.0.0.0:2380 
+              - --listen-client-urls=https://0.0.0.0:2379
+              - --initial-advertise-peer-urls=https://$(HOSTNAME).etcd:2380
+              # we use a headless service to encapsulate each pod
+              - --advertise-client-urls=https://$(HOSTNAME).etcd:2379
+              - --initial-cluster-state=new
+              - --initial-cluster-token=vc-etcd
+              - --data-dir=/var/lib/etcd/data
+              # --initial-cluster option will be set during runtime based on the number of replicas
+              livenessProbe:
+                exec:
+                  command: 
+                  - sh
+                  - -c
+                  - ETCDCTL_API=3 etcdctl --endpoints=https://etcd:2379 --cacert=/etc/kubernetes/pki/root/tls.crt --cert=/etc/kubernetes/pki/etcd/tls.crt --key=/etc/kubernetes/pki/etcd/tls.key endpoint health
+                failureThreshold: 8
+                initialDelaySeconds: 60
+                timeoutSeconds: 15
+              readinessProbe:
+                exec:
+                  command: 
+                  - sh
+                  - -c
+                  - ETCDCTL_API=3 etcdctl --endpoints=https://etcd:2379 --cacert=/etc/kubernetes/pki/root/tls.crt --cert=/etc/kubernetes/pki/etcd/tls.crt --key=/etc/kubernetes/pki/etcd/tls.key endpoint health
+                failureThreshold: 8
+                initialDelaySeconds: 15
+                periodSeconds: 2
+                timeoutSeconds: 15
+              volumeMounts:
+              - mountPath: /etc/kubernetes/pki/etcd
+                name: etcd-ca
+                readOnly: true
+              - mountPath: /etc/kubernetes/pki/root
+                name: root-ca
+                readOnly: true
+            volumes: 
+            - name: etcd-ca
+              secret:
+                defaultMode: 420
+                secretName: etcd-ca
+            - name: root-ca
+              secret:
+                defaultMode: 420
+                secretName: root-ca
+    # etcd will be accessed only by apiserver from inside the cluster, so we use a headless service to 
+    # encapsulate it
+    service:
+      metadata:
+        name: etcd
+        annotations:
+          service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+      spec:
+        type: ClusterIP
+        clusterIP: None
+        selector:
+          component-name: etcd
+  # a statefulset and service bundle for apiserver
+  apiServer:
+    metadata:
+      name: apiserver
+    statefulset:
+      metadata:
+        name: apiserver
+      spec:
+        replicas: 1
+        revisionHistoryLimit: 10
+        serviceName: apiserver-svc
+        selector:
+          matchLabels:
+            component-name: apiserver
+        # apiserver will not be updated, unless it is deleted
+        updateStrategy:
+          type: OnDelete
+        template:
+          metadata:
+            labels:
+              component-name: apiserver
+          spec:
+            hostname: apiserver
+            subdomain: apiserver-svc
+            containers:
+            - name: apiserver
+              image: virtualcluster/apiserver-v1.15.4
+              imagePullPolicy: Always
+              command:
+              - kube-apiserver
+              args:
+              - --bind-address=0.0.0.0
+              - --allow-privileged=true
+              - --anonymous-auth=true
+              - --client-ca-file=/etc/kubernetes/pki/root/tls.crt
+              - --tls-cert-file=/etc/kubernetes/pki/apiserver/tls.crt
+              - --tls-private-key-file=/etc/kubernetes/pki/apiserver/tls.key
+              - --kubelet-https=true
+              - --kubelet-client-certificate=/etc/kubernetes/pki/apiserver/tls.crt
+              - --kubelet-client-key=/etc/kubernetes/pki/apiserver/tls.key
+              - --enable-bootstrap-token-auth=true
+              - --etcd-servers=https://etcd-0.etcd:2379
+              - --etcd-cafile=/etc/kubernetes/pki/root/tls.crt
+              - --etcd-certfile=/etc/kubernetes/pki/apiserver/tls.crt
+              - --etcd-keyfile=/etc/kubernetes/pki/apiserver/tls.key
+              - --service-account-key-file=/etc/kubernetes/pki/service-account/tls.key
+              - --service-cluster-ip-range=10.32.0.0/16
+              - --service-node-port-range=30000-32767
+              - --authorization-mode=Node,RBAC
+              - --runtime-config=api/all
+              - --enable-admission-plugins=NamespaceLifecycle,NodeRestriction,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota
+              - --apiserver-count=1
+              - --endpoint-reconciler-type=master-count
+              - --v=2
+              ports:
+              - containerPort: 6443
+                name: api
+              livenessProbe:
+                # since we set anonymous-auth to false, we use tcp instead of https
+                tcpSocket:
+                  port: 6443
+                failureThreshold: 8
+                initialDelaySeconds: 15
+                periodSeconds: 10
+                timeoutSeconds: 15
+              readinessProbe:
+                httpGet:
+                  port: 6443
+                  path: /healthz
+                  scheme: HTTPS
+                failureThreshold: 8
+                initialDelaySeconds: 5
+                periodSeconds: 2
+                timeoutSeconds: 30
+              volumeMounts:
+              - mountPath: /etc/kubernetes/pki/apiserver
+                name: apiserver-ca
+                readOnly: true
+              - mountPath: /etc/kubernetes/pki/root
+                name: root-ca
+                readOnly: true
+              - mountPath: /etc/kubernetes/pki/service-account
+                name: serviceaccount-rsa
+                readOnly: true
+            securityContext: {}
+            terminationGracePeriodSeconds: 30
+            dnsConfig:
+              searches:
+              - cluster.local
+            volumes:
+            - name: apiserver-ca
+              secret:
+                defaultMode: 420
+                secretName: apiserver-ca
+            - name: root-ca
+              secret:
+                defaultMode: 420
+                secretName: root-ca
+            - name: serviceaccount-rsa
+              secret:
+                defaultMode: 420
+                secretName: serviceaccount-rsa
+    service:
+      metadata:
+        name: apiserver-svc
+      spec:
+        selector:
+          component-name: apiserver
+        type: NodePort
+        ports:
+        - port: 6443
+          protocol: TCP
+          targetPort: api
+  # a statefulset and service bundle for controller-manager
+  controllerManager:
+    metadata:
+      name: controller-manager
+    # statefuleset template for controller-manager
+    statefulset:  
+      metadata:
+        name: controller-manager
+      spec:
+        serviceName: controller-manager-svc
+        replicas: 1
+        selector:
+          matchLabels:
+            component-name: controller-manager
+        updateStrategy:
+          type: OnDelete
+        template:
+          metadata:
+            labels:
+              component-name: controller-manager
+          spec:
+            containers:
+            - name: controller-manager
+              image: virtualcluster/controller-manager-v1.15.4
+              imagePullPolicy: Always
+              command:
+              - kube-controller-manager
+              args:
+              - --bind-address=0.0.0.0
+              - --cluster-cidr=10.200.0.0/16
+              - --cluster-signing-cert-file=/etc/kubernetes/pki/root/tls.crt
+              - --cluster-signing-key-file=/etc/kubernetes/pki/root/tls.key
+              - --kubeconfig=/etc/kubernetes/kubeconfig/controller-manager-kubeconfig
+              - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/controller-manager-kubeconfig
+              - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/controller-manager-kubeconfig
+              # control plane contains only one instance for now
+              - --leader-elect=false
+              - --root-ca-file=/etc/kubernetes/pki/root/tls.crt
+              - --service-account-private-key-file=/etc/kubernetes/pki/service-account/tls.key
+              - --service-cluster-ip-range=10.32.0.0/24
+              - --use-service-account-credentials=true
+              - --experimental-cluster-signing-duration=87600h
+              - --v=2
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: 10252
+                  scheme: HTTP
+                failureThreshold: 8
+                initialDelaySeconds: 15
+                periodSeconds: 10
+                timeoutSeconds: 15
+              readinessProbe:
+                httpGet:
+                  port: 10252
+                  path: /healthz
+                  scheme: HTTP
+                failureThreshold: 8
+                initialDelaySeconds: 15
+                periodSeconds: 2
+                timeoutSeconds: 15
+              volumeMounts:
+              - mountPath: /etc/kubernetes/pki/root
+                name: root-ca
+                readOnly: true
+              - mountPath: /etc/kubernetes/pki/service-account
+                name: serviceaccount-rsa
+                readOnly: true
+              - mountPath: /etc/kubernetes/kubeconfig
+                name: kubeconfig
+                readOnly: true
+            volumes:
+            - name: root-ca
+              secret:
+                defaultMode: 420
+                secretName: root-ca
+            - name: serviceaccount-rsa 
+              secret:
+                defaultMode: 420
+                secretName: serviceaccount-rsa
+            - name: kubeconfig
+              secret:
+                defaultMode: 420
+                secretName: controller-manager-kubeconfig
+    # controller-manager will never be accessed proactively, no need to be exposed 

--- a/incubator/virtualcluster/config/sampleswithspec/virtualcluster_1_loadbalancer.yaml
+++ b/incubator/virtualcluster/config/sampleswithspec/virtualcluster_1_loadbalancer.yaml
@@ -3,10 +3,10 @@ kind: Virtualcluster
 metadata: 
   labels:
     controller-tools.k8s.io: "1.0"
-  name: vc-sample-2
-  namespace: tenant-2
+  name: vc-sample-1
+  namespace: tenant1admin
 spec:
   clusterDomain: cluster.local
-  clusterVersionName: cv-sample 
+  clusterVersionName: cv-sample-lb
   # will expire in one year
   pkiExpireDays: 365

--- a/incubator/virtualcluster/config/sampleswithspec/virtualcluster_1_nodeport.yaml
+++ b/incubator/virtualcluster/config/sampleswithspec/virtualcluster_1_nodeport.yaml
@@ -7,6 +7,6 @@ metadata:
   namespace: tenant1admin
 spec:
   clusterDomain: cluster.local
-  clusterVersionName: cv-sample 
+  clusterVersionName: cv-sample-np
   # will expire in one year
   pkiExpireDays: 365

--- a/incubator/virtualcluster/config/setup/all_in_one_ack.yaml
+++ b/incubator/virtualcluster/config/setup/all_in_one_ack.yaml
@@ -1,0 +1,275 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vc-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: vc-manager-role
+rules:
+- apiGroups:
+  - tenancy.x-k8s.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - tenancy.x-k8s.io
+  resources:
+  - clusterversions/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - tenancy.x-k8s.io
+  resources:
+  - virtualclusters
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - tenancy.x-k8s.io
+  resources:
+  - virtualclusters/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - tenancy.x-k8s.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tenancy.x-k8s.io
+  resources:
+  - clusterversions/status
+  verbs:
+  - get
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vc-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vc-manager-role
+subjects:
+- kind: ServiceAccount
+  name: vc-manager
+  namespace: vc-manager
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vc-manager
+  namespace: vc-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vc-manager
+  namespace: vc-manager
+  labels:
+    app: vc-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vc-manager 
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: vc-manager
+    spec:
+      serviceAccountName: vc-manager
+      containers:
+      - command:
+        - manager
+        image: registry.cn-hangzhou.aliyuncs.com/virtualcluster/manager-amd64 
+        imagePullPolicy: Always
+        name: vc-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vc-syncer-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: vc-syncer
+    namespace: vc-manager
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vc-syncer
+  namespace: vc-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vc-syncer
+  namespace: vc-manager
+  labels:
+    app: vc-syncer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vc-syncer
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: vc-syncer
+    spec:
+      serviceAccountName: vc-syncer
+      containers:
+        - command:
+            - syncer
+          image: registry.cn-hangzhou.aliyuncs.com/virtualcluster/syncer-amd64
+          imagePullPolicy: Always
+          name: vc-syncer
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: vn-agent
+  namespace: vc-manager
+  labels:
+    app: vn-agent
+spec:
+  selector:
+    matchLabels:
+      app: vn-agent
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: vn-agent
+    spec:
+      hostNetwork: true
+      containers:
+        - command:
+          - vn-agent
+          - --cert-dir=/etc/vn-agent/
+          - --kubelet-client-certificate=/etc/vn-agent/pki/client.crt
+          - --kubelet-client-key=/etc/vn-agent/pki/client.key
+          image: registry.cn-hangzhou.aliyuncs.com/virtualcluster/vn-agent-amd64
+          imagePullPolicy: Always
+          name: vn-agent
+          volumeMounts:
+          - name: kubelet-client-cert
+            mountPath: /etc/vn-agent/pki/
+      volumes:
+      - name: kubelet-client-cert
+        secret:
+          secretName: vc-kubelet-client

--- a/incubator/virtualcluster/pkg/controller/util/net/util.go
+++ b/incubator/virtualcluster/pkg/controller/util/net/util.go
@@ -2,10 +2,18 @@ package net
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	GetLBIPTimeoutSec = 30
+	GetLBIPPeriodSec  = 2
 )
 
 // GetSvcNodePort returns the nodePort of service with given name
@@ -19,4 +27,48 @@ func GetSvcNodePort(name, namespace string, cli client.Client) (int32, error) {
 		return 0, err
 	}
 	return svc.Spec.Ports[0].NodePort, nil
+}
+
+// GetNodeIP returns a node IP address
+func GetNodeIP(cli client.Client) (string, error) {
+	nodeLst := &v1.NodeList{}
+	if err := cli.List(context.TODO(), nodeLst); err != nil {
+		return "", err
+	}
+	if len(nodeLst.Items) == 0 {
+		return "", errors.New("there is no available nodes")
+	}
+	for _, addr := range nodeLst.Items[0].Status.Addresses {
+		if addr.Type == v1.NodeInternalIP {
+			return addr.Address, nil
+		}
+	}
+	return "", errors.New("there is no 'NodeInternalIP' type address")
+}
+
+// GetLBIP returns the external ip address assigned to Loadbalancer by
+// cloud provider
+func GetLBIP(name, namespace string, cli client.Client) (string, error) {
+	timeout := time.After(GetLBIPTimeoutSec * time.Second)
+	for {
+		period := time.After(GetLBIPPeriodSec * time.Second)
+		select {
+		case <-timeout:
+			return "", fmt.Errorf("Get LoadBalancer IP timeout for svc %s:%s",
+				namespace, name)
+		case <-period:
+			// if external IP is not assigned to LB yet, we will
+			// retry to get in period second
+			svc := &v1.Service{}
+			err := cli.Get(context.TODO(), types.NamespacedName{
+				Namespace: namespace,
+				Name:      name}, svc)
+			if err != nil {
+				return "", err
+			}
+			if len(svc.Status.LoadBalancer.Ingress) != 0 {
+				return svc.Status.LoadBalancer.Ingress[0].IP, nil
+			}
+		}
+	}
 }

--- a/incubator/virtualcluster/pkg/syncer/conversion/helper.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/helper.go
@@ -21,8 +21,8 @@ import (
 	"encoding/hex"
 	"strings"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/tenant/config/manager/all_in_one_ack.yaml
+++ b/tenant/config/manager/all_in_one_ack.yaml
@@ -1,0 +1,245 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: tenant-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - watch
+  - delete
+- apiGroups:
+  - tenancy.x-k8s.io
+  resources:
+  - tenants
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - tenancy.x-k8s.io
+  resources:
+  - tenants/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
+  - tenancy.x-k8s.io
+  resources:
+  - tenantnamespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - tenancy.x-k8s.io
+  resources:
+  - tenantnamespaces/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: tenant-system
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    alpha.admissionwebhook.cert-manager.io: "true"
+  creationTimestamp: null
+  name: tenant-validating-webhook-cfg
+webhooks:
+- clientConfig:
+    caBundle: XG4=
+    service:
+      name: webhook-server-service
+      namespace: tenant-system
+      path: /validating-create-update-tenantnamespace
+  failurePolicy: Fail
+  name: validating-create-update-tenantnamespace.x-k8s.io
+  namespaceSelector:
+    matchExpressions:
+    - key: control-plane
+      operator: DoesNotExist
+  rules:
+  - apiGroups:
+    - tenancy
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - tenantnamespaces
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: controller-manager-service
+  namespace: tenant-system
+  labels:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+spec:
+  selector:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  ports:
+  - port: 443
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: webhook-server-secret
+  namespace: tenant-system
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: controller-manager
+  namespace: tenant-system
+  labels:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      controller-tools.k8s.io: "1.0"
+  serviceName: controller-manager-service
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+        controller-tools.k8s.io: "1.0"
+    spec:
+      containers:
+      - command:
+        - /manager
+        image: registry.cn-hangzhou.aliyuncs.com/virtualcluster/tenant
+        imagePullPolicy: Always
+        name: manager
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: SECRET_NAME
+            value: webhook-server-secret
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+        ports:
+        - containerPort: 9876
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/cert
+          name: cert
+          readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-secret


### PR DESCRIPTION
1. allow Virtualcluster to be exposed through loadbalancer.
2. when vc is exposed by loadbalancer, the vcctl will replace vc url
in kubeconfig by external ip of the loadbalancer.
3. add ack specified yaml files that pulling container images from docker registry
hosts alibaba cloud. (ack users may have issues with downloading image
from docker hub).