### PR TITLE
[Incubator][VC]annotate slb id to vc cr

### DIFF
--- a/incubator/virtualcluster/go.mod
+++ b/incubator/virtualcluster/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/aliyun/alibaba-cloud-sdk-go v1.60.324
 	github.com/emicklei/go-restful v2.9.6+incompatible
+	github.com/go-logr/logr v0.1.0
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/google/cadvisor v0.34.0
 	github.com/json-iterator/go v1.1.6 // indirect

--- a/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_aliyun.go
+++ b/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_aliyun.go
@@ -381,8 +381,17 @@ func (mpa *MasterProvisionerAliyun) getASKConfigs() (cfg ASKConfig, err error) {
 	cfg.zoneID = zoneID
 
 	privateKbCfg, pkcExist := ASKCfgMp.Data[AliyunASKCfgMpPrivateCfg]
+	// cfg.privateKbCfg can only be set as "true" or "false"
 	if pkcExist {
-		cfg.privateKbCfg = privateKbCfg
+		if privateKbCfg == "true" || privateKbCfg == "false" {
+			cfg.privateKbCfg = privateKbCfg
+		} else {
+			err = fmt.Errorf("%s.data.%s can only be set as 'true' or 'false'",
+				AliyunASKConfigMap, AliyunASKCfgMpPrivateCfg)
+			return
+		}
+	} else {
+		cfg.privateKbCfg = "false"
 	}
 
 	vpcID, viExist := ASKCfgMp.Data[AliyunASKCfgMpVPCID]


### PR DESCRIPTION
In `aliyun` mode, once a VC is up and running,  patch an annotation that holds the ask slb id to the VC CR

```json
{"metadata":{"annotations":{"tenancy.x-k8s.io/ask.slbID": "<slb-Id>"}}}
```