### PR TITLE
HNC: Make API server QPS throttle configurable with a default value. 

### DIFF
--- a/incubator/hnc/config/default/manager_auth_proxy_patch.yaml
+++ b/incubator/hnc/config/default/manager_auth_proxy_patch.yaml
@@ -25,3 +25,4 @@ spec:
         - "--enable-leader-election"
         - "--enable-new-object-controller"
         - "--max-reconciles=10"
+        - "--apiserver-qps-throttle=50"


### PR DESCRIPTION
Add command line flags for qps and burst limit for apiservers. Set the default qps to 50 and default burst to 75 respectively.

This is a fix for #369 which reports low HNC performance due to default limit of 5 QPS and 10 burst rate set by client-go library.

Test: Tested via debug logs to ensure the default values are set and the config values changes correctly based on the input from 
manager_autho_proxy_pathc.yaml 

/assign @adrianludwin