### PR TITLE
[Incubator][VC]Set number of dws/uws workers differently for each resource

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/constants/constants.go
+++ b/incubator/virtualcluster/pkg/syncer/constants/constants.go
@@ -38,8 +38,15 @@ const (
 	// LabelSecretName is the service account token secret name in tenant namespace.
 	LabelSecretName = "tenancy.x-k8s.io/secret.name"
 
-	// DefaultControllerWorkers is the quantity of the worker routine for a controller.
-	DefaultControllerWorkers = 3
+	// UwsControllerWorkersHigh is the quantity of the worker routine for a resource that generates high number of uws requests.
+	UwsControllerWorkerHigh = 10
+	// UwsControllerWorkersLow is the quantity of the worker routine for a resource that generates low number of uws requests.
+	UwsControllerWorkerLow = 3
+
+	// DwsControllerWorkersHigh is the quantity of the worker routine for a resource that generates high number of dws requests.
+	DwsControllerWorkerHigh = 10
+	// DwsControllerWorkersLow is the quantity of the worker routine for a resource that generates low number of dws requests.
+	DwsControllerWorkerLow = 3
 
 	// ResourceSyncerUserAgent is the userAgent name when starting resource syncer.
 	ResourceSyncerUserAgent = "resource-syncer"

--- a/incubator/virtualcluster/pkg/syncer/resources/configmap/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/configmap/controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
 )
@@ -55,7 +56,7 @@ func Register(
 	}
 
 	// Create the multi cluster configmap controller
-	options := mc.Options{Reconciler: c}
+	options := mc.Options{Reconciler: c, MaxConcurrentReconciles: constants.DwsControllerWorkerLow}
 	multiClusterConfigMapController, err := mc.NewMCController("tenant-masters-configmap-controller", &v1.ConfigMap{}, options)
 	if err != nil {
 		klog.Errorf("failed to create multi cluster configmap controller %v", err)

--- a/incubator/virtualcluster/pkg/syncer/resources/event/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/event/controller.go
@@ -63,7 +63,7 @@ func Register(
 		client:   client,
 		informer: informer,
 		queue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "super_master_event"),
-		workers:  constants.DefaultControllerWorkers,
+		workers:  constants.UwsControllerWorkerLow,
 	}
 
 	// Create the multi cluster pod controller

--- a/incubator/virtualcluster/pkg/syncer/resources/namespace/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/namespace/controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
 )
@@ -55,7 +56,7 @@ func Register(
 	}
 
 	// Create the multi cluster configmap controller
-	options := mc.Options{Reconciler: c}
+	options := mc.Options{Reconciler: c, MaxConcurrentReconciles: constants.DwsControllerWorkerLow}
 	multiClusterNamespaceController, err := mc.NewMCController("tenant-masters-namespace-controller", &v1.Namespace{}, options)
 	if err != nil {
 		klog.Errorf("failed to create multi cluster namespace controller %v", err)

--- a/incubator/virtualcluster/pkg/syncer/resources/node/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/node/controller.go
@@ -61,11 +61,11 @@ func Register(
 		nodeNameToCluster: make(map[string]map[string]struct{}),
 		nodeClient:        client,
 		queue:             workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "super_master_node"),
-		workers:           constants.DefaultControllerWorkers,
+		workers:           constants.UwsControllerWorkerHigh,
 	}
 
 	// Create the multi cluster node controller
-	options := mc.Options{Reconciler: c}
+	options := mc.Options{Reconciler: c, MaxConcurrentReconciles: constants.DwsControllerWorkerLow}
 	multiClusterNodeController, err := mc.NewMCController("tenant-masters-node-controller", &v1.Node{}, options)
 	if err != nil {
 		klog.Errorf("failed to create multi cluster pod controller %v", err)

--- a/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/controller.go
@@ -66,7 +66,7 @@ func Register(
 		client:              client,
 		informer:            informer,
 		queue:               workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "super_master_persistentvolumes"),
-		workers:             constants.DefaultControllerWorkers,
+		workers:             constants.UwsControllerWorkerLow,
 		periodCheckerPeriod: 60 * time.Second,
 	}
 

--- a/incubator/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
 )
@@ -55,7 +56,7 @@ func Register(
 	}
 
 	// Create the multi cluster PersistentVolumeClaim controller
-	options := mc.Options{Reconciler: c}
+	options := mc.Options{Reconciler: c, MaxConcurrentReconciles: constants.DwsControllerWorkerLow}
 	multiClusterPersistentVolumeClaimController, err := mc.NewMCController("tenant-masters-pvc-controller", &v1.PersistentVolumeClaim{}, options)
 	if err != nil {
 		klog.Errorf("failed to create multi cluster PersistentVolumeClaim controller %v", err)

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/controller.go
@@ -89,14 +89,14 @@ func Register(
 		client:              client,
 		informer:            informer,
 		queue:               workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "super_master_pod"),
-		workers:             constants.DefaultControllerWorkers,
+		workers:             constants.UwsControllerWorkerHigh,
 		periodCheckerPeriod: 60 * time.Second,
 		clusterVNodePodMap:  make(map[string]map[string]map[types.UID]struct{}),
 		clusterVNodeGCMap:   make(map[string]map[string]VNodeGCStatus),
 	}
 
 	// Create the multi cluster pod controller
-	options := mc.Options{Reconciler: c}
+	options := mc.Options{Reconciler: c, MaxConcurrentReconciles: constants.DwsControllerWorkerHigh}
 	multiClusterPodController, err := mc.NewMCController("tenant-masters-pod-controller", &v1.Pod{}, options)
 	if err != nil {
 		klog.Errorf("failed to create multi cluster pod controller %v", err)

--- a/incubator/virtualcluster/pkg/syncer/resources/secret/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/secret/controller.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
 )
@@ -58,7 +59,7 @@ func Register(
 	}
 
 	// Create the multi cluster secret controller
-	options := mc.Options{Reconciler: c}
+	options := mc.Options{Reconciler: c, MaxConcurrentReconciles: constants.DwsControllerWorkerLow}
 	multiClusterSecretController, err := mc.NewMCController("tenant-masters-secret-controller", &v1.Secret{}, options)
 	if err != nil {
 		klog.Errorf("failed to create multi cluster secret controller %v", err)

--- a/incubator/virtualcluster/pkg/syncer/resources/service/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/service/controller.go
@@ -61,11 +61,11 @@ func Register(
 		serviceClient:       serviceClient,
 		periodCheckerPeriod: 60 * time.Second,
 		queue:               workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "super_master_service"),
-		workers:             constants.DefaultControllerWorkers,
+		workers:             constants.UwsControllerWorkerLow,
 	}
 
 	// Create the multi cluster service controller
-	options := mc.Options{Reconciler: c}
+	options := mc.Options{Reconciler: c, MaxConcurrentReconciles: constants.DwsControllerWorkerLow}
 	multiClusterServiceController, err := mc.NewMCController("tenant-masters-service-controller", &v1.Service{}, options)
 	if err != nil {
 		klog.Errorf("failed to create multi cluster service controller %v", err)

--- a/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
 )
@@ -55,7 +56,7 @@ func Register(
 	}
 
 	// Create the multi cluster secret controller
-	options := mc.Options{Reconciler: c}
+	options := mc.Options{Reconciler: c, MaxConcurrentReconciles: constants.DwsControllerWorkerLow}
 	multiClusterServiceAccountController, err := mc.NewMCController("tenant-masters-service-account-controller", &v1.ServiceAccount{}, options)
 	if err != nil {
 		klog.Errorf("failed to create multi cluster secret controller %v", err)

--- a/incubator/virtualcluster/pkg/syncer/resources/storageclass/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/storageclass/controller.go
@@ -70,7 +70,7 @@ func Register(
 		client:              client,
 		informer:            informer,
 		queue:               workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "super_master_storageclasses"),
-		workers:             constants.DefaultControllerWorkers,
+		workers:             constants.UwsControllerWorkerLow,
 		periodCheckerPeriod: 60 * time.Second,
 	}
 

--- a/incubator/virtualcluster/pkg/syncer/syncer.go
+++ b/incubator/virtualcluster/pkg/syncer/syncer.go
@@ -83,7 +83,7 @@ func New(
 	syncer := &Syncer{
 		secretClient: secretClient,
 		queue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virtual_cluster"),
-		workers:      constants.DefaultControllerWorkers,
+		workers:      constants.UwsControllerWorkerLow,
 		clusterSet:   make(map[string]mc.ClusterInterface),
 	}
 


### PR DESCRIPTION
The number uws/dws workers for each resource may differ based on the frequency of the event and the latency requirement of resource. 

In this change, we assign Pod the highest number of workers. Other resources will be assigned low number of workers. Node uws is given high number of workers as well due to the frequent heart beat updates. 
