### PR TITLE
[Incubator][VC]Implement vNode Garbage Collection

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/constants/constants.go
+++ b/incubator/virtualcluster/pkg/syncer/constants/constants.go
@@ -17,6 +17,8 @@ limitations under the License.
 package constants
 
 import (
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -52,6 +54,9 @@ const (
 	PublicObjectKey = "tenancy.x-k8s.io/super.public"
 
 	LabelVirtualNode = "tenancy.x-k8s.io/virtualnode"
+
+	// DefaultvNodeGCGracePeriod is the grace period of time before deleting an orphan vNode in tenant master.
+	DefaultvNodeGCGracePeriod = time.Second * 120
 )
 
 const (

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/checker.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
 )
@@ -48,10 +49,86 @@ func (c *controller) StartPeriodChecker(stopCh <-chan struct{}) error {
 		return fmt.Errorf("failed to wait for caches to sync before starting Pod checker")
 	}
 
+	// Start a loop to do periodic GC of unused(orphan) vNodes in tenant masters.
+	go c.vNodeGCWorker(stopCh)
+
 	// Start a loop to periodically check if pods keep consistency between super
 	// master and tenant masters.
 	wait.Until(c.checkPods, c.periodCheckerPeriod, stopCh)
+
 	return nil
+}
+
+func (c *controller) vNodeGCWorker(stopCh <-chan struct{}) {
+	klog.Infof("Start VNode GarbageCollector")
+	wait.Until(c.vNodeGCDo, c.periodCheckerPeriod, stopCh)
+}
+
+type Candidate struct {
+	cluster  string
+	nodeName string
+}
+
+func (c *controller) vNodeGCDo() {
+
+	candidates := func() []Candidate {
+		c.Lock()
+		defer c.Unlock()
+		var candidates []Candidate
+		for cluster, nodeMap := range c.clusterVNodeGCMap {
+			for nodeName, status := range nodeMap {
+				if status.Phase == VNodeQuiescing && metav1.Now().After(status.QuiesceStartTime.Add(constants.DefaultvNodeGCGracePeriod)) {
+					c.clusterVNodeGCMap[cluster][nodeName] = VNodeGCStatus{
+						QuiesceStartTime: status.QuiesceStartTime,
+						Phase:            VNodeDeleting,
+					}
+					candidates = append(candidates, Candidate{cluster: cluster, nodeName: nodeName})
+				} else if status.Phase == VNodeDeleting {
+					candidates = append(candidates, Candidate{cluster: cluster, nodeName: nodeName})
+				}
+			}
+		}
+		return candidates
+	}()
+
+	if len(candidates) == 0 {
+		return
+	}
+
+	wg := sync.WaitGroup{}
+	for _, candidate := range candidates {
+		wg.Add(1)
+		go func(cluster, nodeName string) {
+			defer wg.Done()
+			c.deleteClusterVNode(cluster, nodeName)
+		}(candidate.cluster, candidate.nodeName)
+	}
+	wg.Wait()
+}
+
+func (c *controller) deleteClusterVNode(cluster, nodeName string) {
+	tenantClient, err := c.multiClusterPodController.GetClusterClient(cluster)
+	if err != nil {
+		klog.Infof("cluster is removed, clear clusterVNodeGCMap entry for cluster %s", cluster)
+		c.Lock()
+		delete(c.clusterVNodeGCMap, cluster)
+		c.Unlock()
+		return
+	}
+	opts := metav1.NewDeleteOptions(0)
+	opts.PropagationPolicy = &constants.DefaultDeletionPolicy
+
+	tenantClient.CoreV1().Nodes().Delete(nodeName, opts)
+	// We need to double check here.
+	if _, err := tenantClient.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{}); err != nil {
+		if !errors.IsNotFound(err) {
+			// If we cannot get the state from tenant apiserver, retry
+			return
+		}
+	}
+	c.Lock()
+	delete(c.clusterVNodeGCMap[cluster], nodeName)
+	c.Unlock()
 }
 
 // checkPods checks to see if pods in super master informer cache and tenant master
@@ -70,6 +147,7 @@ func (c *controller) checkPods() {
 		go func(clusterName string) {
 			defer wg.Done()
 			c.checkPodsOfTenantCluster(clusterName)
+			c.checkNodesOfTenantCluster(clusterName)
 		}(clusterName)
 	}
 	wg.Wait()
@@ -163,5 +241,48 @@ func (c *controller) checkPodsOfTenantCluster(clusterName string) {
 		if updatedPod != nil {
 			klog.Warningf("spec of pod %v/%v diff in super&tenant master", vPod.Namespace, vPod.Name)
 		}
+	}
+}
+
+// checkNodesOfTenantCluster checks if any orphan vNode is missed in c.clusterVNodeGCMap, which can happen if syncer
+// is restarted.
+// Note that this method can be expensive since it cannot leverage pod mccontroller informer cache. The List query
+// goes to tenant master directly. If this method causes performance issue, we should consider moving it to another
+// periodic thread with a larger check interval.
+func (c *controller) checkNodesOfTenantCluster(clusterName string) {
+	tenantClient, err := c.multiClusterPodController.GetClusterClient(clusterName)
+	if err != nil {
+		klog.Errorf("failed to create client from cluster %s config: %v", clusterName, err)
+		return
+	}
+
+	nodeList, err := tenantClient.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		klog.Errorf("failed to list vNode from cluster %s config: %v", clusterName, err)
+		return
+	}
+
+	for _, vNode := range nodeList.Items {
+		if vNode.Labels[constants.LabelVirtualNode] != "true" {
+			continue
+		}
+		func() {
+			c.Lock()
+			defer c.Unlock()
+			if _, exist := c.clusterVNodePodMap[clusterName]; exist {
+				if _, exist := c.clusterVNodePodMap[clusterName][vNode.Name]; exist {
+					// Active Node
+					return
+				}
+			}
+			if _, exist := c.clusterVNodeGCMap[clusterName]; exist {
+				if _, exist := c.clusterVNodeGCMap[clusterName][vNode.Name]; exist {
+					// In GC list already
+					return
+				}
+			}
+			klog.Infof("find an orphan vNode %s missing in GC list in cluster %s", vNode.Name, clusterName)
+			c.addToClusterVNodeGCMap(clusterName, vNode.Name)
+		}()
 	}
 }

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/checker.go
@@ -70,7 +70,6 @@ type Candidate struct {
 }
 
 func (c *controller) vNodeGCDo() {
-
 	candidates := func() []Candidate {
 		c.Lock()
 		defer c.Unlock()

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/controller.go
@@ -173,10 +173,9 @@ func (c *controller) addToClusterVNodeGCMap(cluster string, nodeName string) {
 		QuiesceStartTime: metav1.Now(),
 		Phase:            VNodeQuiescing,
 	}
-
 }
 
-// c.Mutex needs to be Locked before calling removeFromClusterVNodeGCMap
+// c.Mutex needs to be Locked before calling removeQuiescingNodeFromClusterVNodeGCMap
 func (c *controller) removeQuiescingNodeFromClusterVNodeGCMap(cluster string, nodeName string) bool {
 	if _, exist := c.clusterVNodeGCMap[cluster]; exist {
 		if _, exist := c.clusterVNodeGCMap[cluster][nodeName]; exist {

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/controller.go
@@ -18,9 +18,11 @@ package pod
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -33,6 +35,7 @@ import (
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
 )
 
 type controller struct {
@@ -53,6 +56,22 @@ type controller struct {
 	queue   workqueue.RateLimitingInterface
 	// Checker timer
 	periodCheckerPeriod time.Duration
+	// Cluster vNode PodMap and GCMap, needed for vNode garbage collection
+	sync.Mutex
+	clusterVNodePodMap map[string]map[string]map[string]struct{}
+	clusterVNodeGCMap  map[string]map[string]VNodeGCStatus
+}
+
+type VirtulNodeDeletionPhase string
+
+const (
+	VNodeQuiescing VirtulNodeDeletionPhase = "Quiescing"
+	VNodeDeleting  VirtulNodeDeletionPhase = "Deleting"
+)
+
+type VNodeGCStatus struct {
+	QuiesceStartTime metav1.Time
+	Phase            VirtulNodeDeletionPhase
 }
 
 func Register(
@@ -66,6 +85,8 @@ func Register(
 		queue:               workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "super_master_pod"),
 		workers:             constants.DefaultControllerWorkers,
 		periodCheckerPeriod: 60 * time.Second,
+		clusterVNodePodMap:  make(map[string]map[string]map[string]struct{}),
+		clusterVNodeGCMap:   make(map[string]map[string]VNodeGCStatus),
 	}
 
 	// Create the multi cluster pod controller
@@ -141,6 +162,73 @@ func (c *controller) enqueuePod(obj interface{}) {
 	}
 
 	c.queue.Add(key)
+}
+
+// c.Mutex needs to be Locked before calling addToClusterVNodeGCMap
+func (c *controller) addToClusterVNodeGCMap(cluster string, nodeName string) {
+	if _, exist := c.clusterVNodeGCMap[cluster]; !exist {
+		c.clusterVNodeGCMap[cluster] = make(map[string]VNodeGCStatus)
+	}
+	c.clusterVNodeGCMap[cluster][nodeName] = VNodeGCStatus{
+		QuiesceStartTime: metav1.Now(),
+		Phase:            VNodeQuiescing,
+	}
+
+}
+
+// c.Mutex needs to be Locked before calling removeFromClusterVNodeGCMap
+func (c *controller) removeQuiescingNodeFromClusterVNodeGCMap(cluster string, nodeName string) bool {
+	if _, exist := c.clusterVNodeGCMap[cluster]; exist {
+		if _, exist := c.clusterVNodeGCMap[cluster][nodeName]; exist {
+			if c.clusterVNodeGCMap[cluster][nodeName].Phase == VNodeQuiescing {
+				delete(c.clusterVNodeGCMap[cluster], nodeName)
+				return true
+			} else {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (c *controller) updateClusterVNodePodMap(cluster string, vPod *v1.Pod, event reconciler.EventType) {
+	nodeName := vPod.Spec.NodeName
+	if nodeName == "" || !isPodScheduled(vPod) {
+		return
+	}
+	func() {
+		c.Lock()
+		defer c.Unlock()
+		if event == reconciler.AddEvent || event == reconciler.UpdateEvent {
+			if _, exist := c.clusterVNodePodMap[cluster]; !exist {
+				c.clusterVNodePodMap[cluster] = make(map[string]map[string]struct{})
+			}
+			if _, exist := c.clusterVNodePodMap[cluster][nodeName]; !exist {
+				c.clusterVNodePodMap[cluster][nodeName] = make(map[string]struct{})
+			}
+			c.clusterVNodePodMap[cluster][nodeName][vPod.Name] = struct{}{}
+			if !c.removeQuiescingNodeFromClusterVNodeGCMap(cluster, nodeName) {
+				// We have consistency issue here. TODO: add to metrics
+				klog.Errorf("Cluster %s has vPods in vNode %s which is being GCed!", cluster, nodeName)
+			}
+		} else { // delete
+			if _, exist := c.clusterVNodePodMap[cluster][nodeName]; exist {
+				if _, exist := c.clusterVNodePodMap[cluster][nodeName][vPod.Name]; exist {
+					delete(c.clusterVNodePodMap[cluster][nodeName], vPod.Name)
+				} else {
+					klog.Warningf("The nodename %s of deleted pod %s in cluster (%s) is not found in clusterVNodePodMap", nodeName, vPod.Name, cluster)
+				}
+
+				// If vNode does not have any Pod left, put it into gc map
+				if len(c.clusterVNodePodMap[cluster][nodeName]) == 0 {
+					c.addToClusterVNodeGCMap(cluster, nodeName)
+					delete(c.clusterVNodePodMap[cluster], nodeName)
+				}
+			} else {
+				klog.Warningf("Deleted pod %s of cluster (%s) is not found in clusterVNodePodMap", vPod.Name, cluster)
+			}
+		}
+	}()
 }
 
 func (c *controller) AddCluster(cluster mc.ClusterInterface) {


### PR DESCRIPTION
This change implements removing orphan vNode in tenant master. Orphan vNode means no Pods in the tenant master are bound to it, which can happen when vPod is deleted or recreated and bound to another vNode.  vNode is created by Syncer only. 

Why do we need to do this?
- Less pressure on sending vNode heartbeats to tenant master. If we don't do vNode GC, there could accumulate a lot of orphan vNodes in tenant master overtime.
- Better user serverless experience - you see what you use.

Technical challenges 
- K8s does not provide multi-objects consistency semantic. Even though Pod and the bound node are associated, APIServer does not provide an atomic way to perform "delete a node if no pods are bound to it". 
- From syncer's perspective, the biggest race is that uws tries to bind a vPod to a vNode and the GC thread tries to delete the vNode from tenant master. Without APISever support, it is impossible to completely resolve the race. In the worst case, a vPod is bound to a vNode and the vNode is removed by GC thread right away.  

Solutions
The problem can be divided to two parts:
- Find orphan vNodes: This is done by tracking vPod and vNode association in Pod mccontroller dws thread using `clusterVNodePodMap`. Upon vPod deletion event, if we found no more Pods are available in the vNode, the vNode is moved to `clusterVNodeGCMap` as a GC candidate. 
- GC vNode: To avoid accidentally deleting a vNode which is just bound to a vPod by uws, we introduce a grace period for removing an orphan vNode. A vNode GC candidate has two deletion phases, `VNodeQuiescing` and `VNodeDeleting`. 
    - In `VNodeQuiescing` phase, if any vPod is found associated with this vNode or uws attempts to bind a vPod on it, it is removed from `clusterVNodeGCMap`. 
    - If a vNode has been in `VNodeQuiescing` phase for more than `DefaultvNodeGCGracePeriod`, the GC thread will change the vNode to `VNodeDeleting` phase and issue the delete API to remove the vNode from tenant master. Once we confirmed the vNode is deleted, the vNode is removed from `clusterVNodeGCMap`.
    - If uws attempts to bind a vPod to a vNode and the vNode is in `VNodeDeleting` phase, uws will retry until the vNode is removed from APIServer.

The above solution still cannot handle a case - a uws bind API call for some reason takes more than `DefaultvNodeGCGracePeriod`, the race may still happen. However, if we set `DefaultvNodeGCGracePeriod` long enough, the race practically should be extremely rare. 

Finally, syncer restart may cause some orphan vNodes left in tenant master, and they will not be picked up by GC thread after syncer is restarted. To resolve the problem, we still periodically check tenant master to find missing orphan vNodes leveraging the Pod checker thread. This check can be somehow expensive and may be invoked with a much slower rate if necessary.






