### PR TITLE
Manual Test cases for Tenant and TenantNamespace CRDs

### DIFF
--- a/tenant/test/config/tenant/tenant-a.yaml
+++ b/tenant/test/config/tenant/tenant-a.yaml
@@ -3,11 +3,11 @@ kind: Tenant
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: tenant-sample
+  name: tenant-a
 spec:
   # Add fields here
-  tenantAdminNamespaceName: "tenant1admin"
+  tenantAdminNamespaceName: "tenantarootns"
   tenantAdmins:
     - kind: ServiceAccount
-      name: t1-user1
+      name: ta-usera
       namespace: default

--- a/tenant/test/config/tenant/tenant-b.yaml
+++ b/tenant/test/config/tenant/tenant-b.yaml
@@ -3,11 +3,11 @@ kind: Tenant
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: tenant-sample
+  name: tenant-b
 spec:
   # Add fields here
-  tenantAdminNamespaceName: "tenant1admin"
+  tenantAdminNamespaceName: "tenantbrootns"
   tenantAdmins:
     - kind: ServiceAccount
-      name: t1-user1
-      namespace: default
+      name: tb-userb
+      namespace: tenant-system

--- a/tenant/test/config/tenantnamespace/tenantnamespace-a.yaml
+++ b/tenant/test/config/tenantnamespace/tenantnamespace-a.yaml
@@ -1,0 +1,10 @@
+apiVersion: tenancy.x-k8s.io/v1alpha1
+kind: TenantNamespace
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: tenantnamespace-a
+  namespace: tenantarootns
+spec:
+  # Add fields here
+  name: tenantnamespace-a-1

--- a/tenant/test/config/tenantnamespace/tenantnamespace-b.yaml
+++ b/tenant/test/config/tenantnamespace/tenantnamespace-b.yaml
@@ -1,0 +1,10 @@
+apiVersion: tenancy.x-k8s.io/v1alpha1
+kind: TenantNamespace
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: tenantnamespace-b
+  namespace: tenantbrootns
+spec:
+  # Add fields here
+  name: tenantnamespace-b-1

--- a/tenant/test/create_service_account_with_kubeconfig.sh
+++ b/tenant/test/create_service_account_with_kubeconfig.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+# script was taken from https://gist.github.com/innovia/fbba8259042f71db98ea8d4ad19bd708 and adjusted with "apply_rbac" function and colorized output
+
+
+set -e
+set -o pipefail
+
+# Colors
+RED="\e[01;31m"
+GREEN="\e[01;32m"
+YELLOW="\e[01;33m"
+BLUE="\e[01;34m"
+COLOROFF="\e[00m"
+
+# Add user to k8s using service account
+if [[ -z "$1" ]] || [[ -z "$2" ]]; then
+ echo "usage: $0 <service_account_name> <namespace>"
+ exit 1
+fi
+
+SERVICE_ACCOUNT_NAME=$1
+NAMESPACE="$2"
+KUBECFG_FILE_NAME="/tmp/kube/k8s-${SERVICE_ACCOUNT_NAME}-${NAMESPACE}-conf"
+TARGET_FOLDER="/tmp/kube"
+
+create_target_folder() {
+    echo -n "Creating target directory to hold files in ${TARGET_FOLDER}..."
+    mkdir -p "${TARGET_FOLDER}"
+    printf "done"
+}
+
+create_service_account() {
+    echo -e "\\nCreating a service account in ${NAMESPACE} namespace: ${SERVICE_ACCOUNT_NAME}"
+    kubectl create sa "${SERVICE_ACCOUNT_NAME}" --namespace "${NAMESPACE}"
+}
+
+get_secret_name_from_service_account() {
+    echo -e "\\nGetting secret of service account ${SERVICE_ACCOUNT_NAME} on ${NAMESPACE}"
+    SECRET_NAME=$(kubectl get sa "${SERVICE_ACCOUNT_NAME}" --namespace="${NAMESPACE}" -o json | jq -r .secrets[].name)
+    echo "Secret name: ${SECRET_NAME}"
+}
+
+extract_ca_crt_from_secret() {
+    echo -e -n "\\nExtracting ca.crt from secret..."
+    kubectl get secret --namespace "${NAMESPACE}" "${SECRET_NAME}" -o json | jq \
+    -r '.data["ca.crt"]' | base64 --decode  > "${TARGET_FOLDER}/ca.crt"
+    printf "done"
+}
+
+get_user_token_from_secret() {
+    echo -e -n "\\nGetting user token from secret..."
+    USER_TOKEN=$(kubectl get secret --namespace "${NAMESPACE}" "${SECRET_NAME}" -o json | jq -r '.data["token"]' | base64 --decode)
+    printf "done"
+}
+
+set_kube_config_values() {
+    context=$(kubectl config current-context)
+    echo -e "\\nSetting current context to: $context"
+
+    CLUSTER_NAME=$(kubectl config get-contexts "$context" | awk '{print $3}' | tail -n 1)
+    echo "Cluster name: ${CLUSTER_NAME}"
+
+    ENDPOINT=$(kubectl config view \
+    -o jsonpath="{.clusters[?(@.name == \"${CLUSTER_NAME}\")].cluster.server}")
+    echo -e ${BLUE} "Endpoint: ${ENDPOINT} ${COLOROFF}"
+
+    # Set up the config
+    echo -e "\\nPreparing k8s-${SERVICE_ACCOUNT_NAME}-${NAMESPACE}-conf"
+    echo -n "Setting a cluster entry in kubeconfig..."
+    kubectl config set-cluster "${CLUSTER_NAME}" \
+    --kubeconfig="${KUBECFG_FILE_NAME}" \
+    --server="${ENDPOINT}" \
+    --certificate-authority="${TARGET_FOLDER}/ca.crt" \
+    --embed-certs=true
+
+    echo -n "Setting token credentials entry in kubeconfig..."
+    kubectl config set-credentials \
+    "${SERVICE_ACCOUNT_NAME}-${NAMESPACE}-${CLUSTER_NAME}" \
+    --kubeconfig="${KUBECFG_FILE_NAME}" \
+    --token="${USER_TOKEN}"
+
+    echo -n "Setting a context entry in kubeconfig..."
+    kubectl config set-context \
+    "${SERVICE_ACCOUNT_NAME}-${NAMESPACE}-${CLUSTER_NAME}" \
+    --kubeconfig="${KUBECFG_FILE_NAME}" \
+    --cluster="${CLUSTER_NAME}" \
+    --user="${SERVICE_ACCOUNT_NAME}-${NAMESPACE}-${CLUSTER_NAME}" \
+    --namespace="${NAMESPACE}"
+
+    echo -n "Setting the current-context in the kubeconfig file..."
+    kubectl config use-context "${SERVICE_ACCOUNT_NAME}-${NAMESPACE}-${CLUSTER_NAME}" \
+    --kubeconfig="${KUBECFG_FILE_NAME}"
+}
+
+apply_rbac() {
+    echo -e -n "\\nApplying RBAC permissions..."
+    sed -e "s|my_account|${SERVICE_ACCOUNT_NAME}|g" -e "s|my_namespace|${NAMESPACE}|g" \
+    permissions-template.yaml > permissions_${SERVICE_ACCOUNT_NAME}.yaml
+    kubectl apply -f permissions_${SERVICE_ACCOUNT_NAME}.yaml
+    printf "done"
+}
+create_target_folder
+create_service_account
+get_secret_name_from_service_account
+extract_ca_crt_from_secret
+get_user_token_from_secret
+set_kube_config_values
+apply_rbac
+
+echo -e "\\nAll done! Test with:"
+echo -e ${BLUE} "KUBECONFIG=${KUBECFG_FILE_NAME} ${COLOROFF} kubectl get pods"
+KUBECONFIG=${KUBECFG_FILE_NAME} kubectl get pods

--- a/tenant/test/manual_test_cases.md
+++ b/tenant/test/manual_test_cases.md
@@ -1,0 +1,145 @@
+# **Manual Test Cases**
+
+## Requirements
+
+#### First Install CRDs
+```
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/tenant/config/crds/tenancy_v1alpha1_tenant.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/tenant/config/crds/tenancy_v1alpha1_tenantnamespace.yaml
+```
+verify using `kubectl get crd`
+output :
+```
+NAME                                CREATED AT
+tenantnamespaces.tenancy.x-k8s.io   2020-02-04T16:30:51Z
+tenants.tenancy.x-k8s.io            2020-02-04T16:30:50Z
+```
+
+### Install tenant-controller-managers
+```
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/tenant/config/manager/all_in_one.yaml
+```
+This will create a `tenant-system` namespace. Verify it using `kubectl get namespace`
+ 
+### Tenants 
+``` 
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/tenant/test/config/tenant/tenant-a.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/tenant/test/config/tenant/tenant-b.yaml
+```
+verify using `kubectl get ns`, 2 new namespaces `tenantarootns` and `tenantbrootns` are created
+
+### Service Accounts
+```
+bash https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/tenant/test/create_service_account_with_kubeconfig.sh tenant-a-admin default
+bash https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/tenant/test/create_service_account_with_kubeconfig.sh tenant-b-admin default
+```
+
+kubeconfig file path is `/tmp/kube/`
+
+
+## Test Cases
+
+### Use Case 1: When `tenant-a-admin` is admin of `tenant-a`
+
+``` 
+kubectl edit tenant tenant-a
+```
+
+``` 
+apiVersion: tenancy.x-k8s.io/v1alpha1
+kind: Tenant
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: tenant-a
+spec:
+  # Add fields here
+  tenantAdminNamespaceName: "tenantarootns"
+  tenantAdmins:
+    - kind: ServiceAccount
+      name: tenant-a-admin
+      namespace: default
+```
+
+### Test Case 1 : 
+`tenant-a-admin` will be able to create `tenantnamespace-a` in `tenantarootns`
+
+```
+KUBECONFIG=/tmp/kube/k8s-tenant-a-admin-default-conf kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/tenant/test/tenantnamespace/tenantnamespace-a.yaml
+```
+
+### Output 1:
+```tenantnamespace.tenancy.x-k8s.io/tenantnamespace-a created```
+
+Verify using `kubectl get tenantnamespace -n tenantarootns`
+
+##
+
+### Test Case 2 : 
+`tenant-b-admin` will not be able to create `tenantnamespace-a` in `tenantarootns`
+
+```
+KUBECONFIG=/tmp/kube/k8s-tenant-b-admin-tenant-system-conf kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/tenant/test/tenantnamespace/tenantnamespace-a.yaml
+```
+
+### Output 2:
+```
+Error from server (Forbidden): error when retrieving current configuration of:
+Resource: "tenancy.x-k8s.io/v1alpha1, Resource=tenantnamespaces", GroupVersionKind: "tenancy.x-k8s.io/v1alpha1, Kind=TenantNamespace"
+Name: "tenantnamespace-a", Namespace: "tenantarootns"
+Object: &{map["apiVersion":"tenancy.x-k8s.io/v1alpha1" "kind":"TenantNamespace" "metadata":map["annotations":map["kubectl.kubernetes.io/last-applied-configuration":""] "labels":map["controller-tools.k8s.io":"1.0"] "name":"tenantnamespace-a" "namespace":"tenantarootns"] "spec":map["name":"tenantnamespace-a-1"]]}
+from server for: "tnsa.yaml": tenantnamespaces.tenancy.x-k8s.io "tenantnamespace-a" is forbidden: User "system:serviceaccount:default:t2-adminb" cannot get resource "tenantnamespaces" in API group "tenancy.x-k8s.io" in the namespace "tenantarootns"
+```
+
+##
+
+### Use Case 2: When `tenant-b-admin` is added in admin list of `tenant-a`
+
+``` 
+kubectl edit tenant tenant-a
+```
+
+``` 
+apiVersion: tenancy.x-k8s.io/v1alpha1
+kind: Tenant
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: tenant-a
+spec:
+  # Add fields here
+  tenantAdminNamespaceName: "tenantarootns"
+  tenantAdmins:
+    - kind: ServiceAccount
+      name: tenant-a-admin
+      namespace: default
+    - kind: ServiceAccount
+      name: tenant-b-admin
+      namespace: default
+```
+
+
+### Test Case 3 : 
+`tenant-b-admin` will also be able to create `tenantnamespace-a` in `tenantarootns`
+
+``` 
+KUBECONFIG=/tmp/kube/k8s-tenant-a-admin-default-conf kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/tenant/test/tenantnamespace/tenantnamespace-a.yaml
+KUBECONFIG=/tmp/kube/k8s-tenant-b-admin-default-conf kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/tenant/test/tenantnamespace/tenantnamespace-a.yaml
+```
+
+### Output 3:
+```
+tenantnamespace.tenancy.x-k8s.io/tenantnamespace-a created
+```
+
+Verify using `kubectl get tenantnamespace -n tenantarootns`
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Added Test Cases:
1. Tenant admin is able to create tenantnamespace in tenant-root-ns
2. Other tenant admin is not able to create tenantnamespace in tenant-root-ns
3. Multiple tenant admins can be assigned to a tenant and they all can create tenantnamespace in tenant-root-ns