### PR TITLE
fix creation timeout bug.

### DIFF
--- a/incubator/virtualcluster/pkg/controller/util/strings/util.go
+++ b/incubator/virtualcluster/pkg/controller/util/strings/util.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package strings
 
-import "encoding/json"
+import (
+	"strings"
+)
 
 // ContainString checks if string slice sli contains string s
 func ContainString(sli []string, s string) bool {
@@ -39,8 +41,17 @@ func RemoveString(sli []string, s string) (newSli []string) {
 	return
 }
 
-// IsJSON check whether given s is in json format
-func IsJSON(s string) bool {
-	var js map[string]interface{}
-	return json.Unmarshal([]byte(s), &js) == nil
+// SplitFields splits string s into substrings separated by delimiters in
+// rs and returns a slice of the substrings
+func SplitFields(s string, rs ...rune) []string {
+	fn := func(ru rune) bool {
+		var ret bool
+		for _, r := range rs {
+			if ru == r {
+				ret = true
+			}
+		}
+		return ret
+	}
+	return strings.FieldsFunc(s, fn)
 }

--- a/incubator/virtualcluster/pkg/controller/util/strings/util.go
+++ b/incubator/virtualcluster/pkg/controller/util/strings/util.go
@@ -45,13 +45,12 @@ func RemoveString(sli []string, s string) (newSli []string) {
 // rs and returns a slice of the substrings
 func SplitFields(s string, rs ...rune) []string {
 	fn := func(ru rune) bool {
-		var ret bool
 		for _, r := range rs {
 			if ru == r {
-				ret = true
+				return true
 			}
 		}
-		return ret
+		return false
 	}
 	return strings.FieldsFunc(s, fn)
 }

--- a/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_aliyun.go
+++ b/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_aliyun.go
@@ -164,7 +164,7 @@ func sendCreationRequest(cli *sdk.Client, clusterName string, askCfg ASKConfig) 
 "name": "%s", 
 "region_id": "%s",
 "zoneid": "%s", 
-"nat_gateway": false,
+"nat_gateway": true,
 "private_zone": true
 }`, clusterName, askCfg.regionID, askCfg.zoneID)
 	}


### PR DESCRIPTION
1. fix creation timeout bug.    

After ASK creation is timeout, the reconciler will proceed based on ASK state,

    * if in 'initial' state, reconciler will poll the ASK until it is turned in to 'running' state.
    * if in 'running' state, reconciler will proceed post creation actions,
    i.e. retrieving admin-kubeconfig, creating corresponding namespace.

2. handle Alibaba Cloud SDK error by checking the error code