### PR TITLE
[Incubator][VC]Add clusterIP of the default/kubernetes service to apiserver's certificate

### DIFF
--- a/incubator/virtualcluster/Makefile
+++ b/incubator/virtualcluster/Makefile
@@ -78,7 +78,7 @@ release-images: test build-images
 # 1. build all binaries.
 # 2. copy binaries to the corresponding docker image.
 build-images:
-	hack/make-rules/release-images.sh
+	hack/make-rules/release-images.sh $(WHAT)
 
 # Push the docker image
 docker-push:

--- a/incubator/virtualcluster/hack/make-rules/release-images.sh
+++ b/incubator/virtualcluster/hack/make-rules/release-images.sh
@@ -17,5 +17,5 @@
 VC_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 source "${VC_ROOT}/hack/lib/init.sh"
 
-build_binaries
-build_images
+build_binaries "$@"
+build_images "$@"

--- a/incubator/virtualcluster/pkg/controller/pki/pki.go
+++ b/incubator/virtualcluster/pkg/controller/pki/pki.go
@@ -51,7 +51,7 @@ type ClusterCAGroup struct {
 }
 
 // NewAPIServerCertAndKey creates crt and key for apiserver using ca.
-func NewAPIServerCrtAndKey(ca *CrtKeyPair, vc *tenancyv1alpha1.Virtualcluster, apiserverDomain string) (*CrtKeyPair, error) {
+func NewAPIServerCrtAndKey(ca *CrtKeyPair, vc *tenancyv1alpha1.Virtualcluster, apiserverDomain string, apiserverIPs ...string) (*CrtKeyPair, error) {
 	clusterDomain := defaultClusterDomain
 	if vc.Spec.ClusterDomain != "" {
 		clusterDomain = vc.Spec.ClusterDomain
@@ -68,6 +68,12 @@ func NewAPIServerCrtAndKey(ca *CrtKeyPair, vc *tenancyv1alpha1.Virtualcluster, a
 			// add virtual cluster name (i.e. namespace) for vn-agent
 			vc.Name,
 		},
+	}
+
+	for _, ip := range apiserverIPs {
+		if ip != "" {
+			altNames.IPs = append(altNames.IPs, net.ParseIP(ip))
+		}
 	}
 
 	config := &cert.Config{

--- a/incubator/virtualcluster/pkg/controller/util/kube/util.go
+++ b/incubator/virtualcluster/pkg/controller/util/kube/util.go
@@ -17,8 +17,17 @@ limitations under the License.
 package kube
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // the namespace of the pod can be found in this file
@@ -34,4 +43,68 @@ func GetPodNsFromInside() (string, error) {
 		return "", fmt.Errorf("can't get namespace from file %s", svcAccountPath)
 	}
 	return string(fileContentByt), nil
+}
+
+// GetSvcClusterIP gets the ClusterIP of the service 'namespace/name'
+func GetSvcClusterIP(cli client.Client, namespace, name string) (string, error) {
+	svc := &v1.Service{}
+	if err := cli.Get(context.TODO(), types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}, svc); err != nil {
+		return "", err
+	}
+	if svc.Spec.ClusterIP == "" {
+		return "", fmt.Errorf("the clusterIP of service %s is not set", namespace+"/"+name)
+	}
+	return svc.Spec.ClusterIP, nil
+}
+
+// WaitStatefulSetReady checks if the statefulset 'namespace/name' can be ready within
+// the 'timeout'
+func WaitStatefulSetReady(cli client.Client, namespace, name string, timeOutSec, periodSec int64) error {
+	timeOut := time.After(time.Duration(timeOutSec) * time.Second)
+	for {
+		period := time.After(time.Duration(periodSec) * time.Second)
+		select {
+		case <-timeOut:
+			return fmt.Errorf("%s/%s is not ready in %s seconds", timeOutSec)
+		case <-period:
+			sts := &appsv1.StatefulSet{}
+			if err := cli.Get(context.TODO(), types.NamespacedName{
+				Namespace: namespace,
+				Name:      name,
+			}, sts); err != nil {
+				return err
+			}
+			if sts.Status.ReadyReplicas == *sts.Spec.Replicas {
+				return nil
+			}
+		}
+	}
+}
+
+// CreateNS create namespace 'nsName' by client 'cli'
+func CreateNS(cli client.Client, nsName string) error {
+	err := cli.Create(context.TODO(), &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nsName,
+		},
+	})
+	if apierrors.IsAlreadyExists(err) {
+		return nil
+	}
+	return err
+}
+
+// RemoveNS removes namespace 'nsName' by client 'cli'
+func RemoveNS(cli client.Client, nsName string) error {
+	if err := cli.Delete(context.TODO(), &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nsName,
+		},
+	}); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
 }

--- a/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_native.go
+++ b/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_native.go
@@ -21,24 +21,31 @@ import (
 	"crypto/rsa"
 	"errors"
 	"fmt"
-	"time"
 
-	tenancyv1alpha1 "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/kubeconfig"
-	vcpki "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/pki"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/secret"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
-	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/util/cert"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	tenancyv1alpha1 "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/kubeconfig"
+	vcpki "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/pki"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/secret"
+	kubeutil "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/util/kube"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+)
+
+const (
+	DefaultETCDPeerPort    = 2380
+	ComponentPollPeriodSec = 2
+	// timeout for components deployment
+	DeployTimeOutSec = 180
 )
 
 type MasterProvisionerNative struct {
@@ -67,37 +74,72 @@ func (mpn *MasterProvisionerNative) CreateVirtualCluster(vc *tenancyv1alpha1.Vir
 			vc.Spec.ClusterVersionName)
 		return err
 	}
+	rootNS := conversion.ToClusterKey(vc)
+	defaultNS := conversion.ToClusterKey(vc) + "-default"
 	defer func() {
 		if err != nil {
-			log.Error(err, "fail to create virtualcluster, remove namespace for deleting related resources")
+			log.Error(err, "fail to create virtualcluster, removing namespaces for deleting related resources")
+			if rmNSErr := kubeutil.RemoveNS(mpn, rootNS); rmNSErr != nil {
+				log.Error(err, "fail to remove namespace", "namespace", rootNS)
+			}
+			if rmNSErr := kubeutil.RemoveNS(mpn, defaultNS); rmNSErr != nil {
+				log.Error(err, "fail to remove namespace", "namespace", defaultNS)
+			}
 		}
 	}()
 
-	// 1. create ns
-	err = mpn.createNS(vc)
+	// 1. create the root ns
+	err = kubeutil.CreateNS(mpn, rootNS)
 	if err != nil {
 		return err
 	}
 
-	// 2. create PKI
+	// 2. create the default ns and default/kubernetes svc
+	err = kubeutil.CreateNS(mpn, defaultNS)
+	if err != nil {
+		return err
+	}
+	err = mpn.Create(context.TODO(), &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubernetes",
+			Namespace: defaultNS,
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Name:       "https",
+					Port:       443,
+					Protocol:   "TCP",
+					TargetPort: intstr.FromInt(6443),
+				},
+			},
+			SessionAffinity: v1.ServiceAffinityNone,
+			Type:            v1.ServiceTypeClusterIP,
+		},
+	})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	// 3. create PKI
 	err = mpn.createPKI(vc, cv)
 	if err != nil {
 		return err
 	}
 
-	// 3. deploy etcd
+	// 4. deploy etcd
 	err = mpn.deployComponent(vc, cv.Spec.ETCD)
 	if err != nil {
 		return err
 	}
 
-	// 4. deploy apiserver
+	// 5. deploy apiserver
 	err = mpn.deployComponent(vc, cv.Spec.APIServer)
 	if err != nil {
 		return err
 	}
 
-	// 5. deploy controller-manager
+	// 6. deploy controller-manager
 	err = mpn.deployComponent(vc, cv.Spec.ControllerManager)
 	if err != nil {
 		return err
@@ -188,29 +230,12 @@ func (mpn *MasterProvisionerNative) deployComponent(vc *tenancyv1alpha1.Virtualc
 		}
 	}
 
-	// make sure the StatsfulSet is ready
-	// (i.e. Status.ReadyReplicas == Spec.Replicas)
-	timeout := time.After(DeployTimeOut)
-	for {
-		period := time.After(ComponentPollPeriod)
-		select {
-		case <-timeout:
-			return fmt.Errorf("deploy %s timeout", ssBdl.Name)
-		case <-period:
-			sts := &appsv1.StatefulSet{}
-			if err := mpn.Get(context.TODO(), types.NamespacedName{
-				Namespace: ns,
-				Name:      ssBdl.Name},
-				sts); err != nil {
-				return err
-			}
-			if sts.Status.ReadyReplicas == *sts.Spec.Replicas {
-				log.Info("component is ready", "component", ssBdl.Name)
-				return nil
-			}
-		}
+	// wait for the statefuleset to be ready
+	err = kubeutil.WaitStatefulSetReady(mpn, ns, ssBdl.GetName(), DeployTimeOutSec, ComponentPollPeriodSec)
+	if err != nil {
+		return err
 	}
-
+	return nil
 }
 
 // createPKISecrets creates secrets to store crt/key pairs and kubeconfigs
@@ -252,18 +277,6 @@ func (mpn *MasterProvisionerNative) createPKISecrets(caGroup *vcpki.ClusterCAGro
 	return nil
 }
 
-func (mpn *MasterProvisionerNative) createNS(vc *tenancyv1alpha1.Virtualcluster) error {
-	err := mpn.Create(context.TODO(), &v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: conversion.ToClusterKey(vc),
-		},
-	})
-	if apierrors.IsAlreadyExists(err) {
-		return nil
-	}
-	return err
-}
-
 // createPKI constructs the PKI (all crt/key pair and kubeconfig) for the
 // virtual clusters, and store them as secrets in the meta cluster
 func (mpn *MasterProvisionerNative) createPKI(vc *tenancyv1alpha1.Virtualcluster, cv *tenancyv1alpha1.ClusterVersion) error {
@@ -299,8 +312,19 @@ func (mpn *MasterProvisionerNative) createPKI(vc *tenancyv1alpha1.Virtualcluster
 	caGroup.ETCD = etcdCAPair
 
 	// create crt, key for apiserver
+	// get the clusterIP of the kubernetes service in the default namespace
+	defaultNS := conversion.ToClusterKey(vc) + "-default"
+	kubeClusterIP, err := kubeutil.GetSvcClusterIP(mpn, defaultNS, "kubernetes")
+	if err != nil {
+		return err
+	}
+	log.Info("the clusterIP will be added to the certificate",
+		"vc", vc.GetName(),
+		"clusterIP", kubeClusterIP,
+		"service", defaultNS+"/kubernetes")
+
 	apiserverDomain := cv.GetAPIServerDomain(ns)
-	apiserverCAPair, err := vcpki.NewAPIServerCrtAndKey(rootCAPair, vc, apiserverDomain)
+	apiserverCAPair, err := vcpki.NewAPIServerCrtAndKey(rootCAPair, vc, apiserverDomain, kubeClusterIP)
 	if err != nil {
 		return err
 	}

--- a/incubator/virtualcluster/pkg/controller/virtualcluster/virtualcluster_controller.go
+++ b/incubator/virtualcluster/pkg/controller/virtualcluster/virtualcluster_controller.go
@@ -19,7 +19,6 @@ package virtualcluster
 import (
 	"context"
 	"fmt"
-	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,15 +33,6 @@ import (
 
 	tenancyv1alpha1 "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
 	strutil "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/util/strings"
-)
-
-const (
-	DefaultETCDPeerPort = 2380
-
-	// frequency of polling apiserver for readiness of each component
-	ComponentPollPeriod = 2 * time.Second
-	// timeout for components deployment
-	DeployTimeOut = 180 * time.Second
 )
 
 var log = logf.Log.WithName("virtualcluster-controller")


### PR DESCRIPTION
add clusterIP of the default/kubernetes service to apiservercertificate. To achieve this, we proceed following steps before deploying apiserver,

  * create namespace corresponding to the default ns on super-cluster.
  * create the kubernetes service in the corresponding namespace on the
    super master and get its clusterIP.
  * generate certificate that including the clusterIP got in the previous step
    for the apiserver.

other minor changes are,

  * change Makefile to allow building image for the specified target
  * move kubernetes related functions to 'virtualcluster/controller/util/kube'