### PR TITLE
[Incubator] [VC] delete node-controller serviceaccount to disable node periodic checkin in aliyun modeg

### DIFF
--- a/incubator/virtualcluster/config/crds/tenancy_v1alpha1_clusterversion.yaml
+++ b/incubator/virtualcluster/config/crds/tenancy_v1alpha1_clusterversion.yaml
@@ -10,6 +10,8 @@ spec:
   names:
     kind: ClusterVersion
     plural: clusterversions
+    shortNames:
+    - cv
   scope: Cluster
   validation:
     openAPIV3Schema:

--- a/incubator/virtualcluster/config/crds/tenancy_v1alpha1_virtualcluster.yaml
+++ b/incubator/virtualcluster/config/crds/tenancy_v1alpha1_virtualcluster.yaml
@@ -10,6 +10,8 @@ spec:
   names:
     kind: Virtualcluster
     plural: virtualclusters
+    shortNames:
+    - vc
   scope: Namespaced
   validation:
     openAPIV3Schema:


### PR DESCRIPTION
The default node healthy checking intervals of the node-controller is 40 secs. In the VC scenario,  each node needs to send heartbeats to all tenant masters every 40 secs, which may cause high overheads. To mitigate this issue, we need to extend the default interval, however, ACK doesn't allow the user to change this value. Therefore, we disable the node controller by deleting the node-controller service account. 