### PR TITLE
[Incubator][VC] Add storageclass object periodic checker

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/resources/service/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/service/checker.go
@@ -103,7 +103,7 @@ func (c *controller) checkServicesOfTenantCluster(clusterName string) {
 		}
 
 		if err != nil {
-			klog.Errorf("failed to get pService %s/%s from super master cache: %v", pService.Namespace, pService.Name, err)
+			klog.Errorf("failed to get pService %s/%s from super master cache: %v", targetNamespace, vService.Name, err)
 			continue
 		}
 

--- a/incubator/virtualcluster/pkg/syncer/resources/storageclass/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/storageclass/checker.go
@@ -67,7 +67,7 @@ func (c *controller) checkStorageClass() {
 	}
 
 	for _, pStorageClass := range pStorageClassList {
-		if pStorageClass.Labels[constants.PublicObjectKey] != "true" {
+		if !publicStorageClass(pStorageClass) {
 			continue
 		}
 		for _, clusterName := range clusterNames {

--- a/incubator/virtualcluster/pkg/syncer/resources/storageclass/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/storageclass/checker.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storageclass
+
+import (
+	"fmt"
+	"sync"
+
+	v1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+)
+
+func (c *controller) StartPeriodChecker(stopCh <-chan struct{}) error {
+	if !cache.WaitForCacheSync(stopCh, c.storageclassSynced) {
+		return fmt.Errorf("failed to wait for caches to sync before starting Service checker")
+	}
+
+	wait.Until(c.checkStorageClass, c.periodCheckerPeriod, stopCh)
+	return nil
+}
+
+// checkStorageClass check if StorageClass keeps consistency between super master and tenant masters.
+func (c *controller) checkStorageClass() {
+	clusterNames := c.multiClusterStorageClassController.GetClusterNames()
+	if len(clusterNames) == 0 {
+		klog.Infof("tenant masters has no clusters, give up storage class period checker")
+		return
+	}
+
+	wg := sync.WaitGroup{}
+
+	for _, clusterName := range clusterNames {
+		wg.Add(1)
+		go func(clusterName string) {
+			defer wg.Done()
+			c.checkStorageClassOfTenantCluster(clusterName)
+		}(clusterName)
+	}
+	wg.Wait()
+
+	pStorageClassList, err := c.storageclassLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("error listing storageclass from super master informer cache: %v", err)
+		return
+	}
+
+	for _, pStorageClass := range pStorageClassList {
+		if pStorageClass.Labels[constants.PublicObjectKey] != "true" {
+			continue
+		}
+		for _, clusterName := range clusterNames {
+			_, err := c.multiClusterStorageClassController.Get(clusterName, "", pStorageClass.Name)
+			if err != nil {
+				if errors.IsNotFound(err) {
+					c.queue.Add(scReconcileRequest{key: pStorageClass.Name, clusterName: clusterName})
+				}
+				klog.Errorf("fail to get storageclass from cluster %s: %v", clusterName, err)
+			}
+		}
+	}
+}
+
+func (c *controller) checkStorageClassOfTenantCluster(clusterName string) {
+	listObj, err := c.multiClusterStorageClassController.List(clusterName)
+	if err != nil {
+		klog.Errorf("error listing storageclass from cluster %s informer cache: %v", clusterName, err)
+		return
+	}
+	klog.Infof("check storageclass consistency in cluster %s", clusterName)
+	scList := listObj.(*v1.StorageClassList)
+	for i, vStorageClass := range scList.Items {
+		pStorageClass, err := c.storageclassLister.Get(vStorageClass.Name)
+		if errors.IsNotFound(err) {
+			// super master is the source of the truth for sc object, delete tenant master obj
+			tenantClient, err := c.multiClusterStorageClassController.GetClusterClient(clusterName)
+			if err != nil {
+				klog.Errorf("error getting cluster %s clientset: %v", clusterName, err)
+				continue
+			}
+			opts := &metav1.DeleteOptions{
+				PropagationPolicy: &constants.DefaultDeletionPolicy,
+			}
+			if err := tenantClient.StorageV1().StorageClasses().Delete(vStorageClass.Name, opts); err != nil {
+				klog.Errorf("error deleting storageclass %v in cluster %s: %v", vStorageClass.Name, clusterName, err)
+			}
+			continue
+		}
+
+		if err != nil {
+			klog.Errorf("failed to get pStorageClass %s from super master cache: %v", vStorageClass.Name, err)
+			continue
+		}
+
+		updatedStorageClass := conversion.CheckStorageClassEquality(pStorageClass, &scList.Items[i])
+		if updatedStorageClass != nil {
+			klog.Warningf("spec of storageClass %v diff in super&tenant master", vStorageClass.Name)
+		}
+	}
+}

--- a/incubator/virtualcluster/pkg/syncer/resources/storageclass/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/storageclass/controller.go
@@ -18,6 +18,7 @@ package storageclass
 
 import (
 	"fmt"
+	"time"
 
 	v1 "k8s.io/api/storage/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -48,6 +49,9 @@ type controller struct {
 	// UWS queue
 	workers int
 	queue   workqueue.RateLimitingInterface
+
+	// Checker timer
+	periodCheckerPeriod time.Duration
 }
 
 type scReconcileRequest struct {
@@ -61,10 +65,11 @@ func Register(
 	controllerManager *manager.ControllerManager,
 ) {
 	c := &controller{
-		client:   client,
-		informer: informer,
-		queue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "super_master_storageclasses"),
-		workers:  constants.DefaultControllerWorkers,
+		client:              client,
+		informer:            informer,
+		queue:               workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "super_master_storageclasses"),
+		workers:             constants.DefaultControllerWorkers,
+		periodCheckerPeriod: 60 * time.Second,
 	}
 
 	options := mc.Options{Reconciler: c}
@@ -134,10 +139,6 @@ func (c *controller) enqueueStorageClass(obj interface{}) {
 }
 
 func (c *controller) StartDWS(stopCh <-chan struct{}) error {
-	return nil
-}
-
-func (c *controller) StartPeriodChecker(stopCh <-chan struct{}) error {
 	return nil
 }
 


### PR DESCRIPTION
This change adds storageclass periodic checker to make sure tenant and super are consistent.
We don't implement a more aggressive consistency guarantee logic such that watching tenant sc delete events to reduce the overhead of using informer.  We may add it later if necessary. Note that for storageclass, the source of truth is super master. If tenant master happens to create a sc with the same name as one of the sc in super, the checker reports a warning if their specs are different for now.

Manual Test:
Delete sc from tenant master and within 60 seconds, the sc is recreated again in tenant.  