### PR TITLE
[Incubator][VC]Avoid duplicated root namespace name for virtual cluster

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/cluster/cluster.go
+++ b/incubator/virtualcluster/pkg/syncer/cluster/cluster.go
@@ -49,6 +49,8 @@ import (
 // The dependencies are lazily created in getters and cached for reuse.
 // It is not thread safe.
 type Cluster struct {
+	// The root namespace name for this cluster
+	key string
 	// Name of the corresponding virtual cluster object.
 	VCName string
 	// Namespace of the corresponding virtual cluster object.
@@ -102,7 +104,7 @@ type CacheOptions struct {
 var _ mccontroller.ClusterInterface = &Cluster{}
 
 // New creates a new Cluster.
-func NewTenantCluster(namespace, name string, vclister vclisters.VirtualclusterLister, configBytes []byte, o Options) (*Cluster, error) {
+func NewTenantCluster(key, namespace, name string, vclister vclisters.VirtualclusterLister, configBytes []byte, o Options) (*Cluster, error) {
 	clusterRestConfig, err := clientcmd.RESTConfigFromKubeConfig(configBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build rest config: %v", err)
@@ -114,6 +116,7 @@ func NewTenantCluster(namespace, name string, vclister vclisters.VirtualclusterL
 	}
 
 	return &Cluster{
+		key:              key,
 		VCName:           name,
 		VCNamespace:      namespace,
 		vclister:         vclister,
@@ -124,9 +127,9 @@ func NewTenantCluster(namespace, name string, vclister vclisters.VirtualclusterL
 		stopCh:           make(chan struct{})}, nil
 }
 
-// GetClusterName returns the unique cluster name, aka, the full name of virtual cluster CRD.
+// GetClusterName returns the unique cluster name, aka, the root namespace name.
 func (c *Cluster) GetClusterName() string {
-	return c.VCNamespace + "-" + c.VCName
+	return c.key
 }
 
 // GetSpec returns the virtual cluster spec.

--- a/incubator/virtualcluster/pkg/syncer/conversion/helper.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/helper.go
@@ -42,14 +42,12 @@ const (
 
 var masterServices = sets.NewString("kubernetes")
 
-// ToClusterKey make a unique id for a virtual cluster object.
-// The key uses the format <namespace>-<name> unless <namespace> is empty, then
-// it's just <name>.
+// ToClusterKey makes a unique key which is used to create the root namespace in super master for a virtual cluster.
+// To avoid name conflict, the key uses the format <namespace>-<hash>-<name>
 func ToClusterKey(vc *v1alpha1.Virtualcluster) string {
-	if len(vc.GetNamespace()) > 0 {
-		return vc.GetNamespace() + "-" + vc.GetName()
-	}
-	return vc.GetName()
+	fullname := vc.GetNamespace() + "/" + vc.GetName()
+	digest := sha256.Sum256([]byte(fullname))
+	return vc.GetNamespace() + "-" + hex.EncodeToString(digest[0:])[0:5] + "-" + vc.GetName()
 }
 
 func ToSuperMasterNamespace(cluster, ns string) string {

--- a/incubator/virtualcluster/pkg/syncer/conversion/helper.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/helper.go
@@ -45,9 +45,8 @@ var masterServices = sets.NewString("kubernetes")
 // ToClusterKey makes a unique key which is used to create the root namespace in super master for a virtual cluster.
 // To avoid name conflict, the key uses the format <namespace>-<hash>-<name>
 func ToClusterKey(vc *v1alpha1.Virtualcluster) string {
-	fullname := vc.GetNamespace() + "/" + vc.GetName()
-	digest := sha256.Sum256([]byte(fullname))
-	return vc.GetNamespace() + "-" + hex.EncodeToString(digest[0:])[0:5] + "-" + vc.GetName()
+	digest := sha256.Sum256([]byte(vc.GetUID()))
+	return vc.GetNamespace() + "-" + hex.EncodeToString(digest[0:])[0:6] + "-" + vc.GetName()
 }
 
 func ToSuperMasterNamespace(cluster, ns string) string {

--- a/incubator/virtualcluster/pkg/syncer/syncer.go
+++ b/incubator/virtualcluster/pkg/syncer/syncer.go
@@ -264,10 +264,10 @@ func (s *Syncer) addCluster(key string, vc *v1alpha1.Virtualcluster) error {
 
 	adminKubeConfigSecret, err := s.secretClient.Secrets(clusterName).Get(KubeconfigAdmin, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to get secret (%s) for virtual cluster %s/%s: %v", KubeconfigAdmin, vc.Namespace, vc.Name, err)
+		return fmt.Errorf("failed to get secret (%s) for virtual cluster in root namespace %s: %v", KubeconfigAdmin, clusterName, err)
 	}
 
-	tenantCluster, err := cluster.NewTenantCluster(vc.Namespace, vc.Name, s.lister, adminKubeConfigSecret.Data[KubeconfigAdmin], cluster.Options{})
+	tenantCluster, err := cluster.NewTenantCluster(clusterName, vc.Namespace, vc.Name, s.lister, adminKubeConfigSecret.Data[KubeconfigAdmin], cluster.Options{})
 	if err != nil {
 		return fmt.Errorf("failed to new tenant cluster %s/%s: %v", vc.Namespace, vc.Name, err)
 	}


### PR DESCRIPTION
We cannot assume vc.namespace + "-" + vc.Name is unique in supermaster. 
For example:

vc.namespace : tenant-a
vc.name: vc1
vs.
vc.namespace : tenant
vc.name: a-vc1

This change adds a hash string in between to avoid naming conflict in super master.

Local test result:

tenant1admin-c1fba-vc-sample-1                   Active   99s
tenant1admin-c1fba-vc-sample-1-default           Active   99s
tenant1admin-c1fba-vc-sample-1-kube-node-lease   Active   45s
tenant1admin-c1fba-vc-sample-1-kube-public       Active   45s
tenant1admin-c1fba-vc-sample-1-kube-system       Active   45s
vc-manager                                       Active   32d