### PR TITLE
Allow user to choose different underlying platforms to provision tenant master

### DIFF
--- a/incubator/virtualcluster/cmd/manager/main.go
+++ b/incubator/virtualcluster/cmd/manager/main.go
@@ -31,8 +31,12 @@ import (
 )
 
 func main() {
-	var metricsAddr string
+	var (
+		metricsAddr       string
+		masterProvisioner string
+	)
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&masterProvisioner, "master-prov", "native", "The underlying platform that will provision master for virtualcluster.")
 	flag.Parse()
 	logf.SetLogger(logf.ZapLogger(false))
 	log := logf.Log.WithName("entrypoint")
@@ -64,7 +68,7 @@ func main() {
 
 	// Setup all Controllers
 	log.Info("Setting up controller")
-	if err := controller.AddToManager(mgr); err != nil {
+	if err := controller.AddToManager(mgr, masterProvisioner); err != nil {
 		log.Error(err, "unable to register controllers to the manager")
 		os.Exit(1)
 	}

--- a/incubator/virtualcluster/pkg/controller/clusterversion/clusterversion_controller.go
+++ b/incubator/virtualcluster/pkg/controller/clusterversion/clusterversion_controller.go
@@ -38,7 +38,7 @@ var log = logf.Log.WithName("clusterversion-controller")
 // Add creates a new ClusterVersion Controller and adds it to the Manager with
 // default RBAC. The Manager will set fields on the Controller and Start it
 // when the Manager is Started.
-func Add(mgr manager.Manager) error {
+func Add(mgr manager.Manager, _ string) error {
 	return add(mgr, newReconciler(mgr))
 }
 

--- a/incubator/virtualcluster/pkg/controller/controller.go
+++ b/incubator/virtualcluster/pkg/controller/controller.go
@@ -21,12 +21,12 @@ import (
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-var AddToManagerFuncs []func(manager.Manager) error
+var AddToManagerFuncs []func(manager.Manager, string) error
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(m manager.Manager) error {
+func AddToManager(m manager.Manager, masterProvisioner string) error {
 	for _, f := range AddToManagerFuncs {
-		if err := f(m); err != nil {
+		if err := f(m, masterProvisioner); err != nil {
 			return err
 		}
 	}

--- a/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner.go
+++ b/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner.go
@@ -1,0 +1,10 @@
+package virtualcluster
+
+import (
+	tenancyv1alpha1 "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+)
+
+type MasterProvisioner interface {
+	CreateVirtualCluster(vc *tenancyv1alpha1.Virtualcluster) error
+	DeleteVirtualCluster(vc *tenancyv1alpha1.Virtualcluster) error
+}

--- a/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_aliyun.go
+++ b/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_aliyun.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package virtualcluster
+
+import (
+	"errors"
+
+	tenancyv1alpha1 "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+type MasterProvisionerAliyun struct {
+	client.Client
+	scheme *runtime.Scheme
+}
+
+func NewMasterProvisionerAliyun(mgr manager.Manager) *MasterProvisionerAliyun {
+	return &MasterProvisionerAliyun{
+		Client: mgr.GetClient(),
+		scheme: mgr.GetScheme(),
+	}
+}
+
+func (mpa *MasterProvisionerAliyun) CreateVirtualCluster(vc *tenancyv1alpha1.Virtualcluster) error {
+	return errors.New("Not implement yet")
+}
+
+func (mpa *MasterProvisionerAliyun) DeleteVirtualCluster(vc *tenancyv1alpha1.Virtualcluster) error {
+	return errors.New("Not implement yet")
+}

--- a/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_native.go
+++ b/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_native.go
@@ -1,0 +1,354 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package virtualcluster
+
+import (
+	"context"
+	"crypto/rsa"
+	"errors"
+	"fmt"
+	"time"
+
+	tenancyv1alpha1 "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/kubeconfig"
+	vcpki "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/pki"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/secret"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/cert"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+type MasterProvisionerNative struct {
+	client.Client
+	scheme *runtime.Scheme
+}
+
+func NewMasterProvisionerNative(mgr manager.Manager) *MasterProvisionerNative {
+	return &MasterProvisionerNative{
+		Client: mgr.GetClient(),
+		scheme: mgr.GetScheme(),
+	}
+}
+
+// CreateVirtualCluster sets up the control plane for vc on meta k8s
+func (mpn *MasterProvisionerNative) CreateVirtualCluster(vc *tenancyv1alpha1.Virtualcluster) error {
+	cvs := &tenancyv1alpha1.ClusterVersionList{}
+	err := mpn.List(context.TODO(), cvs, client.InNamespace(""))
+	if err != nil {
+		return err
+	}
+
+	cv := getClusterVersion(cvs, vc.Spec.ClusterVersionName)
+	if cv == nil {
+		err = fmt.Errorf("desired ClusterVersion %s not found",
+			vc.Spec.ClusterVersionName)
+		return err
+	}
+	defer func() {
+		if err != nil {
+			log.Error(err, "fail to create virtualcluster, remove namespace for deleting related resources")
+		}
+	}()
+
+	// 1. create ns
+	err = mpn.createNS(vc)
+	if err != nil {
+		return err
+	}
+
+	// 2. create PKI
+	err = mpn.createPKI(vc, cv)
+	if err != nil {
+		return err
+	}
+
+	// 3. deploy etcd
+	err = mpn.deployComponent(vc, cv.Spec.ETCD)
+	if err != nil {
+		return err
+	}
+
+	// 4. deploy apiserver
+	err = mpn.deployComponent(vc, cv.Spec.APIServer)
+	if err != nil {
+		return err
+	}
+
+	// 5. deploy controller-manager
+	err = mpn.deployComponent(vc, cv.Spec.ControllerManager)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// genInitialClusterArgs generates the values for `--inital-cluster` option of etcd based on the number of
+// replicas specified in etcd StatefulSet
+func genInitialClusterArgs(replicas int32, stsName, svcName string) (argsVal string) {
+	for i := int32(0); i < replicas; i++ {
+		// use 2380 as the default port for etcd peer communication
+		peerAddr := fmt.Sprintf("%s-%d=https://%s-%d.%s:%d",
+			stsName, i, stsName, i, svcName, DefaultETCDPeerPort)
+		if i == replicas-1 {
+			argsVal = argsVal + peerAddr
+			break
+		}
+		argsVal = argsVal + peerAddr + ","
+	}
+
+	return argsVal
+}
+
+// completmentETCDTemplate completments the ETCD template of the specified clusterversion
+// based on the virtual cluster setting
+func completmentETCDTemplate(vcns string, etcdBdl *tenancyv1alpha1.StatefulSetSvcBundle) {
+	etcdBdl.StatefulSet.ObjectMeta.Namespace = vcns
+	etcdBdl.Service.ObjectMeta.Namespace = vcns
+	args := etcdBdl.StatefulSet.Spec.Template.Spec.Containers[0].Args
+	icaVal := genInitialClusterArgs(*etcdBdl.StatefulSet.Spec.Replicas,
+		etcdBdl.StatefulSet.Name, etcdBdl.Service.Name)
+	args = append(args, "--initial-cluster", icaVal)
+	etcdBdl.StatefulSet.Spec.Template.Spec.Containers[0].Args = args
+}
+
+// completmentAPIServerTemplate completments the apiserver template of the specified clusterversion
+// based on the virtual cluster setting
+func completmentAPIServerTemplate(vcns string, apiserverBdl *tenancyv1alpha1.StatefulSetSvcBundle) {
+	apiserverBdl.StatefulSet.ObjectMeta.Namespace = vcns
+	apiserverBdl.Service.ObjectMeta.Namespace = vcns
+}
+
+// completmentCtrlMgrTemplate completments the controller manager template of the specified clusterversion
+// based on the virtual cluster setting
+func completmentCtrlMgrTemplate(vcns string, ctrlMgrBdl *tenancyv1alpha1.StatefulSetSvcBundle) {
+	ctrlMgrBdl.StatefulSet.ObjectMeta.Namespace = vcns
+}
+
+// deployComponent deploys master component in namespace vcName based on the given StatefulSet
+// and Service Bundle ssBdl
+func (mpn *MasterProvisionerNative) deployComponent(vc *tenancyv1alpha1.Virtualcluster, ssBdl *tenancyv1alpha1.StatefulSetSvcBundle) error {
+	log.Info("deploying StatefulSet for master component", "component", ssBdl.Name)
+
+	ns := conversion.ToClusterKey(vc)
+
+	switch ssBdl.Name {
+	case "etcd":
+		completmentETCDTemplate(ns, ssBdl)
+	case "apiserver":
+		completmentAPIServerTemplate(ns, ssBdl)
+	case "controller-manager":
+		completmentCtrlMgrTemplate(ns, ssBdl)
+	default:
+		return fmt.Errorf("try to deploy unknwon component: %s", ssBdl.Name)
+	}
+
+	err := mpn.Create(context.TODO(), ssBdl.StatefulSet)
+	if err != nil {
+		return err
+	}
+
+	err = controllerutil.SetControllerReference(vc, ssBdl.StatefulSet, mpn.scheme)
+	if err != nil {
+		return err
+	}
+
+	if ssBdl.Service != nil {
+		log.Info("deploying Service for master component", "component", ssBdl.Name)
+		err = mpn.Create(context.TODO(), ssBdl.Service)
+		if err != nil {
+			return err
+		}
+		err := controllerutil.SetControllerReference(vc, ssBdl.Service, mpn.scheme)
+		if err != nil {
+			return err
+		}
+	}
+
+	// make sure the StatsfulSet is ready
+	// (i.e. Status.ReadyReplicas == Spec.Replicas)
+	timeout := time.After(DeployTimeOut)
+	for {
+		period := time.After(ComponentPollPeriod)
+		select {
+		case <-timeout:
+			return fmt.Errorf("deploy %s timeout", ssBdl.Name)
+		case <-period:
+			sts := &appsv1.StatefulSet{}
+			if err := mpn.Get(context.TODO(), types.NamespacedName{
+				Namespace: ns,
+				Name:      ssBdl.Name},
+				sts); err != nil {
+				return err
+			}
+			if sts.Status.ReadyReplicas == *sts.Spec.Replicas {
+				log.Info("component is ready", "component", ssBdl.Name)
+				return nil
+			}
+		}
+	}
+
+}
+
+// createPKISecrets creates secrets to store crt/key pairs and kubeconfigs
+// for master components of the virtual cluster
+func (mpn *MasterProvisionerNative) createPKISecrets(caGroup *vcpki.ClusterCAGroup, namespace string) error {
+	// create secret for root crt/key pair
+	rootSrt := secret.CrtKeyPairToSecret(secret.RootCASecretName, namespace, caGroup.RootCA)
+	// create secret for apiserver crt/key pair
+	apiserverSrt := secret.CrtKeyPairToSecret(secret.APIServerCASecretName,
+		namespace, caGroup.APIServer)
+	// create secret for etcd crt/key pair
+	etcdSrt := secret.CrtKeyPairToSecret(secret.ETCDCASecretName,
+		namespace, caGroup.ETCD)
+	// create secret for controller manager kubeconfig
+	ctrlMgrSrt := secret.KubeconfigToSecret(secret.ControllerManagerSecretName,
+		namespace, caGroup.CtrlMgrKbCfg)
+	// create secret for admin kubeconfig
+	adminSrt := secret.KubeconfigToSecret(secret.AdminSecretName,
+		namespace, caGroup.AdminKbCfg)
+	// create secret for service account rsa key
+	svcActSrt, err := secret.RsaKeyToSecret(secret.ServiceAccountSecretName,
+		namespace, caGroup.ServiceAccountPrivateKey)
+	if err != nil {
+		return err
+	}
+	secrets := []*v1.Secret{rootSrt, apiserverSrt, etcdSrt,
+		ctrlMgrSrt, adminSrt, svcActSrt}
+
+	// create all secrets on metacluster
+	for _, srt := range secrets {
+		log.Info("creating secret", "name",
+			srt.Name, "namespace", srt.Namespace)
+		err := mpn.Create(context.TODO(), srt)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (mpn *MasterProvisionerNative) createNS(vc *tenancyv1alpha1.Virtualcluster) error {
+	err := mpn.Create(context.TODO(), &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: conversion.ToClusterKey(vc),
+		},
+	})
+	if apierrors.IsAlreadyExists(err) {
+		return nil
+	}
+	return err
+}
+
+// createPKI constructs the PKI (all crt/key pair and kubeconfig) for the
+// virtual clusters, and store them as secrets in the meta cluster
+func (mpn *MasterProvisionerNative) createPKI(vc *tenancyv1alpha1.Virtualcluster, cv *tenancyv1alpha1.ClusterVersion) error {
+	ns := conversion.ToClusterKey(vc)
+	caGroup := &vcpki.ClusterCAGroup{}
+	// create root ca, all components will share a single root ca
+	rootCACrt, rootKey, rootCAErr := pkiutil.NewCertificateAuthority(
+		&cert.Config{
+			CommonName:   "kubernetes",
+			Organization: []string{"kubernetes-sig.kubernetes-sigs/multi-tenancy.virtualcluster"},
+		})
+	if rootCAErr != nil {
+		return rootCAErr
+	}
+
+	rootRsaKey, ok := rootKey.(*rsa.PrivateKey)
+	if !ok {
+		return errors.New("fail to assert rsa PrivateKey")
+	}
+
+	rootCAPair := &vcpki.CrtKeyPair{
+		Crt: rootCACrt,
+		Key: rootRsaKey,
+	}
+	caGroup.RootCA = rootCAPair
+
+	etcdDomains := append(cv.GetEtcdServers(), cv.GetEtcdDomain())
+	// create crt, key for etcd
+	etcdCAPair, etcdCrtErr := vcpki.NewEtcdServerCrtAndKey(rootCAPair, etcdDomains)
+	if etcdCrtErr != nil {
+		return etcdCrtErr
+	}
+	caGroup.ETCD = etcdCAPair
+
+	// create crt, key for apiserver
+	apiserverDomain := cv.GetAPIServerDomain(ns)
+	apiserverCAPair, err := vcpki.NewAPIServerCrtAndKey(rootCAPair, vc, apiserverDomain)
+	if err != nil {
+		return err
+	}
+	caGroup.APIServer = apiserverCAPair
+
+	// create kubeconfig for controller-manager
+	ctrlmgrKbCfg, err := kubeconfig.GenerateKubeconfig(
+		"system:kube-controller-manager",
+		vc.Name, apiserverDomain, []string{}, rootCAPair)
+	if err != nil {
+		return err
+	}
+	caGroup.CtrlMgrKbCfg = ctrlmgrKbCfg
+
+	// create kubeconfig for admin user
+	adminKbCfg, err := kubeconfig.GenerateKubeconfig(
+		"admin", vc.Name, apiserverDomain,
+		[]string{"system:masters"}, rootCAPair)
+	if err != nil {
+		return err
+	}
+	caGroup.AdminKbCfg = adminKbCfg
+
+	// create rsa key for service-account
+	svcAcctCAPair, err := vcpki.NewServiceAccountSigningKey()
+	if err != nil {
+		return err
+	}
+	caGroup.ServiceAccountPrivateKey = svcAcctCAPair
+
+	// store ca and kubeconfig into secrets
+	genSrtsErr := mpn.createPKISecrets(caGroup, ns)
+	if genSrtsErr != nil {
+		return genSrtsErr
+	}
+
+	return nil
+}
+
+func (mpn *MasterProvisionerNative) DeleteVirtualCluster(vc *tenancyv1alpha1.Virtualcluster) error {
+	return errors.New("Not implement yet")
+}
+
+func getClusterVersion(cvl *tenancyv1alpha1.ClusterVersionList, cvn string) *tenancyv1alpha1.ClusterVersion {
+	for _, cv := range cvl.Items {
+		if cv.Name == cvn {
+			return &cv
+		}
+	}
+	return nil
+}

--- a/incubator/virtualcluster/pkg/controller/virtualcluster/virtualcluster_controller.go
+++ b/incubator/virtualcluster/pkg/controller/virtualcluster/virtualcluster_controller.go
@@ -18,23 +18,14 @@ package virtualcluster
 
 import (
 	"context"
-	"crypto/rsa"
-	"errors"
 	"fmt"
 	"time"
 
-	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -42,10 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	tenancyv1alpha1 "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/kubeconfig"
-	vcpki "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/pki"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/secret"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
 )
 
 const (
@@ -62,15 +49,24 @@ var log = logf.Log.WithName("virtualcluster-controller")
 // Add creates a new Virtualcluster Controller and adds it to the Manager with
 // default RBAC. The Manager will set fields on the Controller and Start it
 // when the Manager is Started.
-func Add(mgr manager.Manager) error {
-	return add(mgr, newReconciler(mgr))
+func Add(mgr manager.Manager, masterProvisioner string) error {
+	return add(mgr, newReconciler(mgr, masterProvisioner))
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, masterProv string, provArgs ...interface{}) reconcile.Reconciler {
+	var mp MasterProvisioner
+	switch masterProv {
+	case "native":
+		mp = NewMasterProvisionerNative(mgr)
+	case "aliyun":
+		mp = NewMasterProvisionerAliyun(mgr)
+	}
+
 	return &ReconcileVirtualcluster{
 		Client: mgr.GetClient(),
 		scheme: mgr.GetScheme(),
+		mp:     mp,
 	}
 }
 
@@ -100,282 +96,7 @@ var _ reconcile.Reconciler = &ReconcileVirtualcluster{}
 type ReconcileVirtualcluster struct {
 	client.Client
 	scheme *runtime.Scheme
-}
-
-// createPKI constructs the PKI (all crt/key pair and kubeconfig) for the
-// virtual clusters, and store them as secrets in the meta cluster
-func (r *ReconcileVirtualcluster) createPKI(vc *tenancyv1alpha1.Virtualcluster, cv *tenancyv1alpha1.ClusterVersion) error {
-	ns := conversion.ToClusterKey(vc)
-	caGroup := &vcpki.ClusterCAGroup{}
-	// create root ca, all components will share a single root ca
-	rootCACrt, rootKey, rootCAErr := pkiutil.NewCertificateAuthority(
-		&cert.Config{
-			CommonName:   "kubernetes",
-			Organization: []string{"kubernetes-sig.kubernetes-sigs/multi-tenancy.virtualcluster"},
-		})
-	if rootCAErr != nil {
-		return rootCAErr
-	}
-
-	rootRsaKey, ok := rootKey.(*rsa.PrivateKey)
-	if !ok {
-		return errors.New("fail to assert rsa PrivateKey")
-	}
-
-	rootCAPair := &vcpki.CrtKeyPair{
-		Crt: rootCACrt,
-		Key: rootRsaKey,
-	}
-	caGroup.RootCA = rootCAPair
-
-	etcdDomains := append(cv.GetEtcdServers(), cv.GetEtcdDomain())
-	// create crt, key for etcd
-	etcdCAPair, etcdCrtErr := vcpki.NewEtcdServerCrtAndKey(rootCAPair, etcdDomains)
-	if etcdCrtErr != nil {
-		return etcdCrtErr
-	}
-	caGroup.ETCD = etcdCAPair
-
-	// create crt, key for apiserver
-	apiserverDomain := cv.GetAPIServerDomain(ns)
-	apiserverCAPair, err := vcpki.NewAPIServerCrtAndKey(rootCAPair, vc, apiserverDomain)
-	if err != nil {
-		return err
-	}
-	caGroup.APIServer = apiserverCAPair
-
-	// create kubeconfig for controller-manager
-	ctrlmgrKbCfg, err := kubeconfig.GenerateKubeconfig(
-		"system:kube-controller-manager",
-		vc.Name, apiserverDomain, []string{}, rootCAPair)
-	if err != nil {
-		return err
-	}
-	caGroup.CtrlMgrKbCfg = ctrlmgrKbCfg
-
-	// create kubeconfig for admin user
-	adminKbCfg, err := kubeconfig.GenerateKubeconfig(
-		"admin", vc.Name, apiserverDomain,
-		[]string{"system:masters"}, rootCAPair)
-	if err != nil {
-		return err
-	}
-	caGroup.AdminKbCfg = adminKbCfg
-
-	// create rsa key for service-account
-	svcAcctCAPair, err := vcpki.NewServiceAccountSigningKey()
-	if err != nil {
-		return err
-	}
-	caGroup.ServiceAccountPrivateKey = svcAcctCAPair
-
-	// store ca and kubeconfig into secrets
-	genSrtsErr := r.createPKISecrets(caGroup, ns)
-	if genSrtsErr != nil {
-		return genSrtsErr
-	}
-
-	return nil
-}
-
-// genInitialClusterArgs generates the values for `--inital-cluster` option of etcd based on the number of
-// replicas specified in etcd StatefulSet
-func genInitialClusterArgs(replicas int32, stsName, svcName string) (argsVal string) {
-	for i := int32(0); i < replicas; i++ {
-		// use 2380 as the default port for etcd peer communication
-		peerAddr := fmt.Sprintf("%s-%d=https://%s-%d.%s:%d",
-			stsName, i, stsName, i, svcName, DefaultETCDPeerPort)
-		if i == replicas-1 {
-			argsVal = argsVal + peerAddr
-			break
-		}
-		argsVal = argsVal + peerAddr + ","
-	}
-
-	return argsVal
-}
-
-// completmentETCDTemplate completments the ETCD template of the specified clusterversion
-// based on the virtual cluster setting
-func completmentETCDTemplate(vcns string, etcdBdl *tenancyv1alpha1.StatefulSetSvcBundle) {
-	etcdBdl.StatefulSet.ObjectMeta.Namespace = vcns
-	etcdBdl.Service.ObjectMeta.Namespace = vcns
-	args := etcdBdl.StatefulSet.Spec.Template.Spec.Containers[0].Args
-	icaVal := genInitialClusterArgs(*etcdBdl.StatefulSet.Spec.Replicas,
-		etcdBdl.StatefulSet.Name, etcdBdl.Service.Name)
-	args = append(args, "--initial-cluster", icaVal)
-	etcdBdl.StatefulSet.Spec.Template.Spec.Containers[0].Args = args
-}
-
-// completmentAPIServerTemplate completments the apiserver template of the specified clusterversion
-// based on the virtual cluster setting
-func completmentAPIServerTemplate(vcns string, apiserverBdl *tenancyv1alpha1.StatefulSetSvcBundle) {
-	apiserverBdl.StatefulSet.ObjectMeta.Namespace = vcns
-	apiserverBdl.Service.ObjectMeta.Namespace = vcns
-}
-
-// completmentCtrlMgrTemplate completments the controller manager template of the specified clusterversion
-// based on the virtual cluster setting
-func completmentCtrlMgrTemplate(vcns string, ctrlMgrBdl *tenancyv1alpha1.StatefulSetSvcBundle) {
-	ctrlMgrBdl.StatefulSet.ObjectMeta.Namespace = vcns
-}
-
-// deployComponent deploys master component in namespace vcName based on the given StatefulSet
-// and Service Bundle ssBdl
-func (r *ReconcileVirtualcluster) deployComponent(vc *tenancyv1alpha1.Virtualcluster, ssBdl *tenancyv1alpha1.StatefulSetSvcBundle) error {
-	log.Info("deploying StatefulSet for master component", "component", ssBdl.Name)
-
-	ns := conversion.ToClusterKey(vc)
-
-	switch ssBdl.Name {
-	case "etcd":
-		completmentETCDTemplate(ns, ssBdl)
-	case "apiserver":
-		completmentAPIServerTemplate(ns, ssBdl)
-	case "controller-manager":
-		completmentCtrlMgrTemplate(ns, ssBdl)
-	default:
-		return fmt.Errorf("try to deploy unknwon component: %s", ssBdl.Name)
-	}
-
-	err := r.Create(context.TODO(), ssBdl.StatefulSet)
-	if err != nil {
-		return err
-	}
-
-	err = controllerutil.SetControllerReference(vc, ssBdl.StatefulSet, r.scheme)
-	if err != nil {
-		return err
-	}
-
-	if ssBdl.Service != nil {
-		log.Info("deploying Service for master component", "component", ssBdl.Name)
-		err = r.Create(context.TODO(), ssBdl.Service)
-		if err != nil {
-			return err
-		}
-		err := controllerutil.SetControllerReference(vc, ssBdl.Service, r.scheme)
-		if err != nil {
-			return err
-		}
-	}
-
-	// make sure the StatsfulSet is ready
-	// (i.e. Status.ReadyReplicas == Spec.Replicas)
-	timeout := time.After(DeployTimeOut)
-	for {
-		period := time.After(ComponentPollPeriod)
-		select {
-		case <-timeout:
-			return fmt.Errorf("deploy %s timeout", ssBdl.Name)
-		case <-period:
-			sts := &appsv1.StatefulSet{}
-			if err := r.Get(context.TODO(), types.NamespacedName{
-				Namespace: ns,
-				Name:      ssBdl.Name},
-				sts); err != nil {
-				return err
-			}
-			if sts.Status.ReadyReplicas == *sts.Spec.Replicas {
-				log.Info("component is ready", "component", ssBdl.Name)
-				return nil
-			}
-		}
-	}
-
-}
-
-// createPKISecrets creates secrets to store crt/key pairs and kubeconfigs
-// for master components of the virtual cluster
-func (r *ReconcileVirtualcluster) createPKISecrets(caGroup *vcpki.ClusterCAGroup, namespace string) error {
-	// create secret for root crt/key pair
-	rootSrt := secret.CrtKeyPairToSecret(secret.RootCASecretName,
-		namespace, caGroup.RootCA)
-	// create secret for apiserver crt/key pair
-	apiserverSrt := secret.CrtKeyPairToSecret(secret.APIServerCASecretName,
-		namespace, caGroup.APIServer)
-	// create secret for etcd crt/key pair
-	etcdSrt := secret.CrtKeyPairToSecret(secret.ETCDCASecretName,
-		namespace, caGroup.ETCD)
-	// create secret for controller manager kubeconfig
-	ctrlMgrSrt := secret.KubeconfigToSecret(secret.ControllerManagerSecretName,
-		namespace, caGroup.CtrlMgrKbCfg)
-	// create secret for admin kubeconfig
-	adminSrt := secret.KubeconfigToSecret(secret.AdminSecretName,
-		namespace, caGroup.AdminKbCfg)
-	// create secret for service account rsa key
-	svcActSrt, err := secret.RsaKeyToSecret(secret.ServiceAccountSecretName,
-		namespace, caGroup.ServiceAccountPrivateKey)
-	if err != nil {
-		return err
-	}
-	secrets := []*v1.Secret{rootSrt, apiserverSrt, etcdSrt,
-		ctrlMgrSrt, adminSrt, svcActSrt}
-
-	// create all secrets on metacluster
-	for _, srt := range secrets {
-		log.Info("creating secret", "name",
-			srt.Name, "namespace", srt.Namespace)
-		err := r.Create(context.TODO(), srt)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (r *ReconcileVirtualcluster) createNS(vc *tenancyv1alpha1.Virtualcluster) error {
-	err := r.Create(context.TODO(), &v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: conversion.ToClusterKey(vc),
-		},
-	})
-	if apierrors.IsAlreadyExists(err) {
-		return nil
-	}
-	return err
-}
-
-// createVirtualcluster creates a new Virtualcluster based on the specified ClusterVersion
-func (r *ReconcileVirtualcluster) createVirtualcluster(vc *tenancyv1alpha1.Virtualcluster, cv *tenancyv1alpha1.ClusterVersion) (err error) {
-	defer func() {
-		if err != nil {
-			log.Error(err, "fail to create virtualcluster, remove namespace for deleting related resources")
-		}
-	}()
-
-	// 1. create ns
-	err = r.createNS(vc)
-	if err != nil {
-		return
-	}
-
-	// 2. create PKI
-	err = r.createPKI(vc, cv)
-	if err != nil {
-		return
-	}
-
-	// 3. deploy etcd
-	err = r.deployComponent(vc, cv.Spec.ETCD)
-	if err != nil {
-		return
-	}
-
-	// 4. deploy apiserver
-	err = r.deployComponent(vc, cv.Spec.APIServer)
-	if err != nil {
-		return
-	}
-
-	// 5. deploy controller-manager
-	err = r.deployComponent(vc, cv.Spec.ControllerManager)
-	if err != nil {
-		return
-	}
-
-	return
+	mp     MasterProvisioner
 }
 
 // Reconcile reads that state of the cluster for a Virtualcluster object and makes changes based on the state read
@@ -425,19 +146,8 @@ func (r *ReconcileVirtualcluster) Reconcile(request reconcile.Request) (rncilRsl
 	case tenancyv1alpha1.ClusterPending:
 		// create new virtualcluster when vc is pending
 		log.Info("Virtualcluster is pending", "vc", vc.Name)
-		cvs := &tenancyv1alpha1.ClusterVersionList{}
-		err = r.List(context.TODO(), cvs, client.InNamespace(""))
-		if err != nil {
-			return
-		}
 
-		cv := getClusterVersion(cvs, vc.Spec.ClusterVersionName)
-		if cv == nil {
-			err = fmt.Errorf("desired ClusterVersion %s not found",
-				vc.Spec.ClusterVersionName)
-			return
-		}
-		err = r.createVirtualcluster(vc, cv)
+		err = r.mp.CreateVirtualCluster(vc)
 		if err != nil {
 			return
 		}
@@ -460,13 +170,4 @@ func (r *ReconcileVirtualcluster) Reconcile(request reconcile.Request) (rncilRsl
 		err = fmt.Errorf("unknown vc phase: %s", vc.Status.Phase)
 		return
 	}
-}
-
-func getClusterVersion(cvl *tenancyv1alpha1.ClusterVersionList, cvn string) *tenancyv1alpha1.ClusterVersion {
-	for _, cv := range cvl.Items {
-		if cv.Name == cvn {
-			return &cv
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
1. abstract Create/Delete Virtualcluster functions, and encapsulate
them into a new interface `MasterProvisioner`
2. adapt existing minikube implementation to `MasterProvisioner` interface
3. add template of `MasterProvisionerAliyun`