### PR TITLE
[Incubator][VC]Fix cluster cache not ready race

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/cluster/cluster.go
+++ b/incubator/virtualcluster/pkg/syncer/cluster/cluster.go
@@ -56,13 +56,15 @@ type Cluster struct {
 	// scheme is injected by the controllerManager when controllerManager.Start is called
 	scheme *runtime.Scheme
 
-	//
 	mapper meta.RESTMapper
 
 	// informers are injected by the controllerManager when controllerManager.Start is called
 	cache  cache.Cache
 	client *client.DelegatingClient
 	Options
+
+	// a flag indicates that the cluster cache has been synced
+	synced bool
 
 	stopCh chan struct{}
 }
@@ -85,7 +87,7 @@ type CacheOptions struct {
 
 // New creates a new Cluster.
 func NewTenantCluster(name string, spec *v1alpha1.VirtualclusterSpec, config *rest.Config, o Options) *Cluster {
-	return &Cluster{Name: name, spec: spec, Config: config, Options: o, stopCh: make(chan struct{})}
+	return &Cluster{Name: name, spec: spec, Config: config, Options: o, synced: false, stopCh: make(chan struct{})}
 }
 
 // GetClusterName returns the name given when Cluster c was created.
@@ -230,6 +232,14 @@ func (c *Cluster) WaitForCacheSync() bool {
 		return false
 	}
 	return ca.WaitForCacheSync(c.stopCh)
+}
+
+func (c *Cluster) SetSynced() {
+	c.synced = true
+}
+
+func (c *Cluster) Synced() bool {
+	return c.synced
 }
 
 // Stop send a msg to stopCh, stop the cache.

--- a/incubator/virtualcluster/pkg/syncer/syncer.go
+++ b/incubator/virtualcluster/pkg/syncer/syncer.go
@@ -290,7 +290,7 @@ func (s *Syncer) addCluster(key string, vc *v1alpha1.Virtualcluster) error {
 	return nil
 }
 
-func (s *Syncer) runCluster(cluster mc.ClusterInterface) {
+func (s *Syncer) runCluster(cluster *cluster.Cluster) {
 	go func() {
 		err := cluster.Start()
 		klog.Infof("cluster %s shutdown: %v", cluster.GetClusterName(), err)
@@ -302,4 +302,5 @@ func (s *Syncer) runCluster(cluster mc.ClusterInterface) {
 		s.queue.AddAfter(cluster.GetClusterName(), 5*time.Second)
 		return
 	}
+	cluster.SetSynced()
 }


### PR DESCRIPTION
We have a slight race window in syncer.go. Before calling runCluster() to start the cluster cache, the cluster has been available in all MCControllers. Therefore, when any uws thread tries to query tenant master, the tenant cache may be stale. 

In this change, a synced flag is added and if the flag is false, the MultiClusterController.GetCluster() method returns nil and the reconcile request will be requeued.

Also, the tenant cluster cache start is done in syncer.go. The duplicated logic in MultiClusterController.Start() can be removed.