### PR TITLE
[Incubator][VC]Clean up - Refactor resource controller - Part 3

### DIFF
--- a/incubator/virtualcluster/pkg/controller/virtualcluster/virtualcluster_controller_test.go
+++ b/incubator/virtualcluster/pkg/controller/virtualcluster/virtualcluster_controller_test.go
@@ -48,7 +48,7 @@ func TestReconcile(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
-	recFn, requests := SetupTestReconcile(newReconciler(mgr))
+	recFn, requests := SetupTestReconcile(newReconciler(mgr, "native"))
 	g.Expect(add(mgr, recFn)).NotTo(gomega.HaveOccurred())
 
 	stopMgr, mgrStopped := StartTestManager(mgr, g)

--- a/incubator/virtualcluster/pkg/syncer/resources/secret/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/secret/dws.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secret
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/utils"
+)
+
+func (c *controller) StartDWS(stopCh <-chan struct{}) error {
+	if !cache.WaitForCacheSync(stopCh, c.secretSynced) {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+	return c.multiClusterSecretController.Start(stopCh)
+}
+
+// The reconcile logic for tenant master secret informer
+func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
+	klog.Infof("reconcile secret %s/%s %s event for cluster %s", request.Namespace, request.Name, request.Event, request.Cluster.Name)
+
+	switch request.Event {
+	case reconciler.AddEvent:
+		err := c.reconcileSecretCreate(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.Secret))
+		if err != nil {
+			klog.Errorf("failed reconcile secret %s/%s CREATE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
+			return reconciler.Result{Requeue: true}, err
+		}
+	case reconciler.UpdateEvent:
+		err := c.reconcileSecretUpdate(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.Secret))
+		if err != nil {
+			klog.Errorf("failed reconcile secret %s/%s CREATE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
+			return reconciler.Result{Requeue: true}, err
+		}
+	case reconciler.DeleteEvent:
+		err := c.reconcileSecretRemove(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.Secret))
+		if err != nil {
+			klog.Errorf("failed reconcile secret %s/%s DELETE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
+			return reconciler.Result{Requeue: true}, err
+		}
+	}
+	return reconciler.Result{}, nil
+}
+
+func (c *controller) reconcileSecretCreate(cluster, namespace, name string, secret *v1.Secret) error {
+	switch secret.Type {
+	case v1.SecretTypeServiceAccountToken:
+		return c.reconcileServiceAccountSecretUpdate(cluster, namespace, name, secret)
+	default:
+		return c.reconcileNormalSecretCreate(cluster, namespace, name, secret)
+	}
+}
+
+func (c *controller) reconcileServiceAccountSecretUpdate(cluster, namespace, name string, secret *v1.Secret) error {
+	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
+
+	saName := secret.Annotations[v1.ServiceAccountNameKey]
+
+	pSecret, err := utils.GetSecret(c.secretClient, targetNamespace, saName)
+	if err != nil {
+		return err
+	}
+
+	needUpdate := false
+
+	if pSecret.Labels[constants.SyncStatusKey] != constants.SyncStatusReady {
+		needUpdate = true
+		if len(pSecret.Labels) == 0 {
+			pSecret.Labels = make(map[string]string)
+		}
+		pSecret.Labels[constants.SyncStatusKey] = constants.SyncStatusReady
+	}
+
+	if !equality.Semantic.DeepEqual(secret.Data, pSecret.Data) {
+		needUpdate = true
+		pSecret.Data = secret.Data
+	}
+
+	if !needUpdate {
+		return nil
+	}
+
+	_, err = c.secretClient.Secrets(targetNamespace).Update(pSecret)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *controller) reconcileNormalSecretCreate(cluster, namespace, name string, secret *v1.Secret) error {
+	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
+	_, err := c.secretLister.Secrets(targetNamespace).Get(name)
+	if err == nil {
+		return c.reconcileNormalSecretUpdate(cluster, namespace, name, secret)
+	}
+
+	newObj, err := conversion.BuildMetadata(cluster, targetNamespace, secret)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.secretClient.Secrets(targetNamespace).Create(newObj.(*v1.Secret))
+	if errors.IsAlreadyExists(err) {
+		klog.Infof("secret %s/%s of cluster %s already exist in super master", namespace, name, cluster)
+		return nil
+	}
+
+	return err
+}
+
+func (c *controller) reconcileSecretUpdate(cluster, namespace, name string, secret *v1.Secret) error {
+	switch secret.Type {
+	case v1.SecretTypeServiceAccountToken:
+		return c.reconcileServiceAccountSecretUpdate(cluster, namespace, name, secret)
+	default:
+		return c.reconcileNormalSecretUpdate(cluster, namespace, name, secret)
+	}
+}
+
+func (c *controller) reconcileNormalSecretUpdate(cluster, namespace, name string, vSecret *v1.Secret) error {
+	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
+	pSecret, err := c.secretLister.Secrets(targetNamespace).Get(name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	updatedSecret := conversion.CheckSecretEquality(pSecret, vSecret)
+	if updatedSecret != nil {
+		pSecret, err = c.secretClient.Secrets(targetNamespace).Update(updatedSecret)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *controller) reconcileSecretRemove(cluster, namespace, name string, secret *v1.Secret) error {
+	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
+	opts := &metav1.DeleteOptions{
+		PropagationPolicy: &constants.DefaultDeletionPolicy,
+	}
+	err := c.secretClient.Secrets(targetNamespace).Delete(name, opts)
+	if errors.IsNotFound(err) {
+		klog.Warningf("secret %s/%s of cluster is not found in super master", namespace, name)
+		return nil
+	}
+	return err
+}

--- a/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/controller.go
@@ -18,22 +18,23 @@ package serviceaccount
 
 import (
 	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	listersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
 )
 
 type controller struct {
-	client                               v1core.CoreV1Interface
-	saInformer                           coreinformers.ServiceAccountInformer
+	// super master sa client
+	saClient v1core.CoreV1Interface
+	// super master sa lister/synced function
+	saLister listersv1.ServiceAccountLister
+	saSynced cache.InformerSynced
+	// Connect to all tenant master sa informers
 	multiClusterServiceAccountController *mc.MultiClusterController
 }
 
@@ -43,7 +44,7 @@ func Register(
 	controllerManager *manager.ControllerManager,
 ) {
 	c := &controller{
-		client: client,
+		saClient: client,
 	}
 
 	// Create the multi cluster secret controller
@@ -54,6 +55,8 @@ func Register(
 		return
 	}
 	c.multiClusterServiceAccountController = multiClusterSecretController
+	c.saLister = saInformer.Lister()
+	c.saSynced = saInformer.Informer().HasSynced
 
 	controllerManager.AddController(c)
 }
@@ -62,90 +65,7 @@ func (c *controller) StartUWS(stopCh <-chan struct{}) error {
 	return nil
 }
 
-func (c *controller) StartDWS(stopCh <-chan struct{}) error {
-	return c.multiClusterServiceAccountController.Start(stopCh)
-}
-
 func (c *controller) StartPeriodChecker(stopCh <-chan struct{}) {
-}
-
-func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
-	klog.Infof("reconcile service account %s/%s %s event for cluster %s", request.Namespace, request.Name, request.Event, request.Cluster.Name)
-
-	switch request.Event {
-	case reconciler.AddEvent:
-		err := c.reconcileServiceAccountCreate(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.ServiceAccount))
-		if err != nil {
-			klog.Errorf("failed reconcile service account %s/%s CREATE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
-			return reconciler.Result{Requeue: true}, err
-		}
-	case reconciler.UpdateEvent:
-		err := c.reconcileServiceAccountUpdate(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.ServiceAccount))
-		if err != nil {
-			klog.Errorf("failed reconcile service account %s/%s CREATE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
-			return reconciler.Result{Requeue: true}, err
-		}
-	case reconciler.DeleteEvent:
-		err := c.reconcileServiceAccountRemove(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.ServiceAccount))
-		if err != nil {
-			klog.Errorf("failed reconcile service account %s/%s DELETE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
-			return reconciler.Result{Requeue: true}, err
-		}
-	}
-	return reconciler.Result{}, nil
-}
-
-func (c *controller) reconcileServiceAccountCreate(cluster, namespace, name string, secret *v1.ServiceAccount) error {
-	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
-	// just mark the default service account as a tenant related resource.
-	// service account controller will create it for us.
-	if name == "default" {
-		sa, err := c.client.ServiceAccounts(targetNamespace).Get("default", metav1.GetOptions{})
-		if err != nil {
-			// maybe the sa is not created, retry
-			return err
-		}
-
-		if len(sa.Annotations) == 0 {
-			sa.Annotations = make(map[string]string)
-		}
-		sa.Annotations[constants.LabelCluster] = cluster
-		_, err = c.client.ServiceAccounts(targetNamespace).Update(sa)
-		return err
-	}
-	newObj, err := conversion.BuildMetadata(cluster, targetNamespace, secret)
-	if err != nil {
-		return err
-	}
-
-	pServiceAccount := newObj.(*v1.ServiceAccount)
-	// set to empty and token controller will regenerate one.
-	pServiceAccount.Secrets = nil
-
-	_, err = c.client.ServiceAccounts(targetNamespace).Create(pServiceAccount)
-	if errors.IsAlreadyExists(err) {
-		klog.Infof("service account %s/%s of cluster %s already exist in super master", namespace, name, cluster)
-		return nil
-	}
-	return err
-}
-
-func (c *controller) reconcileServiceAccountUpdate(cluster, namespace, name string, secret *v1.ServiceAccount) error {
-	// do nothing.
-	return nil
-}
-
-func (c *controller) reconcileServiceAccountRemove(cluster, namespace, name string, secret *v1.ServiceAccount) error {
-	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
-	opts := &metav1.DeleteOptions{
-		PropagationPolicy: &constants.DefaultDeletionPolicy,
-	}
-	err := c.client.ServiceAccounts(targetNamespace).Delete(name, opts)
-	if errors.IsNotFound(err) {
-		klog.Warningf("service account %s/%s of cluster %s not found in super master", namespace, name, cluster)
-		return nil
-	}
-	return err
 }
 
 func (c *controller) AddCluster(cluster mc.ClusterInterface) {

--- a/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/dws.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serviceaccount
+
+import (
+	"fmt"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
+)
+
+func (c *controller) StartDWS(stopCh <-chan struct{}) error {
+	if !cache.WaitForCacheSync(stopCh, c.saSynced) {
+		return fmt.Errorf("failed to wait for sa caches to sync")
+	}
+	return c.multiClusterServiceAccountController.Start(stopCh)
+}
+
+// The reconcile logic for tenant master service account informer
+func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
+	klog.Infof("reconcile service account %s/%s %s event for cluster %s", request.Namespace, request.Name, request.Event, request.Cluster.Name)
+
+	switch request.Event {
+	case reconciler.AddEvent:
+		err := c.reconcileServiceAccountCreate(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.ServiceAccount))
+		if err != nil {
+			klog.Errorf("failed reconcile service account %s/%s CREATE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
+			return reconciler.Result{Requeue: true}, err
+		}
+	case reconciler.UpdateEvent:
+		err := c.reconcileServiceAccountUpdate(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.ServiceAccount))
+		if err != nil {
+			klog.Errorf("failed reconcile service account %s/%s CREATE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
+			return reconciler.Result{Requeue: true}, err
+		}
+	case reconciler.DeleteEvent:
+		err := c.reconcileServiceAccountRemove(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.ServiceAccount))
+		if err != nil {
+			klog.Errorf("failed reconcile service account %s/%s DELETE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
+			return reconciler.Result{Requeue: true}, err
+		}
+	}
+	return reconciler.Result{}, nil
+}
+
+func (c *controller) reconcileServiceAccountCreate(cluster, namespace, name string, secret *v1.ServiceAccount) error {
+	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
+	// Just mark the default service account of super master namespace, created by super master service account controller, as a tenant related resource.
+	if name == "default" {
+		sa, err := c.saLister.ServiceAccounts(targetNamespace).Get("default")
+		if err != nil {
+			// maybe the sa is not created, retry
+			return err
+		}
+
+		if len(sa.Annotations) == 0 {
+			sa.Annotations = make(map[string]string)
+		}
+		if sa.Annotations[constants.LabelCluster] != cluster {
+			sa.Annotations[constants.LabelCluster] = cluster
+			_, err = c.saClient.ServiceAccounts(targetNamespace).Update(sa)
+		}
+		return err
+	}
+
+	_, err := c.saLister.ServiceAccounts(targetNamespace).Get(name)
+	if err == nil {
+		// sa already exists.
+		return nil
+	}
+
+	newObj, err := conversion.BuildMetadata(cluster, targetNamespace, secret)
+	if err != nil {
+		return err
+	}
+	pServiceAccount := newObj.(*v1.ServiceAccount)
+	// set to empty and token controller will regenerate one.
+	pServiceAccount.Secrets = nil
+
+	_, err = c.saClient.ServiceAccounts(targetNamespace).Create(pServiceAccount)
+	if errors.IsAlreadyExists(err) {
+		klog.Infof("service account %s/%s of cluster %s already exist in super master", namespace, name, cluster)
+		return nil
+	}
+	return err
+}
+
+func (c *controller) reconcileServiceAccountUpdate(cluster, namespace, name string, secret *v1.ServiceAccount) error {
+	// do nothing.
+	return nil
+}
+
+func (c *controller) reconcileServiceAccountRemove(cluster, namespace, name string, secret *v1.ServiceAccount) error {
+	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
+	opts := &metav1.DeleteOptions{
+		PropagationPolicy: &constants.DefaultDeletionPolicy,
+	}
+	err := c.saClient.ServiceAccounts(targetNamespace).Delete(name, opts)
+	if errors.IsNotFound(err) {
+		klog.Warningf("service account %s/%s of cluster %s not found in super master", namespace, name, cluster)
+		return nil
+	}
+	return err
+}


### PR DESCRIPTION
This change touches secret/serviceaccount resources. It mainly does the followings:

- Move downward syncer logic to a separate dws.go for better code structure.
- Add an serviceaccount informer Lister and add WaitForCacheSync for service account dws thread. This will avoid create duplicated resource without querying super master .
- Add more comments.
