### PR TITLE
[Incubator][VC]Check mccontroller cache before upward syncing Events

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
+++ b/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
@@ -359,6 +359,8 @@ func getTargetObject(objectType runtime.Object) runtime.Object {
 		return &v1.ConfigMap{}
 	case *v1.Node:
 		return &v1.Node{}
+	case *v1.Event:
+		return &v1.Event{}
 	case *v1.Pod:
 		return &v1.Pod{}
 	case *v1.Secret:
@@ -384,6 +386,8 @@ func getTargetObjectList(objectType runtime.Object) runtime.Object {
 		return &v1.ConfigMapList{}
 	case *v1.Node:
 		return &v1.NodeList{}
+	case *v1.Event:
+		return &v1.EventList{}
 	case *v1.Pod:
 		return &v1.PodList{}
 	case *v1.Secret:

--- a/incubator/virtualcluster/pkg/syncer/resources/event/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/event/controller.go
@@ -68,7 +68,7 @@ func Register(
 
 	// Create the multi cluster pod controller
 	options := mc.Options{Reconciler: c}
-	multiClusterEventController, err := mc.NewMCController("tenant-masters-event-controller", nil, options)
+	multiClusterEventController, err := mc.NewMCController("tenant-masters-event-controller", &v1.Event{}, options)
 	if err != nil {
 		klog.Errorf("failed to create multi cluster event controller %v", err)
 		return

--- a/incubator/virtualcluster/pkg/syncer/resources/event/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/event/uws.go
@@ -120,6 +120,13 @@ func (c *controller) backPopulate(key string) error {
 	}
 
 	vEvent := conversion.BuildVirtualPodEvent(clusterName, pEvent, vPod)
-	_, err = tenantClient.CoreV1().Events(tenantNS).Create(vEvent)
-	return err
+	_, err = c.multiClusterEventController.Get(clusterName, tenantNS, vEvent.Name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			_, err = tenantClient.CoreV1().Events(tenantNS).Create(vEvent)
+			return err
+		}
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
This change adds a check to see if an Event has been synced to tenant master to avoid unnecessary err messages about object already exists.