### PR TITLE
Propagate empty source object to descendants if the descendants do not have not copy of the object.

### DIFF
--- a/incubator/hnc/pkg/controllers/config_controller_test.go
+++ b/incubator/hnc/pkg/controllers/config_controller_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/config"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -53,25 +52,6 @@ var _ = Describe("HNCConfiguration", func() {
 		Expect(secretInheritedFrom(ctx, barName, "foo-sec")).Should(Equal(fooName))
 	})
 })
-
-func resetHNCConfigToDefault(ctx context.Context) error {
-	c := getHNCConfig(ctx)
-	c.Spec = config.GetDefaultConfigSpec()
-	return k8sClient.Update(ctx, c)
-}
-
-func getHNCConfig(ctx context.Context) *api.HNCConfiguration {
-	return getHNCConfigWithOffset(1, ctx)
-}
-
-func getHNCConfigWithOffset(offset int, ctx context.Context) *api.HNCConfiguration {
-	snm := types.NamespacedName{Name: api.HNCConfigSingleton}
-	config := &api.HNCConfiguration{}
-	EventuallyWithOffset(offset+1, func() error {
-		return k8sClient.Get(ctx, snm, config)
-	}).Should(Succeed())
-	return config
-}
 
 func addSecretToHNCConfig(ctx context.Context, c *api.HNCConfiguration) error {
 	secSpec := api.TypeSynchronizationSpec{APIVersion: "v1", Kind: "Secret", Mode: api.Propagate}

--- a/incubator/hnc/pkg/controllers/object_controller.go
+++ b/incubator/hnc/pkg/controllers/object_controller.go
@@ -218,8 +218,11 @@ func (r *ObjectReconciler) syncPropagated(ctx context.Context, log logr.Logger, 
 		return remove, nil
 	}
 
-	// If the copy is different from the source, return the write action and the source instance.
-	if !reflect.DeepEqual(object.Canonical(inst), object.Canonical(srcInst)) {
+	// If an object doesn't exist, assume it's been deleted or not yet created.
+	exist := inst.GetCreationTimestamp() != v1.Time{}
+
+	// If the copy does not exist or is different from the source, return the write action and the source instance.
+	if !exist || !reflect.DeepEqual(object.Canonical(inst), object.Canonical(srcInst)) {
 		metadata.SetLabel(inst, api.LabelInheritedFrom, srcInst.GetNamespace())
 		return write, srcInst
 	}

--- a/incubator/hnc/pkg/controllers/test_helpers_test.go
+++ b/incubator/hnc/pkg/controllers/test_helpers_test.go
@@ -7,8 +7,10 @@ import (
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/config"
 )
 
 func setParent(ctx context.Context, nm string, pnm string) {
@@ -71,4 +73,23 @@ func updateHNCConfig(ctx context.Context, c *api.HNCConfiguration) error {
 	} else {
 		return k8sClient.Update(ctx, c)
 	}
+}
+
+func resetHNCConfigToDefault(ctx context.Context) error {
+	c := getHNCConfig(ctx)
+	c.Spec = config.GetDefaultConfigSpec()
+	return k8sClient.Update(ctx, c)
+}
+
+func getHNCConfig(ctx context.Context) *api.HNCConfiguration {
+	return getHNCConfigWithOffset(1, ctx)
+}
+
+func getHNCConfigWithOffset(offset int, ctx context.Context) *api.HNCConfiguration {
+	snm := types.NamespacedName{Name: api.HNCConfigSingleton}
+	config := &api.HNCConfiguration{}
+	EventuallyWithOffset(offset+1, func() error {
+		return k8sClient.Get(ctx, snm, config)
+	}).Should(Succeed())
+	return config
 }


### PR DESCRIPTION
Currently an empty source object will not be propagated to descendants if the descendants do not have any copy of the object as reported in #441. The PR fixes this issue so that empty source object will be propagated to descendants if the descendants do not have the copy of the object.

Fixes #441