### PR TITLE
[Incubator][VC] Clean up - Refactor resource controller - Part 1

### DIFF
--- a/incubator/virtualcluster/go.mod
+++ b/incubator/virtualcluster/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/spf13/cobra v0.0.0-20180319062004-c439c4fa0937
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.4.0
+	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 // indirect
 	golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc
 	golang.org/x/sys v0.0.0-20190429190828-d89cdac9e872 // indirect
 	golang.org/x/text v0.3.2 // indirect

--- a/incubator/virtualcluster/pkg/syncer/resources/configmap/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/configmap/controller.go
@@ -17,30 +17,23 @@ limitations under the License.
 package configmap
 
 import (
-	"fmt"
-
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	listersv1 "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
 )
 
 type controller struct {
-	configMapClient                 v1core.ConfigMapsGetter
-	multiClusterConfigMapController *mc.MultiClusterController
-
+	// super master configMap client
+	configMapClient v1core.ConfigMapsGetter
+	// super master configMap informer lister/synced function
 	configMapLister listersv1.ConfigMapLister
-	configMapSynced cache.InformerSynced
+	// Connect to all tenant master configMap informers
+	multiClusterConfigMapController *mc.MultiClusterController
 }
 
 func Register(
@@ -60,106 +53,16 @@ func Register(
 		return
 	}
 	c.multiClusterConfigMapController = multiClusterConfigMapController
-
 	c.configMapLister = configMapInformer.Lister()
-	c.configMapSynced = configMapInformer.Informer().HasSynced
 
 	controllerManager.AddController(c)
 }
 
 func (c *controller) StartUWS(stopCh <-chan struct{}) error {
-	if !cache.WaitForCacheSync(stopCh, c.configMapSynced) {
-		return fmt.Errorf("failed to wait for caches to sync")
-	}
-
 	return nil
-}
-
-func (c *controller) StartDWS(stopCh <-chan struct{}) error {
-	return c.multiClusterConfigMapController.Start(stopCh)
 }
 
 func (c *controller) StartPeriodChecker(stopCh <-chan struct{}) {
-}
-
-func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
-	klog.Infof("reconcile configmap %s/%s %s event for cluster %s", request.Namespace, request.Name, request.Event, request.Cluster.Name)
-
-	switch request.Event {
-	case reconciler.AddEvent:
-		err := c.reconcileConfigMapCreate(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.ConfigMap))
-		if err != nil {
-			klog.Errorf("failed reconcile configmap %s/%s CREATE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
-			return reconciler.Result{Requeue: true}, nil
-		}
-	case reconciler.UpdateEvent:
-		err := c.reconcileConfigMapUpdate(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.ConfigMap))
-		if err != nil {
-			klog.Errorf("failed reconcile configmap %s/%s UPDATE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
-			return reconciler.Result{Requeue: true}, err
-		}
-	case reconciler.DeleteEvent:
-		err := c.reconcileConfigMapRemove(request.Cluster.Name, request.Namespace, request.Name)
-		if err != nil {
-			klog.Errorf("failed reconcile configmap %s/%s DELETE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
-			return reconciler.Result{Requeue: true}, err
-		}
-	}
-	return reconciler.Result{}, nil
-}
-
-func (c *controller) reconcileConfigMapCreate(cluster, namespace, name string, configMap *v1.ConfigMap) error {
-	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
-	_, err := c.configMapLister.ConfigMaps(targetNamespace).Get(name)
-	if err == nil {
-		return c.reconcileConfigMapUpdate(cluster, namespace, name, configMap)
-	}
-
-	newObj, err := conversion.BuildMetadata(cluster, targetNamespace, configMap)
-	if err != nil {
-		return err
-	}
-
-	_, err = c.configMapClient.ConfigMaps(targetNamespace).Create(newObj.(*v1.ConfigMap))
-	if errors.IsAlreadyExists(err) {
-		klog.Infof("configmap %s/%s of cluster %s already exist in super master", namespace, name, cluster)
-		return nil
-	}
-	return err
-}
-
-func (c *controller) reconcileConfigMapUpdate(cluster, namespace, name string, vConfigMap *v1.ConfigMap) error {
-	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
-	pConfigMap, err := c.configMapLister.ConfigMaps(targetNamespace).Get(name)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-
-	updatedConfigMap := conversion.CheckConfigMapEquality(pConfigMap, vConfigMap)
-	if updatedConfigMap != nil {
-		pConfigMap, err = c.configMapClient.ConfigMaps(targetNamespace).Update(updatedConfigMap)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (c *controller) reconcileConfigMapRemove(cluster, namespace, name string) error {
-	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
-	opts := &metav1.DeleteOptions{
-		PropagationPolicy: &constants.DefaultDeletionPolicy,
-	}
-	err := c.configMapClient.ConfigMaps(targetNamespace).Delete(name, opts)
-	if errors.IsNotFound(err) {
-		klog.Warningf("configmap %s/%s of cluster %s not found in super master", namespace, name, cluster)
-		return nil
-	}
-	return err
 }
 
 func (c *controller) AddCluster(cluster mc.ClusterInterface) {

--- a/incubator/virtualcluster/pkg/syncer/resources/configmap/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/configmap/controller.go
@@ -21,6 +21,7 @@ import (
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	listersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
@@ -32,6 +33,7 @@ type controller struct {
 	configMapClient v1core.ConfigMapsGetter
 	// super master configMap informer lister/synced function
 	configMapLister listersv1.ConfigMapLister
+	configMapSynced cache.InformerSynced
 	// Connect to all tenant master configMap informers
 	multiClusterConfigMapController *mc.MultiClusterController
 }
@@ -54,6 +56,7 @@ func Register(
 	}
 	c.multiClusterConfigMapController = multiClusterConfigMapController
 	c.configMapLister = configMapInformer.Lister()
+	c.configMapSynced = configMapInformer.Informer().HasSynced
 
 	controllerManager.AddController(c)
 }

--- a/incubator/virtualcluster/pkg/syncer/resources/configmap/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/configmap/dws.go
@@ -17,9 +17,12 @@ limitations under the License.
 package configmap
 
 import (
+	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
@@ -28,6 +31,9 @@ import (
 )
 
 func (c *controller) StartDWS(stopCh <-chan struct{}) error {
+	if !cache.WaitForCacheSync(stopCh, c.configMapSynced) {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
 	return c.multiClusterConfigMapController.Start(stopCh)
 }
 

--- a/incubator/virtualcluster/pkg/syncer/resources/configmap/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/configmap/dws.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configmap
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
+)
+
+func (c *controller) StartDWS(stopCh <-chan struct{}) error {
+	return c.multiClusterConfigMapController.Start(stopCh)
+}
+
+// The reconcile logic for tenant master configMap informer
+func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
+	klog.Infof("reconcile configmap %s/%s %s event for cluster %s", request.Namespace, request.Name, request.Event, request.Cluster.Name)
+
+	switch request.Event {
+	case reconciler.AddEvent:
+		err := c.reconcileConfigMapCreate(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.ConfigMap))
+		if err != nil {
+			klog.Errorf("failed reconcile configmap %s/%s CREATE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
+			return reconciler.Result{Requeue: true}, nil
+		}
+	case reconciler.UpdateEvent:
+		err := c.reconcileConfigMapUpdate(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.ConfigMap))
+		if err != nil {
+			klog.Errorf("failed reconcile configmap %s/%s UPDATE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
+			return reconciler.Result{Requeue: true}, err
+		}
+	case reconciler.DeleteEvent:
+		err := c.reconcileConfigMapRemove(request.Cluster.Name, request.Namespace, request.Name)
+		if err != nil {
+			klog.Errorf("failed reconcile configmap %s/%s DELETE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
+			return reconciler.Result{Requeue: true}, err
+		}
+	}
+	return reconciler.Result{}, nil
+}
+
+func (c *controller) reconcileConfigMapCreate(cluster, namespace, name string, configMap *v1.ConfigMap) error {
+	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
+	_, err := c.configMapLister.ConfigMaps(targetNamespace).Get(name)
+	if err == nil {
+		return c.reconcileConfigMapUpdate(cluster, namespace, name, configMap)
+	}
+
+	newObj, err := conversion.BuildMetadata(cluster, targetNamespace, configMap)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.configMapClient.ConfigMaps(targetNamespace).Create(newObj.(*v1.ConfigMap))
+	if errors.IsAlreadyExists(err) {
+		klog.Infof("configmap %s/%s of cluster %s already exist in super master", namespace, name, cluster)
+		return nil
+	}
+	return err
+}
+
+func (c *controller) reconcileConfigMapUpdate(cluster, namespace, name string, vConfigMap *v1.ConfigMap) error {
+	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
+	pConfigMap, err := c.configMapLister.ConfigMaps(targetNamespace).Get(name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	updatedConfigMap := conversion.CheckConfigMapEquality(pConfigMap, vConfigMap)
+	if updatedConfigMap != nil {
+		pConfigMap, err = c.configMapClient.ConfigMaps(targetNamespace).Update(updatedConfigMap)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *controller) reconcileConfigMapRemove(cluster, namespace, name string) error {
+	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
+	opts := &metav1.DeleteOptions{
+		PropagationPolicy: &constants.DefaultDeletionPolicy,
+	}
+	err := c.configMapClient.ConfigMaps(targetNamespace).Delete(name, opts)
+	if errors.IsNotFound(err) {
+		klog.Warningf("configmap %s/%s of cluster %s not found in super master", namespace, name, cluster)
+		return nil
+	}
+	return err
+}

--- a/incubator/virtualcluster/pkg/syncer/resources/endpoints/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/endpoints/controller.go
@@ -17,30 +17,23 @@ limitations under the License.
 package endpoints
 
 import (
-	"fmt"
-
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	listersv1 "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
 )
 
 type controller struct {
-	endpointClient                  v1core.EndpointsGetter
-	multiClusterEndpointsController *mc.MultiClusterController
-
+	// super master endpoints client
+	endpointClient v1core.EndpointsGetter
+	// super master endpoints informer lister/synced function
 	endpointsLister listersv1.EndpointsLister
-	endpointsSynced cache.InformerSynced
+	// Connect to all tenant master endpoints informers
+	multiClusterEndpointsController *mc.MultiClusterController
 }
 
 func Register(
@@ -59,108 +52,16 @@ func Register(
 		return
 	}
 	c.multiClusterEndpointsController = multiClusterEndpointsController
-
 	c.endpointsLister = endpointsInformer.Lister()
-	c.endpointsSynced = endpointsInformer.Informer().HasSynced
 
 	controllerManager.AddController(c)
 }
 
 func (c *controller) StartUWS(stopCh <-chan struct{}) error {
-	if !cache.WaitForCacheSync(stopCh, c.endpointsSynced) {
-		return fmt.Errorf("failed to wait for caches to sync")
-	}
-
 	return nil
-}
-
-func (c *controller) StartDWS(stopCh <-chan struct{}) error {
-	return c.multiClusterEndpointsController.Start(stopCh)
 }
 
 func (c *controller) StartPeriodChecker(stopCh <-chan struct{}) {
-}
-
-func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
-	klog.Infof("reconcile endpoints %s/%s %s event for cluster %s", request.Namespace, request.Name, request.Event, request.Cluster.Name)
-
-	switch request.Event {
-	case reconciler.AddEvent:
-		err := c.reconcileEndpointsCreate(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.Endpoints))
-		if err != nil {
-			klog.Errorf("failed reconcile endpoints %s/%s CREATE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
-			return reconciler.Result{Requeue: true}, err
-		}
-	case reconciler.UpdateEvent:
-		err := c.reconcileEndpointsUpdate(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.Endpoints))
-		if err != nil {
-			klog.Errorf("failed reconcile endpoints %s/%s CREATE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
-			return reconciler.Result{Requeue: true}, err
-		}
-	case reconciler.DeleteEvent:
-		err := c.reconcileEndpointsRemove(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.Endpoints))
-		if err != nil {
-			klog.Errorf("failed reconcile endpoints %s/%s DELETE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
-			return reconciler.Result{Requeue: true}, err
-		}
-	}
-	return reconciler.Result{}, nil
-}
-
-func (c *controller) reconcileEndpointsCreate(cluster, namespace, name string, ep *v1.Endpoints) error {
-	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
-	_, err := c.endpointsLister.Endpoints(targetNamespace).Get(name)
-	if err == nil {
-		return c.reconcileEndpointsUpdate(cluster, namespace, name, ep)
-	}
-
-	newObj, err := conversion.BuildMetadata(cluster, targetNamespace, ep)
-	if err != nil {
-		return err
-	}
-
-	pEndpoints := newObj.(*v1.Endpoints)
-
-	_, err = c.endpointClient.Endpoints(targetNamespace).Create(pEndpoints)
-	if errors.IsAlreadyExists(err) {
-		klog.Infof("endpoints %s/%s of cluster %s already exist in super master", namespace, name, cluster)
-		return nil
-	}
-	return err
-}
-
-func (c *controller) reconcileEndpointsUpdate(cluster, namespace, name string, vEP *v1.Endpoints) error {
-	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
-	pEP, err := c.endpointsLister.Endpoints(targetNamespace).Get(name)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-
-	updatedEndpoints := conversion.CheckEndpointsEquality(pEP, vEP)
-	if updatedEndpoints != nil {
-		pEP, err = c.endpointClient.Endpoints(targetNamespace).Update(updatedEndpoints)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (c *controller) reconcileEndpointsRemove(cluster, namespace, name string, ep *v1.Endpoints) error {
-	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
-	opts := &metav1.DeleteOptions{
-		PropagationPolicy: &constants.DefaultDeletionPolicy,
-	}
-	err := c.endpointClient.Endpoints(targetNamespace).Delete(name, opts)
-	if errors.IsNotFound(err) {
-		klog.Warningf("endpoints %s/%s of cluster not found in super master", namespace, name)
-		return nil
-	}
-	return err
 }
 
 func (c *controller) AddCluster(cluster mc.ClusterInterface) {

--- a/incubator/virtualcluster/pkg/syncer/resources/endpoints/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/endpoints/controller.go
@@ -21,6 +21,7 @@ import (
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	listersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
@@ -32,6 +33,7 @@ type controller struct {
 	endpointClient v1core.EndpointsGetter
 	// super master endpoints informer lister/synced function
 	endpointsLister listersv1.EndpointsLister
+	endpointsSynced cache.InformerSynced
 	// Connect to all tenant master endpoints informers
 	multiClusterEndpointsController *mc.MultiClusterController
 }
@@ -53,6 +55,7 @@ func Register(
 	}
 	c.multiClusterEndpointsController = multiClusterEndpointsController
 	c.endpointsLister = endpointsInformer.Lister()
+	c.endpointsSynced = endpointsInformer.Informer().HasSynced
 
 	controllerManager.AddController(c)
 }

--- a/incubator/virtualcluster/pkg/syncer/resources/endpoints/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/endpoints/dws.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoints
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
+)
+
+func (c *controller) StartDWS(stopCh <-chan struct{}) error {
+	return c.multiClusterEndpointsController.Start(stopCh)
+}
+
+// The reconcile logic for tenant master endpoints informer
+func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
+	klog.Infof("reconcile endpoints %s/%s %s event for cluster %s", request.Namespace, request.Name, request.Event, request.Cluster.Name)
+
+	switch request.Event {
+	case reconciler.AddEvent:
+		err := c.reconcileEndpointsCreate(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.Endpoints))
+		if err != nil {
+			klog.Errorf("failed reconcile endpoints %s/%s CREATE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
+			return reconciler.Result{Requeue: true}, err
+		}
+	case reconciler.UpdateEvent:
+		err := c.reconcileEndpointsUpdate(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.Endpoints))
+		if err != nil {
+			klog.Errorf("failed reconcile endpoints %s/%s CREATE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
+			return reconciler.Result{Requeue: true}, err
+		}
+	case reconciler.DeleteEvent:
+		err := c.reconcileEndpointsRemove(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.Endpoints))
+		if err != nil {
+			klog.Errorf("failed reconcile endpoints %s/%s DELETE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
+			return reconciler.Result{Requeue: true}, err
+		}
+	}
+	return reconciler.Result{}, nil
+}
+
+func (c *controller) reconcileEndpointsCreate(cluster, namespace, name string, ep *v1.Endpoints) error {
+	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
+	_, err := c.endpointsLister.Endpoints(targetNamespace).Get(name)
+	if err == nil {
+		return c.reconcileEndpointsUpdate(cluster, namespace, name, ep)
+	}
+
+	newObj, err := conversion.BuildMetadata(cluster, targetNamespace, ep)
+	if err != nil {
+		return err
+	}
+
+	pEndpoints := newObj.(*v1.Endpoints)
+
+	_, err = c.endpointClient.Endpoints(targetNamespace).Create(pEndpoints)
+	if errors.IsAlreadyExists(err) {
+		klog.Infof("endpoints %s/%s of cluster %s already exist in super master", namespace, name, cluster)
+		return nil
+	}
+	return err
+}
+
+func (c *controller) reconcileEndpointsUpdate(cluster, namespace, name string, vEP *v1.Endpoints) error {
+	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
+	pEP, err := c.endpointsLister.Endpoints(targetNamespace).Get(name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	updatedEndpoints := conversion.CheckEndpointsEquality(pEP, vEP)
+	if updatedEndpoints != nil {
+		pEP, err = c.endpointClient.Endpoints(targetNamespace).Update(updatedEndpoints)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *controller) reconcileEndpointsRemove(cluster, namespace, name string, ep *v1.Endpoints) error {
+	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
+	opts := &metav1.DeleteOptions{
+		PropagationPolicy: &constants.DefaultDeletionPolicy,
+	}
+	err := c.endpointClient.Endpoints(targetNamespace).Delete(name, opts)
+	if errors.IsNotFound(err) {
+		klog.Warningf("endpoints %s/%s of cluster not found in super master", namespace, name)
+		return nil
+	}
+	return err
+}

--- a/incubator/virtualcluster/pkg/syncer/resources/endpoints/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/endpoints/dws.go
@@ -17,9 +17,12 @@ limitations under the License.
 package endpoints
 
 import (
+	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
@@ -28,6 +31,9 @@ import (
 )
 
 func (c *controller) StartDWS(stopCh <-chan struct{}) error {
+	if !cache.WaitForCacheSync(stopCh, c.endpointsSynced) {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
 	return c.multiClusterEndpointsController.Start(stopCh)
 }
 

--- a/incubator/virtualcluster/pkg/syncer/resources/event/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/event/controller.go
@@ -35,16 +35,21 @@ import (
 )
 
 type controller struct {
-	client                      v1core.EventsGetter
-	multiClusterEventController *mc.MultiClusterController
-	informer                    coreinformers.Interface
-
-	workers     int
+	// super master event client (not used for now)
+	client v1core.EventsGetter
+	// super master event informer/lister/synced functions
+	informer    coreinformers.Interface
 	eventLister listersv1.EventLister
 	eventSynced cache.InformerSynced
 	nsLister    listersv1.NamespaceLister
 	nsSynced    cache.InformerSynced
-	queue       workqueue.RateLimitingInterface
+
+	// Connect to all tenant master event informers
+	multiClusterEventController *mc.MultiClusterController
+
+	// UWS queue
+	workers int
+	queue   workqueue.RateLimitingInterface
 }
 
 func Register(

--- a/incubator/virtualcluster/pkg/syncer/resources/namespace/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/namespace/controller.go
@@ -21,6 +21,7 @@ import (
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	listersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
@@ -32,6 +33,7 @@ type controller struct {
 	namespaceClient v1core.NamespacesGetter
 	// super master namespace lister
 	nsLister listersv1.NamespaceLister
+	nsSynced cache.InformerSynced
 	// Connect to all tenant master namespace informers
 	multiClusterNamespaceController *mc.MultiClusterController
 }
@@ -54,6 +56,7 @@ func Register(
 	}
 	c.multiClusterNamespaceController = multiClusterNamespaceController
 	c.nsLister = namespaceInformer.Lister()
+	c.nsSynced = namespaceInformer.Informer().HasSynced
 
 	controllerManager.AddController(c)
 }

--- a/incubator/virtualcluster/pkg/syncer/resources/namespace/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/namespace/controller.go
@@ -17,31 +17,23 @@ limitations under the License.
 package namespace
 
 import (
-	"fmt"
-	"strings"
-
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	listersv1 "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
 )
 
 type controller struct {
-	namespaceClient                 v1core.NamespacesGetter
-	multiClusterNamespaceController *mc.MultiClusterController
-
+	// super master namespace client
+	namespaceClient v1core.NamespacesGetter
+	// super master namespace lister
 	nsLister listersv1.NamespaceLister
-	nsSynced cache.InformerSynced
+	// Connect to all tenant master namespace informers
+	multiClusterNamespaceController *mc.MultiClusterController
 }
 
 func Register(
@@ -61,90 +53,16 @@ func Register(
 		return
 	}
 	c.multiClusterNamespaceController = multiClusterNamespaceController
-
 	c.nsLister = namespaceInformer.Lister()
-	c.nsSynced = namespaceInformer.Informer().HasSynced
 
 	controllerManager.AddController(c)
 }
 
 func (c *controller) StartUWS(stopCh <-chan struct{}) error {
-	if !cache.WaitForCacheSync(stopCh, c.nsSynced) {
-		return fmt.Errorf("failed to wait for caches to sync")
-	}
-
 	return nil
-}
-
-func (c *controller) StartDWS(stopCh <-chan struct{}) error {
-	return c.multiClusterNamespaceController.Start(stopCh)
 }
 
 func (c *controller) StartPeriodChecker(stopCh <-chan struct{}) {
-}
-
-func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
-	klog.Infof("reconcile namespace %s %s event for cluster %s", request.Name, request.Event, request.Cluster.Name)
-
-	switch request.Event {
-	case reconciler.AddEvent:
-		err := c.reconcileNamespaceCreate(request.Cluster.Name, request.Name, request.Obj.(*v1.Namespace))
-		if err != nil {
-			klog.Errorf("failed reconcile namespace %s CREATE of cluster %s %v", request.Name, request.Cluster.Name, err)
-			return reconciler.Result{Requeue: true}, nil
-		}
-	case reconciler.UpdateEvent:
-		err := c.reconcileNamespaceUpdate(request.Cluster.Name, request.Name, request.Obj.(*v1.Namespace))
-		if err != nil {
-			klog.Errorf("failed reconcile namespace %s UPDATE of cluster %s %v", request.Name, request.Cluster.Name, err)
-			return reconciler.Result{}, err
-		}
-	case reconciler.DeleteEvent:
-		err := c.reconcileNamespaceRemove(request.Cluster.Name, request.Name)
-		if err != nil {
-			klog.Errorf("failed reconcile namespace %s DELETE of cluster %s %v", request.Name, request.Cluster.Name, err)
-			return reconciler.Result{}, err
-		}
-	}
-	return reconciler.Result{}, nil
-}
-
-func (c *controller) reconcileNamespaceCreate(cluster, name string, namespace *v1.Namespace) error {
-	targetNamespace := conversion.ToSuperMasterNamespace(cluster, name)
-	_, err := c.nsLister.Get(targetNamespace)
-	if err == nil {
-		// namespace is ready.
-		return nil
-	}
-
-	newObj, err := conversion.BuildSuperMasterNamespace(cluster, namespace)
-	if err != nil {
-		return err
-	}
-
-	_, err = c.namespaceClient.Namespaces().Create(newObj.(*v1.Namespace))
-	if errors.IsAlreadyExists(err) {
-		klog.Infof("namespace %s of cluster %s already exist in super master", name, cluster)
-		return nil
-	}
-	return err
-}
-
-func (c *controller) reconcileNamespaceUpdate(cluster, name string, namespace *v1.Namespace) error {
-	return nil
-}
-
-func (c *controller) reconcileNamespaceRemove(cluster, name string) error {
-	targetName := strings.Join([]string{cluster, name}, "-")
-	opts := &metav1.DeleteOptions{
-		PropagationPolicy: &constants.DefaultDeletionPolicy,
-	}
-	err := c.namespaceClient.Namespaces().Delete(targetName, opts)
-	if errors.IsNotFound(err) {
-		klog.Warningf("namespace %s of cluster %s not found in super master", name, cluster)
-		return nil
-	}
-	return err
 }
 
 func (c *controller) AddCluster(cluster mc.ClusterInterface) {

--- a/incubator/virtualcluster/pkg/syncer/resources/namespace/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/namespace/dws.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
+)
+
+func (c *controller) StartDWS(stopCh <-chan struct{}) error {
+	return c.multiClusterNamespaceController.Start(stopCh)
+}
+
+// The reconcile logic for tenant master namespace informer
+func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
+	klog.Infof("reconcile namespace %s %s event for cluster %s", request.Name, request.Event, request.Cluster.Name)
+
+	switch request.Event {
+	case reconciler.AddEvent:
+		err := c.reconcileNamespaceCreate(request.Cluster.Name, request.Name, request.Obj.(*v1.Namespace))
+		if err != nil {
+			klog.Errorf("failed reconcile namespace %s CREATE of cluster %s %v", request.Name, request.Cluster.Name, err)
+			return reconciler.Result{Requeue: true}, nil
+		}
+	case reconciler.UpdateEvent:
+		err := c.reconcileNamespaceUpdate(request.Cluster.Name, request.Name, request.Obj.(*v1.Namespace))
+		if err != nil {
+			klog.Errorf("failed reconcile namespace %s UPDATE of cluster %s %v", request.Name, request.Cluster.Name, err)
+			return reconciler.Result{}, err
+		}
+	case reconciler.DeleteEvent:
+		err := c.reconcileNamespaceRemove(request.Cluster.Name, request.Name)
+		if err != nil {
+			klog.Errorf("failed reconcile namespace %s DELETE of cluster %s %v", request.Name, request.Cluster.Name, err)
+			return reconciler.Result{}, err
+		}
+	}
+	return reconciler.Result{}, nil
+}
+
+func (c *controller) reconcileNamespaceCreate(cluster, name string, namespace *v1.Namespace) error {
+	targetNamespace := conversion.ToSuperMasterNamespace(cluster, name)
+	_, err := c.nsLister.Get(targetNamespace)
+	if err == nil {
+		// namespace is ready.
+		return nil
+	}
+
+	newObj, err := conversion.BuildSuperMasterNamespace(cluster, namespace)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.namespaceClient.Namespaces().Create(newObj.(*v1.Namespace))
+	if errors.IsAlreadyExists(err) {
+		klog.Infof("namespace %s of cluster %s already exist in super master", name, cluster)
+		return nil
+	}
+	return err
+}
+
+func (c *controller) reconcileNamespaceUpdate(cluster, name string, namespace *v1.Namespace) error {
+	return nil
+}
+
+func (c *controller) reconcileNamespaceRemove(cluster, name string) error {
+	targetName := strings.Join([]string{cluster, name}, "-")
+	opts := &metav1.DeleteOptions{
+		PropagationPolicy: &constants.DefaultDeletionPolicy,
+	}
+	err := c.namespaceClient.Namespaces().Delete(targetName, opts)
+	if errors.IsNotFound(err) {
+		klog.Warningf("namespace %s of cluster %s not found in super master", name, cluster)
+		return nil
+	}
+	return err
+}

--- a/incubator/virtualcluster/pkg/syncer/resources/namespace/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/namespace/dws.go
@@ -17,11 +17,13 @@ limitations under the License.
 package namespace
 
 import (
+	"fmt"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
@@ -30,6 +32,9 @@ import (
 )
 
 func (c *controller) StartDWS(stopCh <-chan struct{}) error {
+	if !cache.WaitForCacheSync(stopCh, c.nsSynced) {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
 	return c.multiClusterNamespaceController.Start(stopCh)
 }
 


### PR DESCRIPTION
This change mainly does the followings:

1) Move downward syncer logic to a separate dws.go for better code structure.
2) Move WaitForCacheSync to the right sync thread.
3) Add more comments.

This change touches configmap/events/namespace/event resources. There are no functional change.