### PR TITLE
Add performance tests on controller start/restart

### DIFF
--- a/incubator/hnc/scripts/performance/clean-up-topologies.sh
+++ b/incubator/hnc/scripts/performance/clean-up-topologies.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "Clean up topologies: deleting namespaces with ptlg(toplogy) prefix"
+kubectl get ns | awk '/tplg.*/{print $1}' | xargs kubectl delete ns

--- a/incubator/hnc/scripts/performance/load-topology-full.sh
+++ b/incubator/hnc/scripts/performance/load-topology-full.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Clean up topologies
+. ./scripts/performance/clean-up-topologies.sh
+
+# N is the number of children per node(namespace). Default to 20 (421 nodes).
+N=20
+
+# O is the number of objects per namespace. Default to 1.
+O=1
+
+echo "Loading Topology Full($N children/node, $O objects/node)..."
+
+# Create root namespace
+kubectl create ns tplg-full-0-0
+for ((k=1;k<=O;k++))
+do
+  kubectl -n tplg-full-0-0 create configmap configmap$k-0-0 --from-literal key=value
+done
+
+# Create all namespaces with tree depth 1
+for ((i=1;i<=N;i++))
+do
+  echo "Creating namespace tplg-full-0-$i"
+  kubectl create ns tplg-full-0-$i
+  for ((k=1;k<=O;k++))
+  do
+    kubectl -n tplg-full-0-$i create configmap configmap$k-0-$i --from-literal key=value
+  done
+  # Create all namespaces with tree depth 2
+  for ((j=1;j<=N;j++))
+  do
+    echo "Creating namespace tplg-full-$i-$j"
+    kubectl create ns tplg-full-$i-$j
+    for ((k=1;k<=O;k++))
+    do
+      kubectl -n tplg-full-$i-$j create configmap configmap$k-$i-$j --from-literal key=value
+    done
+  done
+done
+
+# Create full topology.
+for ((i=1;i<=N;i++))
+do
+  kubectl hns set tplg-full-0-$i --parent tplg-full-0-0
+  for ((j=1;j<=N;j++))
+  do
+    kubectl hns set tplg-full-$i-$j --parent tplg-full-0-$i
+  done
+done

--- a/incubator/hnc/scripts/performance/load-topology-skewer.sh
+++ b/incubator/hnc/scripts/performance/load-topology-skewer.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Clean up topologies
+. ./scripts/performance/clean-up-topologies.sh
+
+# N is the depth of the tree. Default to 100 (100 nodes).
+N=100
+
+# O is the number of objects per namespace. Default to 1.
+O=1
+
+echo "Loading Topology Skewer($N levels, $O objects/node)..."
+
+# Create all namespaces
+for ((i=1;i<=N;i++))
+do
+  echo "Creating namespace tplg-skewer-$i"
+  kubectl create ns tplg-skewer-$i
+  for ((k=1;k<=O;k++))
+  do
+    kubectl -n tplg-skewer-$i create configmap configmap$k-$i --from-literal key=value
+  done
+done
+
+# Create skewer topology.
+for ((i=2;i<=N;i++))
+do
+  kubectl hns set tplg-skewer-$i --parent tplg-skewer-$((i-1))
+done

--- a/incubator/hnc/scripts/performance/load-topology-wide.sh
+++ b/incubator/hnc/scripts/performance/load-topology-wide.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Clean up topologies
+. ./scripts/performance/clean-up-topologies.sh
+
+# N is the number of children of the root. Default to 500 (501 nodes).
+N=500
+
+# O is the number of objects per namespace. Default to 1.
+O=1
+
+echo "Loading Topology Wide($N children, $O objects/node)..."
+
+# Create all namespaces
+for ((i=0;i<=N;i++))
+do
+  kubectl create ns tplg-wide-$i
+  for ((k=1;k<=O;k++))
+  do
+    kubectl -n tplg-wide-$i create configmap configmap$k-$i --from-literal key=value
+  done
+done
+
+# Create wide topology
+for ((i=1;i<=N;i++))
+do
+  kubectl hns set tplg-wide-$i --parent tplg-wide-0
+done

--- a/incubator/hnc/scripts/performance/start-controllers.sh
+++ b/incubator/hnc/scripts/performance/start-controllers.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Start controllers and output the performance
+echo "Creating hnc-controller-manager deployment"
+kubectl apply -f manifests/hnc-manager.yaml
+ts=$(date -u +"%Y-%m-%dT%T")
+
+echo "Waiting for the controllers to start..."
+sleep 10
+echo "Looking for logs containing Status:start..."
+# Empty the variables.
+start=
+finish=
+# Run until the start is not empty.
+timeout=120
+until [ ! -z "$start" ]
+do
+  timeout=$((timeout-1))
+  if [ $timeout -lt 1 ]
+  then
+    echo "Error: no controller activities detected."
+    break
+  fi
+  sleep 1
+  start=$(kubectl logs -n hnc-system deployment/hnc-controller-manager -c manager | grep "\"Status\":\"start\"")
+done
+if [ -z "$start" ]
+then
+  continue
+fi
+
+# Collect all the data in the start log
+sec1=`echo ${start} | jq -r '.ts' | grep -Eo ^[0-9]*`
+
+echo "Waiting for the controllers to finish..."
+echo "Looking for logs containing Status:finish..."
+# Run until the finish is not empty.
+timeout=900
+until [ ! -z "$finish" ]
+do
+  timeout=$((timeout-1))
+  if [ $timeout -lt 1 ]
+  then
+    echo "Error: controller activities timed out(600s)."
+    break
+  fi
+  sleep 1
+  finish=$(kubectl logs -n hnc-system deployment/hnc-controller-manager -c manager | grep "\"Status\":\"finish\"")
+done
+if [ -z "$finish" ]
+then
+  continue
+fi
+
+# Collect all the data in the finish log
+sec2=`echo ${finish} | jq -r '.ts' | grep -Eo ^[0-9]*`
+TotalHierConfigReconciles=`echo ${finish} | jq -r '.TotalHierConfigReconciles' | grep -Eo ^[0-9]*`
+TotalObjReconciles=`echo ${finish} | jq -r '.TotalObjReconciles' | grep -Eo ^[0-9]*`
+HierConfigWrites=`echo ${finish} | jq -r '.HierConfigWrites' | grep -Eo ^[0-9]*`
+NamespaceWrites=`echo ${finish} | jq -r '.NamespaceWrites' | grep -Eo ^[0-9]*`
+ObjectWrites=`echo ${finish} | jq -r '.ObjectWrites' | grep -Eo ^[0-9]*`
+
+diffTime=$((sec2-sec1))s
+
+echo "HNC startup time : $ts"
+ts=$(date -u +"%Y-%m-%dT%T")
+echo "Current time : $ts"
+ts=$(date -u -d @${sec1} +"%Y-%m-%dT%T")
+echo "Controllers start working time : $ts"
+ts=$(date -u -d @${sec2} +"%Y-%m-%dT%T")
+echo "Controllers finish working time : $ts"
+echo "Controllers working time for HNC startup: $diffTime"
+echo "Total HierConfig reconciles: $TotalHierConfigReconciles"
+echo "Total Object reconciles: $TotalObjReconciles"
+echo "Total HierConfig writes: $HierConfigWrites"
+echo "Total Namespace writes: $NamespaceWrites"
+echo "Total Object writes: $ObjectWrites"

--- a/incubator/hnc/scripts/performance/test.sh
+++ b/incubator/hnc/scripts/performance/test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+echo "Performance Test - Controller Start/Restart Time"
+
+rootname[1]="tplg-wide-0"
+rootname[2]="tplg-full-0-0"
+rootname[3]="tplg-skewer-1"
+
+for tplg in {1..3}
+do
+  echo "************Loading the topology ${tplg}************"
+  echo "Deleting hnc-controller-manager deployment"
+  kubectl -n hnc-system delete deployment hnc-controller-manager 
+  echo "Disabling validating webhook"
+  kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io/hnc-validating-webhook-configuration
+  case $tplg in
+  1)
+    . ./scripts/performance/load-topology-wide.sh
+    ;;
+  2)
+    . ./scripts/performance/load-topology-full.sh
+    ;;
+  3)
+    . ./scripts/performance/load-topology-skewer.sh
+    ;;
+  esac
+  root=${rootname[tplg]}
+
+  echo "************Starting up the controllers on topology ${tplg}************"
+  . ./scripts/performance/start-controllers.sh
+
+  echo "************Restarting the controllers on topology ${tplg}************" 
+  echo "Deleting hnc-controller-manager deployment"
+  kubectl -n hnc-system delete deployment hnc-controller-manager
+  . ./scripts/performance/start-controllers.sh
+done


### PR DESCRIPTION
Add scripts to load different topologies of namespaces into the cluster.
Start/restart controllers and output completion time and number of api
reads/writes to see the performance.

Tested on GKE cluster.