### PR TITLE
[incubator][VC]Add sync controller for StorageClass resource

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/constants/constants.go
+++ b/incubator/virtualcluster/pkg/syncer/constants/constants.go
@@ -43,6 +43,9 @@ const (
 
 	TenantDNSServerNS          = "kube-system"
 	TenantDNSServerServiceName = "kube-dns"
+
+	// PublicObjectKey is a label key which marks the super master object that should be populated to every tenant master.
+	PublicObjectKey = "tenancy.x-k8s.io/super.public"
 )
 
 var DefaultDeletionPolicy = metav1.DeletePropagationBackground

--- a/incubator/virtualcluster/pkg/syncer/conversion/equality.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/equality.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
+	v1storage "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -349,4 +350,15 @@ func CheckEndpointsEquality(pObj, vObj *v1.Endpoints) *v1.Endpoints {
 	}
 
 	return updated
+}
+
+func CheckStorageClassEquality(pObj, vObj *v1storage.StorageClass) *v1storage.StorageClass {
+	pCopy := pObj.DeepCopy()
+	pCopy.ObjectMeta = *vObj.ObjectMeta.DeepCopy()
+
+	if !equality.Semantic.DeepEqual(vObj, pCopy) {
+		return pCopy
+	} else {
+		return nil
+	}
 }

--- a/incubator/virtualcluster/pkg/syncer/conversion/helper.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/helper.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -158,4 +159,10 @@ func BuildVirtualPodEvent(cluster string, pEvent *v1.Event, vPod *v1.Pod) *v1.Ev
 	vEvent.Message = strings.ReplaceAll(vEvent.Message, cluster, "")
 
 	return vEvent
+}
+
+func BuildVirtualStorageClass(cluster string, pStorageClass *storagev1.StorageClass) *storagev1.StorageClass {
+	vStorageClass := pStorageClass.DeepCopy()
+	ResetMetadata(vStorageClass)
+	return vStorageClass
 }

--- a/incubator/virtualcluster/pkg/syncer/resources/register.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/register.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/resources/secret"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/resources/service"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/resources/serviceaccount"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/resources/storageclass"
 )
 
 func Register(client clientset.Interface, informerFactory informers.SharedInformerFactory, controllerManager *manager.ControllerManager) {
@@ -42,4 +43,5 @@ func Register(client clientset.Interface, informerFactory informers.SharedInform
 	service.Register(client.CoreV1(), informerFactory.Core().V1().Services(), controllerManager)
 	endpoints.Register(client.CoreV1(), informerFactory.Core().V1().Endpoints(), controllerManager)
 	event.Register(client.CoreV1(), informerFactory.Core().V1(), controllerManager)
+	storageclass.Register(client.StorageV1(), informerFactory.Storage().V1(), controllerManager)
 }

--- a/incubator/virtualcluster/pkg/syncer/resources/storageclass/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/storageclass/controller.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storageclass
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/storage/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	storageinformers "k8s.io/client-go/informers/storage/v1"
+	v1storage "k8s.io/client-go/kubernetes/typed/storage/v1"
+	listersv1 "k8s.io/client-go/listers/storage/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
+	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
+)
+
+type controller struct {
+	// super master storageclasses client
+	client v1storage.StorageClassesGetter
+	// super master storageclasses informer/lister/synced functions
+	informer           storageinformers.Interface
+	storageclassLister listersv1.StorageClassLister
+	storageclassSynced cache.InformerSynced
+
+	// Connect to all tenant master storageclass informers
+	multiClusterStorageClassController *mc.MultiClusterController
+
+	// UWS queue
+	workers int
+	queue   workqueue.RateLimitingInterface
+}
+
+type scReconcileRequest struct {
+	key         string
+	clusterName string
+}
+
+func Register(
+	client v1storage.StorageClassesGetter,
+	informer storageinformers.Interface,
+	controllerManager *manager.ControllerManager,
+) {
+	c := &controller{
+		client:   client,
+		informer: informer,
+		queue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "super_master_storageclasses"),
+		workers:  constants.DefaultControllerWorkers,
+	}
+
+	options := mc.Options{Reconciler: c}
+	multiClusterStorageClassController, err := mc.NewMCController("tenant-masters-storageclass-controller", &v1.StorageClass{}, options)
+	if err != nil {
+		klog.Errorf("failed to create multi cluster event controller %v", err)
+		return
+	}
+	c.multiClusterStorageClassController = multiClusterStorageClassController
+
+	c.storageclassLister = informer.StorageClasses().Lister()
+	c.storageclassSynced = informer.StorageClasses().Informer().HasSynced
+	informer.StorageClasses().Informer().AddEventHandler(
+		cache.FilteringResourceEventHandler{
+			FilterFunc: func(obj interface{}) bool {
+				switch t := obj.(type) {
+				case *v1.StorageClass:
+					return publicStorageClass(t)
+				case cache.DeletedFinalStateUnknown:
+					if e, ok := t.Obj.(*v1.StorageClass); ok {
+						return publicStorageClass(e)
+					}
+					utilruntime.HandleError(fmt.Errorf("unable to convert object %v to *v1.StorageClass", obj))
+					return false
+				default:
+					utilruntime.HandleError(fmt.Errorf("unable to handle object in super master storageclass controller: %v", obj))
+					return false
+				}
+			},
+			Handler: cache.ResourceEventHandlerFuncs{
+				AddFunc: c.enqueueStorageClass,
+				UpdateFunc: func(oldObj, newObj interface{}) {
+					newStorageClass := newObj.(*v1.StorageClass)
+					oldStorageClass := oldObj.(*v1.StorageClass)
+					if newStorageClass.ResourceVersion != oldStorageClass.ResourceVersion {
+						c.enqueueStorageClass(newObj)
+					}
+				},
+				DeleteFunc: c.enqueueStorageClass,
+			},
+		})
+
+	controllerManager.AddController(c)
+}
+
+func publicStorageClass(e *v1.StorageClass) bool {
+	// We only backpopulate specific storageclass to tenant masters
+	return e.Labels[constants.PublicObjectKey] == "true"
+}
+
+func (c *controller) enqueueStorageClass(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %v: %v", obj, err))
+		return
+	}
+
+	clusterNames := c.multiClusterStorageClassController.GetClusterNames()
+	if len(clusterNames) == 0 {
+		klog.Infof("No tenant masters, stop backpopulate storageclass %v", key)
+		return
+	}
+
+	for _, clusterName := range clusterNames {
+		c.queue.Add(scReconcileRequest{key: key, clusterName: clusterName})
+	}
+}
+
+func (c *controller) StartDWS(stopCh <-chan struct{}) error {
+	return nil
+}
+
+func (c *controller) StartPeriodChecker(stopCh <-chan struct{}) {
+}
+
+func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
+	return reconciler.Result{}, nil
+}
+
+func (c *controller) AddCluster(cluster mc.ClusterInterface) {
+	klog.Infof("tenant-masters-storageclass-controller watch cluster %s for storageclass resource", cluster.GetClusterName())
+	err := c.multiClusterStorageClassController.WatchClusterResource(cluster, mc.WatchOptions{})
+	if err != nil {
+		klog.Errorf("failed to watch cluster %s storageclass: %v", cluster.GetClusterName(), err)
+	}
+}
+
+func (c *controller) RemoveCluster(cluster mc.ClusterInterface) {
+	klog.Infof("tenant-masters-storageclass-controller stop watching cluster %s for storageclass resource", cluster.GetClusterName())
+	c.multiClusterStorageClassController.TeardownClusterResource(cluster)
+}

--- a/incubator/virtualcluster/pkg/syncer/resources/storageclass/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/storageclass/uws.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storageclass
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// StartUWS starts the upward syncer
+// and blocks until an empty struct is sent to the stop channel.
+func (c *controller) StartUWS(stopCh <-chan struct{}) error {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	klog.Infof("starting storageclass upward syncer")
+
+	if !cache.WaitForCacheSync(stopCh, c.storageclassSynced) {
+		return fmt.Errorf("failed to wait for caches to sync storageclass")
+	}
+
+	klog.V(5).Infof("starting workers")
+	for i := 0; i < c.workers; i++ {
+		go wait.Until(c.run, 1*time.Second, stopCh)
+	}
+	<-stopCh
+	klog.V(1).Infof("shutting down")
+
+	return nil
+}
+
+// run runs a run thread that just dequeues items, processes them, and marks them done.
+// It enforces that the syncHandler is never invoked concurrently with the same key.
+func (c *controller) run() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *controller) processNextWorkItem() bool {
+	req, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(req)
+
+	klog.Infof("back populate storageclass %+v", req)
+	err := c.backPopulate(req.(scReconcileRequest))
+	if err == nil {
+		c.queue.Forget(req)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("error processing storageclass %v (will retry): %v", req, err))
+	c.queue.AddRateLimited(req)
+	return true
+}
+
+func (c *controller) backPopulate(req scReconcileRequest) error {
+	op := "APPLY"
+	pStorageClass, err := c.storageclassLister.Get(req.key)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+		op = "DELETE"
+	}
+
+	cluster := c.multiClusterStorageClassController.GetCluster(req.clusterName)
+	if cluster == nil {
+		klog.Errorf("failed to locate cluster %s", req.clusterName)
+		return nil
+	}
+	tenantClient, err := cluster.GetClient()
+	if err != nil {
+		return fmt.Errorf("failed to create client from cluster %s config: %v", req.clusterName, err)
+	}
+
+	clusterCache, err := cluster.GetCache()
+	if err != nil {
+		klog.Errorf("failed to get cache for cluster %s", req.clusterName)
+		return err
+	}
+
+	storageClassInformer, err := clusterCache.GetInformer(&v1.StorageClass{})
+	if err != nil {
+		klog.Errorf("failed to get storageclass informer for cluster %s", req.clusterName)
+		return err
+	}
+
+	hasSynced := storageClassInformer.HasSynced
+	if !hasSynced() {
+		// This should be rare, let us just fail the entire reconcile
+		return fmt.Errorf("storageclass informer has not been synced yet")
+	}
+
+	vStorageClass := &v1.StorageClass{}
+	err = clusterCache.Get(context.TODO(), client.ObjectKey{Name: req.key}, vStorageClass)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			if op == "APPLY" {
+				// Available in super, hence create a new in tenant master
+				vStorageClass := conversion.BuildVirtualStorageClass(req.clusterName, pStorageClass)
+				_, err := tenantClient.StorageV1().StorageClasses().Create(vStorageClass)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		return err
+	}
+
+	if op == "DELETE" {
+		opts := &metav1.DeleteOptions{
+			PropagationPolicy: &constants.DefaultDeletionPolicy,
+		}
+		err := tenantClient.StorageV1().StorageClasses().Delete(req.key, opts)
+		if err != nil {
+			return err
+		}
+	} else {
+		updatedStorageClass := conversion.CheckStorageClassEquality(pStorageClass, vStorageClass)
+		if updatedStorageClass != nil {
+			_, err := tenantClient.StorageV1().StorageClasses().Update(updatedStorageClass)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
We don't allow to use tenant PV for virtual cluster. Hence the PV capability is provided by super master only.  This change adds uws sync controller to back populate StorageClass objects from super master to every tenant master. Super master holds the source of truth for storage class.

All the races, and inconsistency will be handled by PeriodCheck thread which will be done later.  


Test:

Manually verify that the add and delete sc operation in super master is correctly populate to tenant master. 