### PR TITLE
Add OpenCencus metrics and export to Stackdriver

### DIFF
--- a/incubator/hnc/pkg/stats/metrics.go
+++ b/incubator/hnc/pkg/stats/metrics.go
@@ -1,0 +1,44 @@
+package stats
+
+import (
+	"context"
+
+	ocstats "go.opencensus.io/stats"
+	ocview "go.opencensus.io/stats/view"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var (
+	hierConfigReconcileTotal = ocstats.Int64("hierconfig_reconcile_total", "The number of HierConfig reconciliations happened", "times")
+	hierConfigWritesTotal    = ocstats.Int64("hierconfig_writes_total", "The number of HierConfig writes happened during HierConfig reconciliations", "times")
+)
+
+var (
+	hierReconcileView = &ocview.View{
+		Name:        "hnc/reconcilers/hierconfig/total",
+		Measure:     hierConfigReconcileTotal,
+		Description: "The number of HierConfig reconciliations happened",
+		Aggregation: ocview.LastValue(),
+	}
+
+	hierWritesView = &ocview.View{
+		Name:        "hnc/reconcilers/hierconfig/hierconfig_writes_total",
+		Measure:     hierConfigWritesTotal,
+		Description: "The number of HierConfig writes happened during HierConfig reconciliations",
+		Aggregation: ocview.LastValue(),
+	}
+)
+
+func startRecordingMetrics() {
+	log := ctrl.Log.WithName("metricsRecorder")
+
+	// Register the view. It is imperative that this step exists,
+	// otherwise recorded metrics will be dropped and never exported.
+	if err := ocview.Register(hierReconcileView, hierWritesView); err != nil {
+		log.Error(err, "Failed to register the views")
+	}
+}
+
+func recordMetricsInt64(c counter, ms *ocstats.Int64Measure) {
+	ocstats.Record(context.Background(), ms.M(int64(c)))
+}

--- a/incubator/hnc/pkg/stats/stats.go
+++ b/incubator/hnc/pkg/stats/stats.go
@@ -42,6 +42,7 @@ var stats stat
 func StartHierConfigReconcile() {
 	stats.totalHierConfigReconciles.incr()
 	stats.curHierConfigReconciles.incr()
+	recordMetricsInt64(stats.totalHierConfigReconciles, hierConfigReconcileTotal)
 }
 
 // StopHierConfigReconcile updates stats when hierarchyConfig
@@ -76,6 +77,7 @@ func WriteNamespace() {
 // WriteHierConfig updates stats when writing hierarchyConfig instance.
 func WriteHierConfig() {
 	stats.hierConfigWrites.incr()
+	recordMetricsInt64(stats.hierConfigWrites, hierConfigWritesTotal)
 }
 
 // WriteObject updates the object stats by GK when writing the object.
@@ -90,6 +92,7 @@ func init() {
 		actionID: 1,
 		objects:  objects,
 	}
+	startRecordingMetrics()
 }
 
 // StartLoggingActivity generates logs for performance testing.


### PR DESCRIPTION
Export hierconfig_reconcile_total and hierconfig_writes_total metrics to
Stackdriver using OpenCensus. The metrics come from stats counters.

Tested on GKE cluster. I can see the hnc metrics in Stackdriver and the
data changed when new namespaces were created or set parent.