### PR TITLE
[Incubator][VC]Add a go pprof server in syncer

### DIFF
--- a/incubator/virtualcluster/cmd/syncer/app/server.go
+++ b/incubator/virtualcluster/cmd/syncer/app/server.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 
 	"k8s.io/apiserver/pkg/util/term"
@@ -144,6 +146,10 @@ func startSyncer(ctx context.Context, s syncer.Bootstrap, cc *syncerconfig.Compl
 		s.Run(stopCh)
 		go func() {
 			s.ListenAndServe(net.JoinHostPort(cc.Address, cc.Port), cc.CertFile, cc.KeyFile)
+		}()
+		go func() {
+			// start a pprof http server
+			klog.Fatal(http.ListenAndServe(":6060", nil))
 		}()
 		<-ctx.Done()
 	}


### PR DESCRIPTION
The go pprof server can be used to:
- debug hang thread
- count the inflight go routine number
- check the heap allocation

This can be used to analyze syncer resource consumption.

Test:
curl 172.17.0.7:6060/debug/pprof/goroutine?debug=2
This will list all the go routines used by syncer.