### PR TITLE
[incubator][VC] provide kubeconfig according to service account

### DIFF
--- a/incubator/virtualcluster/cmd/syncer/app/options/options.go
+++ b/incubator/virtualcluster/cmd/syncer/app/options/options.go
@@ -63,24 +63,32 @@ type ResourceSyncerOptions struct {
 func NewResourceSyncerOptions() (*ResourceSyncerOptions, error) {
 	return &ResourceSyncerOptions{
 		ComponentConfig: syncerconfig.SyncerConfiguration{
-			LeaderElection:   syncerconfig.SyncerLeaderElectionConfiguration{},
-			ClientConnection: componentbaseconfig.ClientConnectionConfiguration{},
+			LeaderElection:            syncerconfig.SyncerLeaderElectionConfiguration{},
+			ClientConnection:          componentbaseconfig.ClientConnectionConfiguration{},
+			EnableTenantKubeConfig:    false,
+			TenantKubeConfigMountPath: "/var/run/vc",
 		},
+		Address:  "",
+		Port:     "80",
+		CertFile: "",
+		KeyFile:  "",
 	}, nil
 }
 
 func (o *ResourceSyncerOptions) Flags() cliflag.NamedFlagSets {
 	fss := cliflag.NamedFlagSets{}
 
-	fs := fss.FlagSet("misc")
+	fs := fss.FlagSet("")
 	fs.StringVar(&o.SuperMaster, "super-master", o.SuperMaster, "The address of the super master Kubernetes API server (overrides any value in super-master-kubeconfig).")
 	fs.StringVar(&o.ComponentConfig.ClientConnection.Kubeconfig, "super-master-kubeconfig", o.ComponentConfig.ClientConnection.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
+	fs.BoolVar(&o.ComponentConfig.EnableTenantKubeConfig, "enable-tenant-kubeconfig", o.ComponentConfig.EnableTenantKubeConfig, "EnableTenantKubeConfig specifies whether to mount a tenant kubeconfig which is generated from tenant service account or not.")
+	fs.StringVar(&o.ComponentConfig.TenantKubeConfigMountPath, "tenant-kubeconfig-mount-path", o.ComponentConfig.TenantKubeConfigMountPath, "TenantKubeConfigMountPath specifies where the tenant kubeconfig to mount.")
 
 	serverFlags := fss.FlagSet("server")
-	serverFlags.StringVar(&o.Address, "address", "", "The server address.")
-	serverFlags.StringVar(&o.Port, "port", "80", "The server port.")
-	serverFlags.StringVar(&o.CertFile, "cert-file", "", "CertFile is the file containing x509 Certificate for HTTPS.")
-	serverFlags.StringVar(&o.KeyFile, "key-file", "", "KeyFile is the file containing x509 private key matching certFile.")
+	serverFlags.StringVar(&o.Address, "address", o.Address, "The server address.")
+	serverFlags.StringVar(&o.Port, "port", o.Port, "The server port.")
+	serverFlags.StringVar(&o.CertFile, "cert-file", o.CertFile, "CertFile is the file containing x509 Certificate for HTTPS.")
+	serverFlags.StringVar(&o.KeyFile, "key-file", o.KeyFile, "KeyFile is the file containing x509 private key matching certFile.")
 
 	BindFlags(&o.ComponentConfig.LeaderElection, fss.FlagSet("leader election"))
 

--- a/incubator/virtualcluster/cmd/syncer/app/options/options.go
+++ b/incubator/virtualcluster/cmd/syncer/app/options/options.go
@@ -63,10 +63,11 @@ type ResourceSyncerOptions struct {
 func NewResourceSyncerOptions() (*ResourceSyncerOptions, error) {
 	return &ResourceSyncerOptions{
 		ComponentConfig: syncerconfig.SyncerConfiguration{
-			LeaderElection:            syncerconfig.SyncerLeaderElectionConfiguration{},
-			ClientConnection:          componentbaseconfig.ClientConnectionConfiguration{},
-			EnableTenantKubeConfig:    false,
-			TenantKubeConfigMountPath: "/var/run/vc",
+			LeaderElection:             syncerconfig.SyncerLeaderElectionConfiguration{},
+			ClientConnection:           componentbaseconfig.ClientConnectionConfiguration{},
+			EnableTenantKubeConfig:     false,
+			TenantKubeConfigMountPath:  "/var/run/vc",
+			DisableServiceAccountToken: true,
 		},
 		Address:  "",
 		Port:     "80",
@@ -83,6 +84,7 @@ func (o *ResourceSyncerOptions) Flags() cliflag.NamedFlagSets {
 	fs.StringVar(&o.ComponentConfig.ClientConnection.Kubeconfig, "super-master-kubeconfig", o.ComponentConfig.ClientConnection.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
 	fs.BoolVar(&o.ComponentConfig.EnableTenantKubeConfig, "enable-tenant-kubeconfig", o.ComponentConfig.EnableTenantKubeConfig, "EnableTenantKubeConfig specifies whether to mount a tenant kubeconfig which is generated from tenant service account or not.")
 	fs.StringVar(&o.ComponentConfig.TenantKubeConfigMountPath, "tenant-kubeconfig-mount-path", o.ComponentConfig.TenantKubeConfigMountPath, "TenantKubeConfigMountPath specifies where the tenant kubeconfig to mount.")
+	fs.BoolVar(&o.ComponentConfig.DisableServiceAccountToken, "disable-service-account-token", o.ComponentConfig.DisableServiceAccountToken, "DisableServiceAccountToken indicates whether disable service account token automatically mounted.")
 
 	serverFlags := fss.FlagSet("server")
 	serverFlags.StringVar(&o.Address, "address", o.Address, "The server address.")

--- a/incubator/virtualcluster/cmd/syncer/app/server.go
+++ b/incubator/virtualcluster/cmd/syncer/app/server.go
@@ -85,7 +85,8 @@ resource isolation policy specified in Tenant CRD.`,
 }
 
 func Run(cc *syncerconfig.CompletedConfig, stopCh <-chan struct{}) error {
-	ss := syncer.New(cc.SecretClient,
+	ss := syncer.New(&cc.ComponentConfig,
+		cc.SecretClient,
 		cc.VirtualClusterInformer,
 		cc.SuperMasterClient,
 		cc.SuperMasterInformerFactory)

--- a/incubator/virtualcluster/config/sampleswithspec/example_foo.yaml
+++ b/incubator/virtualcluster/config/sampleswithspec/example_foo.yaml
@@ -1,0 +1,7 @@
+apiVersion: samplecontroller.k8s.io/v1alpha1
+kind: Foo
+metadata:
+  name: example-foo
+spec:
+  deploymentName: example-foo
+  replicas: 1

--- a/incubator/virtualcluster/config/setup/sample_foo_controller.yaml
+++ b/incubator/virtualcluster/config/setup/sample_foo_controller.yaml
@@ -1,0 +1,92 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: foos.samplecontroller.k8s.io
+spec:
+  group: samplecontroller.k8s.io
+  version: v1alpha1
+  names:
+    kind: Foo
+    plural: foos
+  scope: Namespaced
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vc-sample-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: vc-test-role
+rules:
+- apiGroups:
+  - samplecontroller.k8s.io
+  resources:
+  - foos
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vc-test-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vc-test-role
+subjects:
+  - kind: ServiceAccount
+    name: vc-sample-controller
+    namespace: vc-sample-controller
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vc-sample-controller
+  namespace: vc-sample-controller
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vc-sample-controller
+  namespace: vc-sample-controller
+  labels:
+    app: vc-sample-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vc-sample-controller
+  template:
+    metadata:
+      labels:
+        app: vc-sample-controller
+    spec:
+      serviceAccountName: vc-sample-controller
+      containers:
+      - command:
+        - sample-controller
+        - -kubeconfig=/var/run/vc/kubeconfig
+        image: virtualcluster/sample-controller-amd64
+        imagePullPolicy: Always
+        name: controller

--- a/incubator/virtualcluster/pkg/syncer/apis/config/types.go
+++ b/incubator/virtualcluster/pkg/syncer/apis/config/types.go
@@ -21,7 +21,7 @@ import (
 	componentbaseconfig "k8s.io/component-base/config"
 )
 
-// SyncerConfiguration configures a syncer
+// SyncerConfiguration configures a syncer. It is read only during syncer life cycle.
 type SyncerConfiguration struct {
 	metav1.TypeMeta
 
@@ -31,6 +31,12 @@ type SyncerConfiguration struct {
 	// ClientConnection specifies the kubeconfig file and client connection
 	// settings for the proxy server to use when communicating with the apiserver.
 	ClientConnection componentbaseconfig.ClientConnectionConfiguration
+
+	// EnableTenantKubeConfig specifies whether to mount a tenant kubeconfig which is
+	// generated from tenant service account or not.
+	EnableTenantKubeConfig bool
+	// TenantKubeConfigMountPath specifies where the tenant kubeconfig to mount.
+	TenantKubeConfigMountPath string
 }
 
 // SyncerLeaderElectionConfiguration expands LeaderElectionConfiguration

--- a/incubator/virtualcluster/pkg/syncer/apis/config/types.go
+++ b/incubator/virtualcluster/pkg/syncer/apis/config/types.go
@@ -37,6 +37,8 @@ type SyncerConfiguration struct {
 	EnableTenantKubeConfig bool
 	// TenantKubeConfigMountPath specifies where the tenant kubeconfig to mount.
 	TenantKubeConfigMountPath string
+	// DisableServiceAccountToken indicates whether disable service account token automatically mounted.
+	DisableServiceAccountToken bool
 }
 
 // SyncerLeaderElectionConfiguration expands LeaderElectionConfiguration

--- a/incubator/virtualcluster/pkg/syncer/conversion/helper.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/helper.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"

--- a/incubator/virtualcluster/pkg/syncer/conversion/mutate.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/mutate.go
@@ -362,6 +362,15 @@ func PodMutateKubeConfig(vPod *v1.Pod, secret *v1.Secret, mountPath string) PodM
 	}
 }
 
+func PodMutateAutoMountServiceAccountToken(disable bool) PodMutator {
+	return func(p *podMutateCtx) error {
+		if disable {
+			p.pPod.Spec.AutomountServiceAccountToken = pointer.BoolPtr(false)
+		}
+		return nil
+	}
+}
+
 type ServiceMutateInterface interface {
 	Mutate(vService *v1.Service)
 }

--- a/incubator/virtualcluster/pkg/syncer/resources/configmap/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/configmap/controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
 )
@@ -39,6 +40,7 @@ type controller struct {
 }
 
 func Register(
+	config *config.SyncerConfiguration,
 	configMapClient v1core.ConfigMapsGetter,
 	configMapInformer coreinformers.ConfigMapInformer,
 	controllerManager *manager.ControllerManager,

--- a/incubator/virtualcluster/pkg/syncer/resources/endpoints/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/endpoints/controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
 )
@@ -39,6 +40,7 @@ type controller struct {
 }
 
 func Register(
+	config *config.SyncerConfiguration,
 	endpointsClient v1core.EndpointsGetter,
 	endpointsInformer coreinformers.EndpointsInformer,
 	controllerManager *manager.ControllerManager,

--- a/incubator/virtualcluster/pkg/syncer/resources/event/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/event/controller.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
 
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
@@ -53,6 +54,7 @@ type controller struct {
 }
 
 func Register(
+	config *config.SyncerConfiguration,
 	client v1core.EventsGetter,
 	informer coreinformers.Interface,
 	controllerManager *manager.ControllerManager,

--- a/incubator/virtualcluster/pkg/syncer/resources/namespace/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/namespace/controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
 )
@@ -39,6 +40,7 @@ type controller struct {
 }
 
 func Register(
+	config *config.SyncerConfiguration,
 	namespaceClient v1core.NamespacesGetter,
 	namespaceInformer coreinformers.NamespaceInformer,
 	controllerManager *manager.ControllerManager,

--- a/incubator/virtualcluster/pkg/syncer/resources/node/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/node/controller.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
 
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
@@ -51,6 +52,7 @@ type controller struct {
 }
 
 func Register(
+	config *config.SyncerConfiguration,
 	client v1core.NodesGetter,
 	nodeInformer coreinformers.NodeInformer,
 	controllerManager *manager.ControllerManager,

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/controller.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
 
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
@@ -36,6 +37,8 @@ import (
 )
 
 type controller struct {
+	// syncer configuration
+	config *config.SyncerConfiguration
 	// super master pod client
 	client v1core.CoreV1Interface
 	// super master informer/listers/synced functions
@@ -56,11 +59,13 @@ type controller struct {
 }
 
 func Register(
+	config *config.SyncerConfiguration,
 	client v1core.CoreV1Interface,
 	informer coreinformers.Interface,
 	controllerManager *manager.ControllerManager,
 ) {
 	c := &controller{
+		config:              config,
 		client:              client,
 		informer:            informer,
 		queue:               workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "super_master_pod"),

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/dws.go
@@ -324,6 +324,11 @@ func createKubeConfigByServiceAccount(saClient v1core.ServiceAccountInterface, s
 					Token: string(token),
 				},
 			}
+			cluster := cfg.Clusters[ctx.Cluster]
+			cluster.Server = "https://kubernetes.default"
+			cfg.Clusters = map[string]*clientcmdapi.Cluster{
+				ctx.Cluster: cluster,
+			}
 
 			out, err := clientcmd.Write(*cfg)
 			if err != nil {

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/dws.go
@@ -178,6 +178,7 @@ func (c *controller) reconcilePodCreate(cluster, namespace, name string, vPod *v
 
 	var ms = []conversion.PodMutator{
 		conversion.PodMutateDefault(vPod, vSecret, pSecret, services, nameServer),
+		conversion.PodMutateAutoMountServiceAccountToken(c.config.DisableServiceAccountToken),
 		conversion.PodAddExtensionMeta(vPod),
 	}
 

--- a/incubator/virtualcluster/pkg/syncer/resources/register.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/register.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/resources/configmap"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/resources/endpoints"
@@ -33,15 +34,15 @@ import (
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/resources/storageclass"
 )
 
-func Register(client clientset.Interface, informerFactory informers.SharedInformerFactory, controllerManager *manager.ControllerManager) {
-	namespace.Register(client.CoreV1(), informerFactory.Core().V1().Namespaces(), controllerManager)
-	pod.Register(client.CoreV1(), informerFactory.Core().V1(), controllerManager)
-	configmap.Register(client.CoreV1(), informerFactory.Core().V1().ConfigMaps(), controllerManager)
-	secret.Register(client.CoreV1(), informerFactory.Core().V1().Secrets(), controllerManager)
-	serviceaccount.Register(client.CoreV1(), informerFactory.Core().V1().ServiceAccounts(), controllerManager)
-	node.Register(client.CoreV1(), informerFactory.Core().V1().Nodes(), controllerManager)
-	service.Register(client.CoreV1(), informerFactory.Core().V1().Services(), controllerManager)
-	endpoints.Register(client.CoreV1(), informerFactory.Core().V1().Endpoints(), controllerManager)
-	event.Register(client.CoreV1(), informerFactory.Core().V1(), controllerManager)
-	storageclass.Register(client.StorageV1(), informerFactory.Storage().V1(), controllerManager)
+func Register(config *config.SyncerConfiguration, client clientset.Interface, informerFactory informers.SharedInformerFactory, controllerManager *manager.ControllerManager) {
+	namespace.Register(config, client.CoreV1(), informerFactory.Core().V1().Namespaces(), controllerManager)
+	pod.Register(config, client.CoreV1(), informerFactory.Core().V1(), controllerManager)
+	configmap.Register(config, client.CoreV1(), informerFactory.Core().V1().ConfigMaps(), controllerManager)
+	secret.Register(config, client.CoreV1(), informerFactory.Core().V1().Secrets(), controllerManager)
+	serviceaccount.Register(config, client.CoreV1(), informerFactory.Core().V1().ServiceAccounts(), controllerManager)
+	node.Register(config, client.CoreV1(), informerFactory.Core().V1().Nodes(), controllerManager)
+	service.Register(config, client.CoreV1(), informerFactory.Core().V1().Services(), controllerManager)
+	endpoints.Register(config, client.CoreV1(), informerFactory.Core().V1().Endpoints(), controllerManager)
+	event.Register(config, client.CoreV1(), informerFactory.Core().V1(), controllerManager)
+	storageclass.Register(config, client.StorageV1(), informerFactory.Storage().V1(), controllerManager)
 }

--- a/incubator/virtualcluster/pkg/syncer/resources/secret/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/secret/controller.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/klog"
 
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
 )
@@ -41,6 +42,7 @@ type controller struct {
 }
 
 func Register(
+	config *config.SyncerConfiguration,
 	secretClient v1core.CoreV1Interface,
 	secretInformer coreinformers.SecretInformer,
 	controllerManager *manager.ControllerManager,

--- a/incubator/virtualcluster/pkg/syncer/resources/service/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/service/controller.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
@@ -48,6 +49,7 @@ type controller struct {
 }
 
 func Register(
+	config *config.SyncerConfiguration,
 	serviceClient v1core.ServicesGetter,
 	serviceInformer coreinformers.ServiceInformer,
 	controllerManager *manager.ControllerManager,

--- a/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
 )
@@ -39,6 +40,7 @@ type controller struct {
 }
 
 func Register(
+	config *config.SyncerConfiguration,
 	client v1core.CoreV1Interface,
 	saInformer coreinformers.ServiceAccountInformer,
 	controllerManager *manager.ControllerManager,

--- a/incubator/virtualcluster/pkg/syncer/resources/storageclass/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/storageclass/controller.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
 
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
@@ -60,6 +61,7 @@ type scReconcileRequest struct {
 }
 
 func Register(
+	config *config.SyncerConfiguration,
 	client v1storage.StorageClassesGetter,
 	informer storageinformers.Interface,
 	controllerManager *manager.ControllerManager,

--- a/incubator/virtualcluster/pkg/syncer/syncer.go
+++ b/incubator/virtualcluster/pkg/syncer/syncer.go
@@ -31,7 +31,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
 
@@ -265,11 +264,11 @@ func (s *Syncer) addCluster(key string, vc *v1alpha1.Virtualcluster) error {
 	if err != nil {
 		return fmt.Errorf("failed to get secret (%s) for virtual cluster %s/%s: %v", KubeconfigAdmin, vc.Namespace, vc.Name, err)
 	}
-	clusterRestConfig, err := clientcmd.RESTConfigFromKubeConfig(adminKubeConfigSecret.Data[KubeconfigAdmin])
+
+	tenantCluster, err := cluster.NewTenantCluster(clusterName, vc.Spec.DeepCopy(), adminKubeConfigSecret.Data[KubeconfigAdmin], cluster.Options{})
 	if err != nil {
-		return fmt.Errorf("failed to build rest config for virtual cluster %s/%s: %v", vc.Namespace, vc.Name, err)
+		return fmt.Errorf("failed to new tenant cluster %s/%s: %v", vc.Namespace, vc.Name, err)
 	}
-	tenantCluster := cluster.NewTenantCluster(clusterName, vc.Spec.DeepCopy(), clusterRestConfig, cluster.Options{})
 
 	s.mu.Lock()
 	if _, exist := s.clusterSet[key]; exist {

--- a/incubator/virtualcluster/pkg/syncer/syncer.go
+++ b/incubator/virtualcluster/pkg/syncer/syncer.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
 	vcinformers "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/client/informers/externalversions/tenancy/v1alpha1"
 	vclisters "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/client/listers/tenancy/v1alpha1"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/cluster"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
@@ -73,6 +74,7 @@ type Bootstrap interface {
 }
 
 func New(
+	config *config.SyncerConfiguration,
 	secretClient v1core.SecretsGetter,
 	virtualClusterInformer vcinformers.VirtualclusterInformer,
 	superMasterClient clientset.Interface,
@@ -107,7 +109,7 @@ func New(
 	multiClusterControllerManager := manager.New()
 	syncer.controllerManager = multiClusterControllerManager
 
-	resources.Register(superMasterClient, superMasterInformers, multiClusterControllerManager)
+	resources.Register(config, superMasterClient, superMasterInformers, multiClusterControllerManager)
 
 	return syncer
 }

--- a/incubator/virtualcluster/pkg/syncer/utils/string.go
+++ b/incubator/virtualcluster/pkg/syncer/utils/string.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import "math/rand"
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyz")
+
+// GenAnAvailableName generate a unique valid name against the string slice passed in.
+// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+func GenAnAvailableName(names []string, prefix string, n int) string {
+	nameMap := make(map[string]struct{})
+	for _, name := range names {
+		nameMap[name] = struct{}{}
+	}
+
+	if n < len(prefix) {
+		panic("target string length cannot larger than the prefix one")
+	}
+
+	for {
+		b := make([]rune, n-len(prefix))
+		for i := range b {
+			b[i] = letters[rand.Intn(len(letters))]
+		}
+
+		ans := prefix + string(b)
+
+		if _, exists := nameMap[prefix+string(b)]; !exists {
+			return ans
+		}
+	}
+}


### PR DESCRIPTION
This change provide a way to access to pod's own master using a kubeconfig.

- [x] create a kubeconfig according to service account when creating pod
- [x] find a mount point and mounts a configmap to pod
- [x] using a flag to control this logic
- [x] provide a sample controller yaml

Signed-off-by: zhuangqh <zhuangqhc@gmail.com>