### PR TITLE
[Incubator][VC] ignore annotations that have specific prefixes 

### DIFF
--- a/incubator/virtualcluster/config/setup/all_in_one.yaml
+++ b/incubator/virtualcluster/config/setup/all_in_one.yaml
@@ -239,11 +239,11 @@ spec:
           imagePullPolicy: Always
           name: vc-syncer
           env:
-          - name: STDLN_OBJ_ANNO_PREFXS
+          - name: STANDALONE_OBJ_ANNO_PREFIXES
             valueFrom: 
               configMapKeyRef:
                 name: syncer-envs
-                key: STDLN_OBJ_ANNO_PREFXS
+                key: STANDALONE_OBJ_ANNO_PREFIXES
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -252,7 +252,7 @@ metadata:
   namespace: vc-manager
 data:
   # use space as delimiter. e.g. STDLN_OBJ_ANNO_PREFXS: "a b c"
-  STDLN_OBJ_ANNO_PREFXS: "" 
+  STANDALONE_OBJ_ANNO_PREFIXES: "" 
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/incubator/virtualcluster/config/setup/all_in_one.yaml
+++ b/incubator/virtualcluster/config/setup/all_in_one.yaml
@@ -238,6 +238,21 @@ spec:
           image: virtualcluster/syncer-amd64
           imagePullPolicy: Always
           name: vc-syncer
+          env:
+          - name: STDLN_OBJ_ANNO_PREFXS
+            valueFrom: 
+              configMapKeyRef:
+                name: syncer-envs
+                key: STDLN_OBJ_ANNO_PREFXS
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: syncer-envs
+  namespace: vc-manager
+data:
+  # use space as delimiter. e.g. STDLN_OBJ_ANNO_PREFXS: "a b c"
+  STDLN_OBJ_ANNO_PREFXS: "" 
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/incubator/virtualcluster/pkg/syncer/conversion/equality.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/equality.go
@@ -37,12 +37,12 @@ func init() {
 	// run in a pod, the env will be set through a configmap
 	// TODO should we add a feature to restart the syncer if the configmap
 	// is updated
-	soap := os.Getenv("STDLN_OBJ_ANNO_PREFXS")
+	soap := os.Getenv("STANDALONE_OBJ_ANNO_PREFIXES")
 	if soap == "" {
 		return
 	}
 	// the delimiter of the prefix list is space
-	StandaloneObjAnnotationPrefixes = append(StandaloneObjAnnotationPrefixes, strings.Split(soap, " ")...)
+	StandaloneObjAnnotationPrefixes = append(StandaloneObjAnnotationPrefixes, strings.Fields(soap)...)
 }
 
 // CheckPodEquality check whether super master object and virtual object
@@ -123,7 +123,7 @@ func CheckKVEquality(pKV, vKV map[string]string) (map[string]string, bool) {
 	moreOrDiff := make(map[string]string)
 
 	for vk, vv := range vKV {
-		if syncerutil.HasPrefixs(vk, StandaloneObjAnnotationPrefixes) {
+		if syncerutil.HasPrefixes(vk, StandaloneObjAnnotationPrefixes) {
 			// tenant pod should not use this key. it may conflicts with syncer.
 			continue
 		}
@@ -136,7 +136,7 @@ func CheckKVEquality(pKV, vKV map[string]string) (map[string]string, bool) {
 	// key in virtual less then super
 	less := make(map[string]string)
 	for pk := range pKV {
-		if syncerutil.HasPrefixs(pk, StandaloneObjAnnotationPrefixes) {
+		if syncerutil.HasPrefixes(pk, StandaloneObjAnnotationPrefixes) {
 			continue
 		}
 

--- a/incubator/virtualcluster/pkg/syncer/conversion/equality.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/equality.go
@@ -17,6 +17,7 @@ limitations under the License.
 package conversion
 
 import (
+	"os"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -25,7 +26,24 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+
+	syncerutil "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/utils"
 )
+
+var StandaloneObjAnnotationPrefixes = []string{"tenancy.x-k8s.io"}
+
+func init() {
+	// load the StandaloneObjAnnotationPrefixex from envs. When the syncer
+	// run in a pod, the env will be set through a configmap
+	// TODO should we add a feature to restart the syncer if the configmap
+	// is updated
+	soap := os.Getenv("STDLN_OBJ_ANNO_PREFXS")
+	if soap == "" {
+		return
+	}
+	// the delimiter of the prefix list is space
+	StandaloneObjAnnotationPrefixes = append(StandaloneObjAnnotationPrefixes, strings.Split(soap, " ")...)
+}
 
 // CheckPodEquality check whether super master object and virtual object
 // is logical equal.
@@ -105,7 +123,7 @@ func CheckKVEquality(pKV, vKV map[string]string) (map[string]string, bool) {
 	moreOrDiff := make(map[string]string)
 
 	for vk, vv := range vKV {
-		if strings.HasPrefix(vk, "tenancy.x-k8s.io") {
+		if syncerutil.HasPrefixs(vk, StandaloneObjAnnotationPrefixes) {
 			// tenant pod should not use this key. it may conflicts with syncer.
 			continue
 		}
@@ -118,7 +136,7 @@ func CheckKVEquality(pKV, vKV map[string]string) (map[string]string, bool) {
 	// key in virtual less then super
 	less := make(map[string]string)
 	for pk := range pKV {
-		if strings.HasPrefix(pk, "tenancy.x-k8s.io") {
+		if syncerutil.HasPrefixs(pk, StandaloneObjAnnotationPrefixes) {
 			continue
 		}
 

--- a/incubator/virtualcluster/pkg/syncer/utils/string.go
+++ b/incubator/virtualcluster/pkg/syncer/utils/string.go
@@ -49,9 +49,9 @@ func GenAnAvailableName(names []string, prefix string, n int) string {
 	}
 }
 
-// HasPrefixs checks whether the string 's' begins with any prefix in 'prefixs'.
-func HasPrefixs(s string, prefixs []string) bool {
-	for _, pf := range prefixs {
+// HasPrefixes checks whether the string 's' begins with any prefix in 'prefixes'.
+func HasPrefixes(s string, prefixes []string) bool {
+	for _, pf := range prefixes {
 		if strings.HasPrefix(s, pf) {
 			return true
 		}

--- a/incubator/virtualcluster/pkg/syncer/utils/string.go
+++ b/incubator/virtualcluster/pkg/syncer/utils/string.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package utils
 
-import "math/rand"
+import (
+	"math/rand"
+	"strings"
+)
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyz")
 
@@ -44,4 +47,14 @@ func GenAnAvailableName(names []string, prefix string, n int) string {
 			return ans
 		}
 	}
+}
+
+// HasPrefixs checks whether the string 's' begins with any prefix in 'prefixs'.
+func HasPrefixs(s string, prefixs []string) bool {
+	for _, pf := range prefixs {
+		if strings.HasPrefix(s, pf) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Try to resolve issue #330 

when comparing virtual object and the real object, syncer will ignore annotation
prefixes specified in env `STDLN_OBJ_ANNO_PREFXS`