### PR TITLE
[Incubator][VC]Avoid infinite retries if virtual cluster is removed

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/constants/constants.go
+++ b/incubator/virtualcluster/pkg/syncer/constants/constants.go
@@ -54,6 +54,8 @@ const (
 
 	// DefaultvNodeGCGracePeriod is the grace period of time before deleting an orphan vNode in tenant master.
 	DefaultvNodeGCGracePeriod = time.Second * 120
+	// If Uws request keeps failing, stop retrying after DefaultUwsRetryTimePeriod.
+	DefaultUwsRetryTimePeriod = time.Second * 300
 
 	DefaultOpaqueMetaPrefix = "tenancy.x-k8s.io"
 )

--- a/incubator/virtualcluster/pkg/syncer/conversion/helper_test.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/helper_test.go
@@ -189,23 +189,15 @@ func TestToClusterKey(t *testing.T) {
 		expectedKey string
 	}{
 		{
-			name: "vc without namespace",
-			vc: &v1alpha1.Virtualcluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "name",
-				},
-			},
-			expectedKey: "name",
-		},
-		{
 			name: "normal vc",
 			vc: &v1alpha1.Virtualcluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "name",
 					Namespace: "ns",
+					UID:       "d64ea0c0-91f8-46f5-8643-c0cab32ab0cd",
 				},
 			},
-			expectedKey: "ns-name",
+			expectedKey: "ns-fd1b34-name",
 		},
 	} {
 		t.Run(tt.name, func(tc *testing.T) {

--- a/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
+++ b/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
@@ -330,6 +330,13 @@ func (c *MultiClusterController) processNextWorkItem() bool {
 		// Return true, don't take a break
 		return true
 	}
+	if c.getCluster(req.Cluster.Name) == nil {
+		// The virtual cluster has been removed, do not reconcile for its dws requests.
+		klog.Warningf("The cluster %s has been removed, drop the dws request %v", req.Cluster.Name, req)
+		c.Queue.Forget(obj)
+		return true
+	}
+
 	// RunInformersAndControllers the syncHandler, passing it the cluster/namespace/Name
 	// string of the resource to be synced.
 	if result, err := c.Reconciler.Reconcile(req); err != nil {

--- a/incubator/virtualcluster/pkg/syncer/reconciler/reconciler.go
+++ b/incubator/virtualcluster/pkg/syncer/reconciler/reconciler.go
@@ -17,6 +17,7 @@ limitations under the License.
 package reconciler
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 
@@ -60,4 +61,11 @@ type Result reconcile.Result
 // Reconciler is the interface used by a Controller to reconcile.
 type Reconciler interface {
 	Reconcile(Request) (Result, error)
+}
+
+type UwsRequest struct {
+	Key              string
+	FirstFailureTime *metav1.Time
+	// Optional, in many cases, the cluster name is unknown when uws request is created
+	ClusterName string
 }

--- a/incubator/virtualcluster/pkg/syncer/resources/event/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/event/controller.go
@@ -115,7 +115,7 @@ func (c *controller) enqueueEvent(obj interface{}) {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %v: %v", obj, err))
 		return
 	}
-	c.queue.Add(key)
+	c.queue.Add(reconciler.UwsRequest{Key: key})
 }
 
 func (c *controller) StartDWS(stopCh <-chan struct{}) error {

--- a/incubator/virtualcluster/pkg/syncer/resources/event/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/event/uws.go
@@ -27,7 +27,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
 )
 
 // StartUWS starts the upward syncer
@@ -60,21 +62,37 @@ func (c *controller) run() {
 }
 
 func (c *controller) processNextWorkItem() bool {
-	key, quit := c.queue.Get()
+	obj, quit := c.queue.Get()
 	if quit {
 		return false
 	}
-	defer c.queue.Done(key)
+	defer c.queue.Done(obj)
 
-	klog.Infof("back populate event %+v", key)
-	err := c.backPopulate(key.(string))
-	if err == nil {
-		c.queue.Forget(key)
+	req, ok := obj.(reconciler.UwsRequest)
+	if !ok {
+		c.queue.Forget(obj)
 		return true
 	}
 
-	utilruntime.HandleError(fmt.Errorf("error processing event %v (will retry): %v", key, err))
-	c.queue.AddRateLimited(key)
+	klog.Infof("back populate event %+v", req.Key)
+	err := c.backPopulate(req.Key)
+	if err == nil {
+		c.queue.Forget(obj)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("error processing event %v (will retry): %v", req.Key, err))
+	if req.FirstFailureTime == nil {
+		now := metav1.Now()
+		req.FirstFailureTime = &now
+	} else {
+		if metav1.Now().After(req.FirstFailureTime.Add(constants.DefaultUwsRetryTimePeriod)) {
+			klog.Warningf("Event uws request is dropped due to timeout: %v", req)
+			c.queue.Forget(obj)
+			return true
+		}
+	}
+	c.queue.AddRateLimited(obj)
 	return true
 }
 

--- a/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/controller.go
@@ -125,7 +125,7 @@ func (c *controller) enqueuePersistentVolume(obj interface{}) {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %v: %v", obj, err))
 		return
 	}
-	c.queue.Add(key)
+	c.queue.Add(reconciler.UwsRequest{Key: key})
 }
 
 func (c *controller) StartDWS(stopCh <-chan struct{}) error {

--- a/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/uws.go
@@ -63,21 +63,37 @@ func (c *controller) run() {
 }
 
 func (c *controller) processNextWorkItem() bool {
-	key, quit := c.queue.Get()
+	obj, quit := c.queue.Get()
 	if quit {
 		return false
 	}
-	defer c.queue.Done(key)
+	defer c.queue.Done(obj)
 
-	klog.Infof("back populate persistentvolume %+v", key)
-	err := c.backPopulate(key.(string))
-	if err == nil {
-		c.queue.Forget(key)
+	req, ok := obj.(reconciler.UwsRequest)
+	if !ok {
+		c.queue.Forget(obj)
 		return true
 	}
 
-	utilruntime.HandleError(fmt.Errorf("error processing persistentvolume %v (will retry): %v", key, err))
-	c.queue.AddRateLimited(key)
+	klog.Infof("back populate persistentvolume %+v", req.Key)
+	err := c.backPopulate(req.Key)
+	if err == nil {
+		c.queue.Forget(obj)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("error processing persistentvolume %v (will retry): %v", req.Key, err))
+	if req.FirstFailureTime == nil {
+		now := metav1.Now()
+		req.FirstFailureTime = &now
+	} else {
+		if metav1.Now().After(req.FirstFailureTime.Add(constants.DefaultUwsRetryTimePeriod)) {
+			klog.Warningf("Persistentvolume uws request is dropped due to timeout: %v", req)
+			c.queue.Forget(obj)
+			return true
+		}
+	}
+	c.queue.AddRateLimited(obj)
 	return true
 }
 

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/controller.go
@@ -167,7 +167,7 @@ func (c *controller) enqueuePod(obj interface{}) {
 		return
 	}
 
-	c.queue.Add(key)
+	c.queue.Add(reconciler.UwsRequest{Key: key})
 }
 
 // c.Mutex needs to be Locked before calling addToClusterVNodeGCMap

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
@@ -29,7 +29,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/resources/node"
 )
 
@@ -63,21 +65,37 @@ func (c *controller) run() {
 }
 
 func (c *controller) processNextWorkItem() bool {
-	key, quit := c.queue.Get()
+	obj, quit := c.queue.Get()
 	if quit {
 		return false
 	}
-	defer c.queue.Done(key)
+	defer c.queue.Done(obj)
 
-	klog.Infof("back populate pod %+v", key)
-	err := c.backPopulate(key.(string))
-	if err == nil {
-		c.queue.Forget(key)
+	req, ok := obj.(reconciler.UwsRequest)
+	if !ok {
+		c.queue.Forget(obj)
 		return true
 	}
 
-	utilruntime.HandleError(fmt.Errorf("error processing pod %v (will retry): %v", key, err))
-	c.queue.AddRateLimited(key)
+	klog.Infof("back populate pod %+v", req.Key)
+	err := c.backPopulate(req.Key)
+	if err == nil {
+		c.queue.Forget(obj)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("error processing pod %v (will retry): %v", req.Key, err))
+	if req.FirstFailureTime == nil {
+		now := metav1.Now()
+		req.FirstFailureTime = &now
+	} else {
+		if metav1.Now().After(req.FirstFailureTime.Add(constants.DefaultUwsRetryTimePeriod)) {
+			klog.Warningf("Pod uws request is dropped due to timeout: %v", req)
+			c.queue.Forget(obj)
+			return true
+		}
+	}
+	c.queue.AddRateLimited(obj)
 	return true
 }
 

--- a/incubator/virtualcluster/pkg/syncer/resources/service/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/service/controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
 )
 
 type controller struct {
@@ -129,7 +130,7 @@ func (c *controller) enqueueService(obj interface{}) {
 		return
 	}
 
-	c.queue.Add(key)
+	c.queue.Add(reconciler.UwsRequest{Key: key})
 }
 
 func (c *controller) AddCluster(cluster mc.ClusterInterface) {

--- a/incubator/virtualcluster/pkg/syncer/resources/storageclass/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/storageclass/checker.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
 )
 
 func (c *controller) StartPeriodChecker(stopCh <-chan struct{}) error {
@@ -74,7 +75,7 @@ func (c *controller) checkStorageClass() {
 			_, err := c.multiClusterStorageClassController.Get(clusterName, "", pStorageClass.Name)
 			if err != nil {
 				if errors.IsNotFound(err) {
-					c.queue.Add(scReconcileRequest{key: pStorageClass.Name, clusterName: clusterName})
+					c.queue.Add(reconciler.UwsRequest{Key: pStorageClass.Name, ClusterName: clusterName})
 				}
 				klog.Errorf("fail to get storageclass from cluster %s: %v", clusterName, err)
 			}

--- a/incubator/virtualcluster/pkg/syncer/resources/storageclass/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/storageclass/controller.go
@@ -55,11 +55,6 @@ type controller struct {
 	periodCheckerPeriod time.Duration
 }
 
-type scReconcileRequest struct {
-	key         string
-	clusterName string
-}
-
 func Register(
 	config *config.SyncerConfiguration,
 	client v1storage.StorageClassesGetter,
@@ -136,7 +131,7 @@ func (c *controller) enqueueStorageClass(obj interface{}) {
 	}
 
 	for _, clusterName := range clusterNames {
-		c.queue.Add(scReconcileRequest{key: key, clusterName: clusterName})
+		c.queue.Add(reconciler.UwsRequest{Key: key, ClusterName: clusterName})
 	}
 }
 


### PR DESCRIPTION
If a virtual cluster object is deleted, the inflight reconcile requests (both uws and dws) may keep failing. This change fixes the problem by doing the following :
- For dws controller, where the cluster who sends the request is known, the request is removed if the owner cluster does not exist. 
- For uws controller, where the destination cluster is not known when request is created, we introduce a timeout to avoid infinite retry. We have periodic checker as a backup hence a timeout mechanism should not cause permanent inconsistency. 

This change also fixes a failed UT. 