### PR TITLE
[Incubator][VC]Do not sync tenant Pod with NodeName set in the spec

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/resources/pod/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/checker.go
@@ -125,6 +125,10 @@ func (c *controller) checkPodsOfTenantCluster(clusterName string) {
 	klog.Infof("check pods consistency in cluster %s", clusterName)
 	podList := listObj.(*v1.PodList)
 	for i, vPod := range podList.Items {
+		if vPod.Spec.NodeName != "" && !isPodScheduled(&vPod) {
+			// We should skip pods with NodeName set in the spec
+			continue
+		}
 		targetNamespace := conversion.ToSuperMasterNamespace(clusterName, vPod.Namespace)
 		pPod, err := c.podLister.Pods(targetNamespace).Get(vPod.Name)
 		if errors.IsNotFound(err) {


### PR DESCRIPTION
Currently, VC does not support DaemonSet like workload. Since tenants do not have full control/knowledge about super master nodes, allowing them to specify node in Pod is impractical and may lead to confusion. 

With this change, syncer does not handle Pod with NodeName set in the spec and a NotSupport event will be generated in the tenant master to notify the user.