### PR TITLE
Increase memory limits

### DIFF
--- a/incubator/hnc/config/manager/manager.yaml
+++ b/incubator/hnc/config/manager/manager.yaml
@@ -32,8 +32,8 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 100Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
We noticed the HNC controller OOMing on 30Mi of memory, even on
relatively small hierarchies. Raising the request to 50Mi (from 20Mi)
and the limit to 100Mi (from 30Mi) should give us enough headroom in
most cases.

Tested: redeployed and observed that the requests/limits were as
expected.

/assign @yiqigao217 