### PR TITLE
[Incubator][VC]Refactor Cluster and MultiClusterController interface methods

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/resources/event/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/event/uws.go
@@ -105,12 +105,7 @@ func (c *controller) backPopulate(key string) error {
 		return nil
 	}
 
-	tenantCluster := c.multiClusterEventController.GetCluster(clusterName)
-	if tenantCluster == nil {
-		// TODO: just return nil if periodic check if ready.
-		return fmt.Errorf("cluster %s not found", clusterName)
-	}
-	tenantClient, err := tenantCluster.GetClient()
+	tenantClient, err := c.multiClusterEventController.GetClusterClient(clusterName)
 	if err != nil {
 		return fmt.Errorf("failed to create client from cluster %s config: %v", clusterName, err)
 	}

--- a/incubator/virtualcluster/pkg/syncer/resources/node/util.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/node/util.go
@@ -55,6 +55,7 @@ func NewVirtualNode(superMasterNode *v1.Node) *v1.Node {
 	n.Status.NodeInfo.OperatingSystem = "Linux"
 	n.Status.DaemonEndpoints = v1.NodeDaemonEndpoints{
 		KubeletEndpoint: v1.DaemonEndpoint{
+			// vn-agent service port. Hard coded for now.
 			Port: 10550,
 		},
 	}

--- a/incubator/virtualcluster/pkg/syncer/resources/node/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/node/uws.go
@@ -114,12 +114,7 @@ func (c *controller) backPopulate(nodeName string) error {
 func (c *controller) updateClusterNodeStatus(clusterName string, node *v1.Node, wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	tenantCluster := c.multiClusterNodeController.GetCluster(clusterName)
-	if tenantCluster == nil {
-		klog.Errorf("cluster %s not found", clusterName)
-		return
-	}
-	tenantClient, err := tenantCluster.GetClient()
+	tenantClient, err := c.multiClusterNodeController.GetClusterClient(clusterName)
 	if err != nil {
 		klog.Errorf("failed to create client from cluster %s config: %v", clusterName, err)
 		return

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
@@ -100,11 +100,7 @@ func (c *controller) backPopulate(key string) error {
 		return nil
 	}
 
-	tenantCluster := c.multiClusterPodController.GetCluster(clusterName)
-	if tenantCluster == nil {
-		return fmt.Errorf("cluster %s not found", clusterName)
-	}
-	tenantClient, err := tenantCluster.GetClient()
+	tenantClient, err := c.multiClusterPodController.GetClusterClient(clusterName)
 	if err != nil {
 		return fmt.Errorf("failed to create client from cluster %s config: %v", clusterName, err)
 	}

--- a/incubator/virtualcluster/pkg/syncer/resources/service/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/service/controller.go
@@ -114,7 +114,7 @@ func (c *controller) reconcileServiceCreate(cluster, namespace, name string, ser
 	}
 
 	pService := newObj.(*v1.Service)
-	conversion.VC(nil).Service(pService).Mutate(service)
+	conversion.VC(nil, "").Service(pService).Mutate(service)
 
 	_, err = c.serviceClient.Services(targetNamespace).Create(pService)
 	if errors.IsAlreadyExists(err) {

--- a/incubator/virtualcluster/pkg/syncer/resources/storageclass/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/storageclass/uws.go
@@ -91,11 +91,7 @@ func (c *controller) backPopulate(req scReconcileRequest) error {
 		op = reconciler.DeleteEvent
 	}
 
-	tenantCluster := c.multiClusterStorageClassController.GetCluster(req.clusterName)
-	if tenantCluster == nil {
-		return fmt.Errorf("cluster %s not found", req.clusterName)
-	}
-	tenantClient, err := tenantCluster.GetClient()
+	tenantClient, err := c.multiClusterStorageClassController.GetClusterClient(req.clusterName)
 	if err != nil {
 		return fmt.Errorf("failed to create client from cluster %s config: %v", req.clusterName, err)
 	}


### PR DESCRIPTION
This change attempts to achieve the following best practices for building syncer framework objects.
- Expose least amount of internal state
- Avoid exposing internal pointers 

As a consequence, with this change,
- Cluster and ClusterInterface does not export GetCache() method anymore. MultiClusterController adds List method to encapsulate the access to internal cluster cache.
- Cluster does not export GetMapper and GetScheme.
- MultiClusterController does not expose GetCluster method anymore. All needs to access cluster pointer are supported by specific public methods such as GetClusterClient and GetClusterDomain.
- Many related codes are changed due to above interface changes.

Bonus fixes:
- Avoid looping the entire cluster map when calling getCluster.
- Fix a small bug in attachTenantMeta in case a standalone replicaset is deployed in tenant master.
