### PR TITLE
fix the master service namespace bug

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/resources/service/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/service/controller.go
@@ -93,7 +93,7 @@ func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, e
 	case reconciler.UpdateEvent:
 		err := c.reconcileServiceUpdate(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.Service))
 		if err != nil {
-			klog.Errorf("failed reconcile service %s/%s CREATE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
+			klog.Errorf("failed reconcile service %s/%s UPDATE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
 			return reconciler.Result{Requeue: true}, err
 		}
 	case reconciler.DeleteEvent:


### PR DESCRIPTION
   transfer the 'default' namespace to the corresponding namespace on the
   super master before making pod env variables for master services