### PR TITLE
[Incubator][VC]Add endpoints and serviceaccount periodic checker

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/conversion/equality.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/equality.go
@@ -411,17 +411,33 @@ func (e vcEquality) CheckSecretEquality(pObj, vObj *v1.Secret) *v1.Secret {
 	return updated
 }
 
+func filterSubSetTargetRef(ep *v1.Endpoints) []v1.EndpointSubset {
+	epSubsetCopy := ep.Subsets
+	for _, each := range epSubsetCopy {
+		for _, addr := range each.Addresses {
+			if addr.TargetRef != nil {
+				addr.TargetRef.Namespace = ""
+				addr.TargetRef.ResourceVersion = ""
+				addr.TargetRef.UID = ""
+			}
+		}
+		for _, addr := range each.NotReadyAddresses {
+			if addr.TargetRef != nil {
+				addr.TargetRef.Namespace = ""
+				addr.TargetRef.ResourceVersion = ""
+				addr.TargetRef.UID = ""
+			}
+		}
+	}
+	return epSubsetCopy
+}
+
 func (e vcEquality) CheckEndpointsEquality(pObj, vObj *v1.Endpoints) *v1.Endpoints {
 	var updated *v1.Endpoints
-	updatedMeta := e.checkDWObjectMetaEquality(&pObj.ObjectMeta, &vObj.ObjectMeta)
-	if updatedMeta != nil {
-		if updated == nil {
-			updated = pObj.DeepCopy()
-		}
-		updated.ObjectMeta = *updatedMeta
-	}
+	pSubsetCopy := filterSubSetTargetRef(pObj)
+	vSubsetCopy := filterSubSetTargetRef(vObj)
 
-	if !equality.Semantic.DeepEqual(pObj.Subsets, vObj.Subsets) {
+	if !equality.Semantic.DeepEqual(pSubsetCopy, vSubsetCopy) {
 		if updated == nil {
 			updated = pObj.DeepCopy()
 		}

--- a/incubator/virtualcluster/pkg/syncer/conversion/equality.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/equality.go
@@ -413,19 +413,19 @@ func (e vcEquality) CheckSecretEquality(pObj, vObj *v1.Secret) *v1.Secret {
 
 func filterSubSetTargetRef(ep *v1.Endpoints) []v1.EndpointSubset {
 	epSubsetCopy := ep.Subsets
-	for _, each := range epSubsetCopy {
-		for _, addr := range each.Addresses {
+	for i, each := range epSubsetCopy {
+		for j, addr := range each.Addresses {
 			if addr.TargetRef != nil {
-				addr.TargetRef.Namespace = ""
-				addr.TargetRef.ResourceVersion = ""
-				addr.TargetRef.UID = ""
+				epSubsetCopy[i].Addresses[j].TargetRef.Namespace = ""
+				epSubsetCopy[i].Addresses[j].TargetRef.ResourceVersion = ""
+				epSubsetCopy[i].Addresses[j].TargetRef.UID = ""
 			}
 		}
-		for _, addr := range each.NotReadyAddresses {
+		for j, addr := range each.NotReadyAddresses {
 			if addr.TargetRef != nil {
-				addr.TargetRef.Namespace = ""
-				addr.TargetRef.ResourceVersion = ""
-				addr.TargetRef.UID = ""
+				epSubsetCopy[i].Addresses[j].TargetRef.Namespace = ""
+				epSubsetCopy[i].Addresses[j].TargetRef.ResourceVersion = ""
+				epSubsetCopy[i].Addresses[j].TargetRef.UID = ""
 			}
 		}
 	}

--- a/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
+++ b/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
@@ -375,6 +375,8 @@ func getTargetObject(objectType runtime.Object) runtime.Object {
 		return &v1.PersistentVolumeClaim{}
 	case *v1.PersistentVolume:
 		return &v1.PersistentVolume{}
+	case *v1.Endpoints:
+		return &v1.Endpoints{}
 	default:
 		return nil
 	}
@@ -402,6 +404,8 @@ func getTargetObjectList(objectType runtime.Object) runtime.Object {
 		return &v1.PersistentVolumeClaimList{}
 	case *v1.PersistentVolume:
 		return &v1.PersistentVolumeList{}
+	case *v1.Endpoints:
+		return &v1.EndpointsList{}
 	default:
 		return nil
 	}

--- a/incubator/virtualcluster/pkg/syncer/resources/endpoints/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/endpoints/checker.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+ Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoints
+
+import (
+	"fmt"
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+)
+
+// StartPeriodChecker starts the period checker for data consistency check. Checker is
+// blocking so should be called via a goroutine.
+func (c *controller) StartPeriodChecker(stopCh <-chan struct{}) error {
+	defer utilruntime.HandleCrash()
+
+	if !cache.WaitForCacheSync(stopCh, c.endpointsSynced) {
+		return fmt.Errorf("failed to wait for caches to sync before starting Endpoint checker")
+	}
+
+	// Start a loop to periodically check if endPoints keep consistency between super
+	// master and tenant masters.
+	wait.Until(c.checkEndPoints, c.periodCheckerPeriod, stopCh)
+
+	return nil
+}
+
+// checkEndPoints checks to see if Endpoints in super master informer cache and tenant master
+// keep consistency.
+// Note that eps are managed by tenant/super ep controller separately. The checker will not do GC but only report diff.
+func (c *controller) checkEndPoints() {
+	clusterNames := c.multiClusterEndpointsController.GetClusterNames()
+	if len(clusterNames) == 0 {
+		klog.Infof("tenant masters has no clusters, give up period checker")
+		return
+	}
+
+	wg := sync.WaitGroup{}
+
+	for _, clusterName := range clusterNames {
+		wg.Add(1)
+		go func(clusterName string) {
+			defer wg.Done()
+			c.checkEndPointsOfTenantCluster(clusterName)
+		}(clusterName)
+	}
+	wg.Wait()
+}
+
+// checkEndPointsOfTenantCluster checks to see if endpoints controller in tenant and super master working consistently.
+func (c *controller) checkEndPointsOfTenantCluster(clusterName string) {
+	listObj, err := c.multiClusterEndpointsController.List(clusterName)
+	if err != nil {
+		klog.Errorf("error listing endpoints from cluster %s informer cache: %v", clusterName, err)
+		return
+	}
+	klog.Infof("check endpoints consistency in cluster %s", clusterName)
+	epList := listObj.(*v1.EndpointsList)
+	for _, vEp := range epList.Items {
+		targetNamespace := conversion.ToSuperMasterNamespace(clusterName, vEp.Namespace)
+		pEp, err := c.endpointsLister.Endpoints(targetNamespace).Get(vEp.Name)
+		if errors.IsNotFound(err) {
+			// pEp not found and vEp still exists, report the inconsistent ep controller behavior
+			klog.Errorf("Cannot find pEp %v/%v in super master", targetNamespace, vEp.Name)
+			continue
+		}
+		if err != nil {
+			klog.Errorf("error getting pEp %s/%s from super master cache: %v", targetNamespace, vEp.Name, err)
+		}
+		updated := conversion.Equality(nil).CheckEndpointsEquality(pEp, &vEp)
+		if updated != nil {
+			klog.Warningf("Endpoint %v/%v diff in super&tenant master", targetNamespace, vEp.Name)
+		}
+	}
+}

--- a/incubator/virtualcluster/pkg/syncer/resources/endpoints/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/endpoints/controller.go
@@ -17,6 +17,8 @@ limitations under the License.
 package endpoints
 
 import (
+	"time"
+
 	v1 "k8s.io/api/core/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -37,6 +39,8 @@ type controller struct {
 	endpointsSynced cache.InformerSynced
 	// Connect to all tenant master endpoints informers
 	multiClusterEndpointsController *mc.MultiClusterController
+	// Checker timer
+	periodCheckerPeriod time.Duration
 }
 
 func Register(
@@ -46,7 +50,8 @@ func Register(
 	controllerManager *manager.ControllerManager,
 ) {
 	c := &controller{
-		endpointClient: endpointsClient,
+		endpointClient:      endpointsClient,
+		periodCheckerPeriod: 60 * time.Second,
 	}
 
 	options := mc.Options{Reconciler: c}
@@ -63,10 +68,6 @@ func Register(
 }
 
 func (c *controller) StartUWS(stopCh <-chan struct{}) error {
-	return nil
-}
-
-func (c *controller) StartPeriodChecker(stopCh <-chan struct{}) error {
 	return nil
 }
 

--- a/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/checker.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+ Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serviceaccount
+
+import (
+	"fmt"
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
+)
+
+// StartPeriodChecker starts the period checker for data consistency check. Checker is
+// blocking so should be called via a goroutine.
+func (c *controller) StartPeriodChecker(stopCh <-chan struct{}) error {
+	defer utilruntime.HandleCrash()
+
+	if !cache.WaitForCacheSync(stopCh, c.saSynced) {
+		return fmt.Errorf("failed to wait for caches to sync before starting SA checker")
+	}
+
+	// Start a loop to periodically check if serviceaccounts keep consistency between super
+	// master and tenant masters.
+	wait.Until(c.checkServiceAccounts, c.periodCheckerPeriod, stopCh)
+
+	return nil
+}
+
+// checkServiceAccounts checks to see if serviceaccounts in super master informer cache and tenant master
+// keep consistency.
+func (c *controller) checkServiceAccounts() {
+	clusterNames := c.multiClusterServiceAccountController.GetClusterNames()
+	if len(clusterNames) == 0 {
+		klog.Infof("tenant masters has no clusters, give up period checker")
+		return
+	}
+
+	wg := sync.WaitGroup{}
+
+	for _, clusterName := range clusterNames {
+		wg.Add(1)
+		go func(clusterName string) {
+			defer wg.Done()
+			c.checkServiceAccountsOfTenantCluster(clusterName)
+		}(clusterName)
+	}
+	wg.Wait()
+
+	pServiceAccounts, err := c.saLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("error listing serviceaccounts from super master informer cache: %v", err)
+		return
+	}
+
+	for _, pSa := range pServiceAccounts {
+		clusterName, vNamespace := conversion.GetVirtualOwner(pSa)
+		if len(clusterName) == 0 || len(vNamespace) == 0 {
+			continue
+		}
+
+		_, err := c.multiClusterServiceAccountController.Get(clusterName, vNamespace, pSa.Name)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				// vSa not found and pSa still exist, we need to delete pSa manually
+				deleteOptions := &metav1.DeleteOptions{}
+				deleteOptions.Preconditions = metav1.NewUIDPreconditions(string(pSa.UID))
+				if err = c.saClient.ServiceAccounts(pSa.Namespace).Delete(pSa.Name, deleteOptions); err != nil {
+					klog.Errorf("error deleting pServiceAccount %v/%v in super master: %v", pSa.Namespace, pSa.Name, err)
+				}
+				continue
+			}
+			klog.Errorf("error getting vServiceAccount %s/%s from cluster %s cache: %v", vNamespace, pSa.Name, clusterName, err)
+		}
+	}
+}
+
+// ccheckServiceAccountsOfTenantCluste checks to see if serviceaccounts in specific cluster keeps consistency.
+func (c *controller) checkServiceAccountsOfTenantCluster(clusterName string) {
+	listObj, err := c.multiClusterServiceAccountController.List(clusterName)
+	if err != nil {
+		klog.Errorf("error listing serviceaccounts from cluster %s informer cache: %v", clusterName, err)
+		return
+	}
+	klog.Infof("check serviceaccounts consistency in cluster %s", clusterName)
+	saList := listObj.(*v1.ServiceAccountList)
+	for i, vSa := range saList.Items {
+		targetNamespace := conversion.ToSuperMasterNamespace(clusterName, vSa.Namespace)
+		_, err := c.saLister.ServiceAccounts(targetNamespace).Get(vSa.Name)
+		if errors.IsNotFound(err) {
+			// pSa not found and vSa still exists, we need to create pSa again
+			if err := c.multiClusterServiceAccountController.RequeueObject(clusterName, &saList.Items[i], reconciler.AddEvent); err != nil {
+				klog.Errorf("error requeue vServiceAccount %v/%v in cluster %s: %v", vSa.Namespace, vSa.Name, clusterName, err)
+			}
+			continue
+		}
+
+		if err != nil {
+			klog.Errorf("error getting pServiceAccount %s/%s from super master cache: %v", targetNamespace, vSa.Name, err)
+		}
+		// Serviceaccounts are handled by sa controller in tenant/super master separately. The secrets of pSa and vSa are not expected to be equal
+	}
+}


### PR DESCRIPTION
This change adds checker for endpoints and serviceaccount checkers. The implementation mostly follows the routines. 

- The endpoints equality method is changed since the ep are handled by tenant/super ep controller separately, hence the target Ref cannot be the same.
- For serviceaccount, we don't compare the secrets since they are created by tenant/super sa controller separately. 