### PR TITLE
[Incubator][VC]Always read synced objects from cluster cache

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/resources/pod/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/checker.go
@@ -258,18 +258,12 @@ func (c *controller) checkPodsOfTenantCluster(clusterName string) {
 // goes to tenant master directly. If this method causes performance issue, we should consider moving it to another
 // periodic thread with a larger check interval.
 func (c *controller) checkNodesOfTenantCluster(clusterName string) {
-	tenantClient, err := c.multiClusterPodController.GetClusterClient(clusterName)
-	if err != nil {
-		klog.Errorf("failed to create client from cluster %s config: %v", clusterName, err)
-		return
-	}
-
-	nodeList, err := tenantClient.CoreV1().Nodes().List(metav1.ListOptions{})
+	listObj, err := c.multiClusterPodController.ListByObjectType(clusterName, &v1.Node{})
 	if err != nil {
 		klog.Errorf("failed to list vNode from cluster %s config: %v", clusterName, err)
 		return
 	}
-
+	nodeList := listObj.(*v1.NodeList)
 	for _, vNode := range nodeList.Items {
 		if vNode.Labels[constants.LabelVirtualNode] != "true" {
 			continue


### PR DESCRIPTION
Each cluster cache watches for all synced objects hence we can use it to satisfy all read requests for synced objects. 

In this change, accessing tenant master to Get/List node and pod resources is replaced by accessing cluster cache. To achieve this, mccontroller adds two APIs: GetByObjectType and ListByObjectType.