### PR TITLE
[Incubator][VC] Update the apiserver's certificate of the Virtualcluster during the runtime

### DIFF
--- a/incubator/virtualcluster/Makefile
+++ b/incubator/virtualcluster/Makefile
@@ -78,7 +78,7 @@ release-images: test build-images
 # 1. build all binaries.
 # 2. copy binaries to the corresponding docker image.
 build-images:
-	hack/make-rules/release-images.sh
+	hack/make-rules/release-images.sh $(WHAT)
 
 # Push the docker image
 docker-push:

--- a/incubator/virtualcluster/config/crds/tenancy_v1alpha1_clusterversion.yaml
+++ b/incubator/virtualcluster/config/crds/tenancy_v1alpha1_clusterversion.yaml
@@ -10,6 +10,8 @@ spec:
   names:
     kind: ClusterVersion
     plural: clusterversions
+    shortNames:
+    - cv
   scope: Cluster
   validation:
     openAPIV3Schema:

--- a/incubator/virtualcluster/config/crds/tenancy_v1alpha1_virtualcluster.yaml
+++ b/incubator/virtualcluster/config/crds/tenancy_v1alpha1_virtualcluster.yaml
@@ -10,6 +10,8 @@ spec:
   names:
     kind: Virtualcluster
     plural: virtualclusters
+    shortNames:
+    - vc
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/incubator/virtualcluster/config/rbac/rbac_role.yaml
+++ b/incubator/virtualcluster/config/rbac/rbac_role.yaml
@@ -105,6 +105,26 @@ rules:
   - update
   - patch
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
   - tenancy.x-k8s.io
   resources:
   - virtualclusters

--- a/incubator/virtualcluster/config/sampleswithspec/clusterversion_v1_nodeport.yaml
+++ b/incubator/virtualcluster/config/sampleswithspec/clusterversion_v1_nodeport.yaml
@@ -122,7 +122,7 @@ spec:
             component-name: apiserver
         # apiserver will not be updated, unless it is deleted
         updateStrategy:
-          type: OnDelete
+          type: RollingUpdate
         template:
           metadata:
             labels:
@@ -132,7 +132,7 @@ spec:
             subdomain: apiserver-svc
             containers:
             - name: apiserver
-              image: virtualcluster/apiserver-v1.15.4
+              image: virtualcluster/apiserver-v1.16.2
               imagePullPolicy: Always
               command:
               - kube-apiserver
@@ -151,6 +151,10 @@ spec:
               - --etcd-cafile=/etc/kubernetes/pki/root/tls.crt
               - --etcd-certfile=/etc/kubernetes/pki/apiserver/tls.crt
               - --etcd-keyfile=/etc/kubernetes/pki/apiserver/tls.key
+              - --proxy-client-key-file=/etc/kubernetes/pki/apiserver/tls.key
+              - --proxy-client-cert-file=/etc/kubernetes/pki/apiserver/tls.crt
+              - --requestheader-client-ca-file=/etc/kubernetes/pki/root/tls.crt
+              - --requestheader-allowed-names=""
               - --service-account-key-file=/etc/kubernetes/pki/service-account/tls.key
               - --service-cluster-ip-range=10.32.0.0/16
               - --service-node-port-range=30000-32767
@@ -234,7 +238,7 @@ spec:
           matchLabels:
             component-name: controller-manager
         updateStrategy:
-          type: OnDelete
+          type: RollingUpdate
         template:
           metadata:
             labels:
@@ -242,7 +246,7 @@ spec:
           spec:
             containers:
             - name: controller-manager
-              image: virtualcluster/controller-manager-v1.15.4
+              image: virtualcluster/controller-manager-v1.16.2
               imagePullPolicy: Always
               command:
               - kube-controller-manager

--- a/incubator/virtualcluster/config/setup/all_in_one.yaml
+++ b/incubator/virtualcluster/config/setup/all_in_one.yaml
@@ -52,6 +52,26 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - get

--- a/incubator/virtualcluster/hack/make-rules/release-images.sh
+++ b/incubator/virtualcluster/hack/make-rules/release-images.sh
@@ -17,5 +17,5 @@
 VC_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 source "${VC_ROOT}/hack/lib/init.sh"
 
-build_binaries
-build_images
+build_binaries "$@"
+build_images "$@"

--- a/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1/virtualcluster_types.go
+++ b/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1/virtualcluster_types.go
@@ -71,11 +71,18 @@ const (
 	// Cluster is processed by Operator, but not all components are ready
 	ClusterPending ClusterPhase = "Pending"
 
-	// All components are ready
+	// All components are running
+	// NOTE when cluster is in this state, pod can't visit the master of
+	// the virtualcluster from inside the cluster by using service account
 	ClusterRunning ClusterPhase = "Running"
 
 	// when update cluster spec, phase will be updating
 	ClusterUpdating ClusterPhase = "Updating"
+
+	// The cluster is ready
+	// NOTE cluster in this state allows in-cluster master visiting, and can
+	// pass the conformance test of Kubernetes version 1.15
+	ClusterReady ClusterPhase = "Ready"
 
 	// Cluster can not be initiated, or occur the error that Operator
 	// can not recover

--- a/incubator/virtualcluster/pkg/controller/pki/pki.go
+++ b/incubator/virtualcluster/pkg/controller/pki/pki.go
@@ -51,7 +51,7 @@ type ClusterCAGroup struct {
 }
 
 // NewAPIServerCertAndKey creates crt and key for apiserver using ca.
-func NewAPIServerCrtAndKey(ca *CrtKeyPair, vc *tenancyv1alpha1.Virtualcluster, apiserverDomain string) (*CrtKeyPair, error) {
+func NewAPIServerCrtAndKey(ca *CrtKeyPair, vc *tenancyv1alpha1.Virtualcluster, apiserverDomain string, IPs ...string) (*CrtKeyPair, error) {
 	clusterDomain := defaultClusterDomain
 	if vc.Spec.ClusterDomain != "" {
 		clusterDomain = vc.Spec.ClusterDomain
@@ -68,6 +68,9 @@ func NewAPIServerCrtAndKey(ca *CrtKeyPair, vc *tenancyv1alpha1.Virtualcluster, a
 			// add virtual cluster name (i.e. namespace) for vn-agent
 			vc.Name,
 		},
+	}
+	for _, ip := range IPs {
+		altNames.IPs = append(altNames.IPs, net.ParseIP(ip))
 	}
 
 	config := &cert.Config{

--- a/incubator/virtualcluster/pkg/syncer/syncer.go
+++ b/incubator/virtualcluster/pkg/syncer/syncer.go
@@ -93,7 +93,8 @@ func New(
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				newVC := newObj.(*v1alpha1.Virtualcluster)
 				oldVC := oldObj.(*v1alpha1.Virtualcluster)
-				if newVC.ResourceVersion == oldVC.ResourceVersion {
+				if newVC.ResourceVersion == oldVC.ResourceVersion ||
+					oldVC.Status.Phase == v1alpha1.ClusterUpdating {
 					return
 				}
 				syncer.enqueueVirtualCluster(newObj)


### PR DESCRIPTION
Update the apiserver's certificate of the Virtualcluster to allow the pod

to visit the apiserver from inside the cluster. New creation steps including,

  * wait for the default/kubernetes svc being synced to super master,
  * regenerate a certificate for the apiserver of the vc by adding the clusterIP of 
     the svc that is corresponding to the default/kubernetes on the super master
  * change the vc status to Updating,
  * delete the apiserver pod,
  * wait for apiserver pod being recreated by the statefulset controller,
  * change the vc status to Ready

Other minor changes,

  * change Makefile to allow building image for specific binaries
  * add auxiliary fields (e.g. shortNames) to vc and cv yamls
  * encapsulate common functionality (e.g. polling Statefulset, update VC status)