### PR TITLE
[Incubator][VC]Add checker metrics for resource mismatch counts and remediation counts

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/metrics/metrics.go
+++ b/incubator/virtualcluster/pkg/syncer/metrics/metrics.go
@@ -28,6 +28,8 @@ const (
 	PodOperationsKey         = "pod_operations_total"
 	PodOperationsDurationKey = "pod_operations_duration_seconds"
 	PodOperationsErrorsKey   = "pod_operations_errors_total"
+	CheckerMissMatchKey      = "checker_missmatch_count"
+	CheckerRemedyKey         = "checker_remedy_count"
 )
 
 var (
@@ -56,6 +58,22 @@ var (
 		},
 		[]string{"operation_type"},
 	)
+	CheckerMissMatchStats = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: ResourceSyncerSubsystem,
+			Name:      CheckerMissMatchKey,
+			Help:      "Last checker scan results for mismatched resources.",
+		},
+		[]string{"counter_name"},
+	)
+	CheckerRemedyStats = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: ResourceSyncerSubsystem,
+			Name:      CheckerRemedyKey,
+			Help:      "Cumulative number of checker remediation actions.",
+		},
+		[]string{"counter_name"},
+	)
 )
 
 var registerMetrics sync.Once
@@ -66,6 +84,8 @@ func Register() {
 		prometheus.MustRegister(PodOperations)
 		prometheus.MustRegister(PodOperationsDuration)
 		prometheus.MustRegister(PodOperationsErrors)
+		prometheus.MustRegister(CheckerMissMatchStats)
+		prometheus.MustRegister(CheckerRemedyStats)
 	})
 }
 

--- a/incubator/virtualcluster/pkg/syncer/resources/endpoints/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/endpoints/dws.go
@@ -17,9 +17,12 @@ limitations under the License.
 package endpoints
 
 import (
+	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
@@ -28,13 +31,18 @@ import (
 )
 
 func (c *controller) StartDWS(stopCh <-chan struct{}) error {
-	// FIXME(zhuangqh): temorary bypass endpoints dws
-	// sign away the right of control to super master kcm.
-	return nil
+	if !cache.WaitForCacheSync(stopCh, c.endpointsSynced) {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+	return c.multiClusterEndpointsController.Start(stopCh)
 }
 
 // The reconcile logic for tenant master endpoints informer
 func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
+	if request.Namespace != "default" || request.Name != "kubernetes" {
+		// For now, we bypass all ep events beside the default kubernetes ep. The tenant/master ep controllers handle ep lifecycle independently.
+		return reconciler.Result{}, nil
+	}
 	klog.Infof("reconcile endpoints %s/%s %s event for cluster %s", request.Namespace, request.Name, request.Event, request.Cluster.Name)
 
 	switch request.Event {

--- a/incubator/virtualcluster/pkg/syncer/resources/service/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/service/checker.go
@@ -19,6 +19,7 @@ package service
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -29,8 +30,11 @@ import (
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/metrics"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
 )
+
+var numMissMatchedServices uint64
 
 func (c *controller) StartPeriodChecker(stopCh <-chan struct{}) error {
 	if !cache.WaitForCacheSync(stopCh, c.serviceSynced) {
@@ -51,6 +55,7 @@ func (c *controller) checkServices() {
 	}
 
 	wg := sync.WaitGroup{}
+	numMissMatchedServices = 0
 
 	for _, clusterName := range clusterNames {
 		wg.Add(1)
@@ -78,10 +83,14 @@ func (c *controller) checkServices() {
 			deleteOptions := metav1.NewPreconditionDeleteOptions(string(pService.UID))
 			if err = c.serviceClient.Services(pService.Namespace).Delete(pService.Name, deleteOptions); err != nil {
 				klog.Errorf("error deleting pService %s/%s in super master: %v", pService.Namespace, pService.Name, err)
+			} else {
+				metrics.CheckerRemedyStats.WithLabelValues("numDeletedOrphanSuperMasterServices").Inc()
 			}
 			continue
 		}
 	}
+
+	metrics.CheckerMissMatchStats.WithLabelValues("numMissMatchedServices").Set(float64(numMissMatchedServices))
 }
 
 func (c *controller) checkServicesOfTenantCluster(clusterName string) {
@@ -98,6 +107,8 @@ func (c *controller) checkServicesOfTenantCluster(clusterName string) {
 		if errors.IsNotFound(err) {
 			if err := c.multiClusterServiceController.RequeueObject(clusterName, &svcList.Items[i], reconciler.AddEvent); err != nil {
 				klog.Errorf("error requeue vservice %v/%v in cluster %s: %v", vService.Namespace, vService.Name, clusterName, err)
+			} else {
+				metrics.CheckerRemedyStats.WithLabelValues("numRequeuedTenantServices").Inc()
 			}
 			continue
 		}
@@ -113,6 +124,7 @@ func (c *controller) checkServicesOfTenantCluster(clusterName string) {
 		}
 		updatedService := conversion.Equality(spec).CheckServiceEquality(pService, &svcList.Items[i])
 		if updatedService != nil {
+			atomic.AddUint64(&numMissMatchedServices, 1)
 			klog.Warningf("spec of service %v/%v diff in super&tenant master", vService.Namespace, vService.Name)
 		}
 	}

--- a/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/checker.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/metrics"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
 )
 
@@ -88,6 +89,8 @@ func (c *controller) checkServiceAccounts() {
 				deleteOptions.Preconditions = metav1.NewUIDPreconditions(string(pSa.UID))
 				if err = c.saClient.ServiceAccounts(pSa.Namespace).Delete(pSa.Name, deleteOptions); err != nil {
 					klog.Errorf("error deleting pServiceAccount %v/%v in super master: %v", pSa.Namespace, pSa.Name, err)
+				} else {
+					metrics.CheckerRemedyStats.WithLabelValues("numDeletedOrphanSuperMasterServiceAccounts").Inc()
 				}
 				continue
 			}
@@ -112,6 +115,8 @@ func (c *controller) checkServiceAccountsOfTenantCluster(clusterName string) {
 			// pSa not found and vSa still exists, we need to create pSa again
 			if err := c.multiClusterServiceAccountController.RequeueObject(clusterName, &saList.Items[i], reconciler.AddEvent); err != nil {
 				klog.Errorf("error requeue vServiceAccount %v/%v in cluster %s: %v", vSa.Namespace, vSa.Name, clusterName, err)
+			} else {
+				metrics.CheckerRemedyStats.WithLabelValues("numRequeuedTenantServiceAccounts").Inc()
 			}
 			continue
 		}


### PR DESCRIPTION
This change adds metrics counters for resource checkers. The metrics include resource mismatch and checker remediations.

This change also allows syncing the tenant kubernetes ep which is not created by ep controller.