### PR TITLE
User DelegatingCache for tenant apiserver read and save clientset client pointer

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/resources/node/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/node/uws.go
@@ -23,12 +23,9 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	clientset "k8s.io/client-go/kubernetes"
-	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 )
@@ -114,28 +111,33 @@ func (c *controller) backPopulate(nodeName string) error {
 	return nil
 }
 
-func (c *controller) updateClusterNodeStatus(cluster string, node *v1.Node, wg *sync.WaitGroup) {
+func (c *controller) updateClusterNodeStatus(clusterName string, node *v1.Node, wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	tenantCluster := c.multiClusterNodeController.GetCluster(cluster)
-	client, err := clientset.NewForConfig(restclient.AddUserAgent(tenantCluster.GetClientInfo().Config, "syncer"))
+	tenantCluster := c.multiClusterNodeController.GetCluster(clusterName)
+	if tenantCluster == nil {
+		klog.Errorf("cluster %s not found", clusterName)
+		return
+	}
+	tenantClient, err := tenantCluster.GetClient()
 	if err != nil {
-		klog.Errorf("could not find cluster %s in controller cache %v", cluster, err)
+		klog.Errorf("failed to create client from cluster %s config: %v", clusterName, err)
 		return
 	}
 
-	vNode, err := client.CoreV1().Nodes().Get(node.Name, metav1.GetOptions{})
+	vNodeObj, err := c.multiClusterNodeController.Get(clusterName, "", node.Name)
 	if err != nil {
-		klog.Errorf("could not find node %s/%s: %v", cluster, node.Name, err)
+		klog.Errorf("could not find node %s/%s: %v", clusterName, node.Name, err)
 		return
 	}
 
+	vNode := vNodeObj.(*v1.Node)
 	newVNode := vNode.DeepCopy()
 	newVNode.Status.Conditions = node.Status.Conditions
 
-	_, _, err = patchNodeStatus(client.CoreV1().Nodes(), types.NodeName(node.Name), vNode, newVNode)
+	_, _, err = patchNodeStatus(tenantClient.CoreV1().Nodes(), types.NodeName(node.Name), vNode, newVNode)
 	if err != nil {
-		klog.Errorf("failed to update node %s/%s's heartbeats: %v", cluster, node.Name, err)
+		klog.Errorf("failed to update node %s/%s's heartbeats: %v", clusterName, node.Name, err)
 		return
 	}
 }

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/controller.go
@@ -42,6 +42,7 @@ type controller struct {
 	informer      coreinformers.Interface
 	podLister     listersv1.PodLister
 	podSynced     cache.InformerSynced
+	serviceLister listersv1.ServiceLister
 	serviceSynced cache.InformerSynced
 	nsLister      listersv1.NamespaceLister
 	nsSynced      cache.InformerSynced
@@ -76,6 +77,7 @@ func Register(
 	}
 	c.multiClusterPodController = multiClusterPodController
 
+	c.serviceLister = informer.Services().Lister()
 	c.serviceSynced = informer.Services().Informer().HasSynced
 
 	c.nsLister = informer.Namespaces().Lister()

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/dws.go
@@ -171,13 +171,13 @@ func (c *controller) getClusterNameServer(client v1core.ServicesGetter, cluster 
 
 func (c *controller) getPodRelatedServices(cluster string, pPod *v1.Pod) ([]*v1.Service, error) {
 	var services []*v1.Service
-	list, err := c.informer.Services().Lister().Services(conversion.ToSuperMasterNamespace(cluster, metav1.NamespaceDefault)).List(labels.Everything())
+	list, err := c.serviceLister.Services(conversion.ToSuperMasterNamespace(cluster, metav1.NamespaceDefault)).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
 	services = append(services, list...)
 
-	list, err = c.informer.Services().Lister().Services(pPod.Namespace).List(labels.Everything())
+	list, err = c.serviceLister.Services(pPod.Namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
@@ -122,7 +122,7 @@ func (c *controller) backPopulate(key string) error {
 		if errors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("could not find pPod %s/%s pPod in controller cache %v", vNamespace, pName, err)
+		return fmt.Errorf("could not find pPod %s/%s's vPod in controller cache %v", vNamespace, pName, err)
 	}
 	vPod := vPodObj.(*v1.Pod)
 


### PR DESCRIPTION
This change uses DelegatingCache for tenant cluster read for watched objects. The synced check logic is moved out of GetCluster method since it is hard to distinguish between cluster is deleted and cluster cache is not synced. 

This change also avoids creating many new clientset client for accessing tenant apiserver.

After this change, we should use func (c *MultiClusterController) Get() method to read watched tenant apiserver object.

I will try to remove GetCache method from ClusterInterface in next change. 