### PR TITLE
Replace "controller" with "reconciler" in hnc/pkg/controllers directory

### DIFF
--- a/incubator/hnc/README.md
+++ b/incubator/hnc/README.md
@@ -177,16 +177,18 @@ interesting directories are probably:
 
 * `/api`: the API definition.
 * `/cmd`: top-level executables. Currently the manager and the kubectl plugin.
-* `/pkg/controllers`: the reconcilers and their tests
+* `/pkg/reconcilers`: the reconcilers and their tests
 * `/pkg/validators`: validating admission controllers
-* `/pkg/forest`: the in-memory data structure, shared between the controllers
+* `/pkg/forest`: the in-memory data structure, shared between the reconcilers
   and validators.
 
-Within the `controllers` directory, there are two controller:
+Within the `reconcilers` directory, there are three reconcilers:
 
-* **Hierarchy controller:** manages the hierarchy via the `Hierarchy` singleton
+* **HNCConfiguration reconciler:** manages the HNCConfiguration via the
+  cluster-wide `config` singleton.
+* **Hierarchy reconciler:** manages the hierarchy via the `Hierarchy` singleton
   as well as the namespace in which it lives.
-* **Object controller:** Propagates (copies and deletes) the relevant objects
+* **Object reconciler:** Propagates (copies and deletes) the relevant objects
   from parents to children. Instantiated once for every supported object GVK
   (group/version/kind) - e.g., `Role`, `Secret`, etc.
 

--- a/incubator/hnc/cmd/manager/main.go
+++ b/incubator/hnc/cmd/manager/main.go
@@ -35,8 +35,8 @@ import (
 	// +kubebuilder:scaffold:imports
 
 	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/controllers"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/forest"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/reconcilers"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/stats"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/validators"
 )
@@ -131,7 +131,7 @@ func main() {
 	// Create all reconciling controllers
 	f := forest.NewForest()
 	setupLog.Info("Creating controllers", "maxReconciles", maxReconciles)
-	if err := controllers.Create(mgr, f, maxReconciles); err != nil {
+	if err := reconcilers.Create(mgr, f, maxReconciles); err != nil {
 		setupLog.Error(err, "cannot create controllers")
 		os.Exit(1)
 	}

--- a/incubator/hnc/pkg/reconcilers/hierarchy_config.go
+++ b/incubator/hnc/pkg/reconcilers/hierarchy_config.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package reconcilers
 
 import (
 	"context"

--- a/incubator/hnc/pkg/reconcilers/hierarchy_config_test.go
+++ b/incubator/hnc/pkg/reconcilers/hierarchy_config_test.go
@@ -1,4 +1,4 @@
-package controllers_test
+package reconcilers_test
 
 import (
 	"context"

--- a/incubator/hnc/pkg/reconcilers/hnc_config.go
+++ b/incubator/hnc/pkg/reconcilers/hnc_config.go
@@ -1,4 +1,4 @@
-package controllers
+package reconcilers
 
 import (
 	"context"
@@ -153,7 +153,7 @@ func (r *ConfigReconciler) createObjectReconciler(gvk schema.GroupVersionKind) e
 
 	or := &ObjectReconciler{
 		Client:            r.Client,
-		Log:               ctrl.Log.WithName("controllers").WithName(gvk.Kind),
+		Log:               ctrl.Log.WithName("reconcilers").WithName(gvk.Kind),
 		Forest:            r.Forest,
 		GVK:               gvk,
 		Affected:          make(chan event.GenericEvent),

--- a/incubator/hnc/pkg/reconcilers/hnc_config_test.go
+++ b/incubator/hnc/pkg/reconcilers/hnc_config_test.go
@@ -1,4 +1,4 @@
-package controllers_test
+package reconcilers_test
 
 import (
 	"context"

--- a/incubator/hnc/pkg/reconcilers/object.go
+++ b/incubator/hnc/pkg/reconcilers/object.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package reconcilers
 
 import (
 	"context"

--- a/incubator/hnc/pkg/reconcilers/object_test.go
+++ b/incubator/hnc/pkg/reconcilers/object_test.go
@@ -1,4 +1,4 @@
-package controllers_test
+package reconcilers_test
 
 import (
 	"context"
@@ -91,7 +91,7 @@ var _ = Describe("Secret", func() {
 		time.Sleep(1 * time.Second)
 		modifyRole(ctx, barName, "foo-role")
 
-		// Set as parent. Give the controller a chance to copy the objects and make
+		// Set as parent. Give the reconciler a chance to copy the objects and make
 		// sure that at least the correct one was copied. This gives us more confidence
 		// that if the other one *isn't* copied, this is because we decided not to, and
 		// not that we just haven't gotten to it yet.

--- a/incubator/hnc/pkg/reconcilers/setup.go
+++ b/incubator/hnc/pkg/reconcilers/setup.go
@@ -1,4 +1,4 @@
-package controllers
+package reconcilers
 
 import (
 	"fmt"
@@ -9,7 +9,7 @@ import (
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/forest"
 )
 
-// The ex map is used by controllers to exclude namespaces to reconcile. We explicitly
+// The ex map is used by reconcilers to exclude namespaces to reconcile. We explicitly
 // exclude some default namespaces with constantly changing objects.
 // TODO make the exclusion configurable - https://github.com/kubernetes-sigs/multi-tenancy/issues/374
 var ex = map[string]bool{
@@ -27,24 +27,24 @@ func Create(mgr ctrl.Manager, f *forest.Forest, maxReconciles int) error {
 	// Create the HierarchyReconciler.
 	hr := &HierarchyReconciler{
 		Client:   mgr.GetClient(),
-		Log:      ctrl.Log.WithName("controllers").WithName("Hierarchy"),
+		Log:      ctrl.Log.WithName("reconcilers").WithName("Hierarchy"),
 		Forest:   f,
 		Affected: hcChan,
 	}
 	if err := hr.SetupWithManager(mgr, maxReconciles); err != nil {
-		return fmt.Errorf("cannot create Hierarchy controller: %s", err.Error())
+		return fmt.Errorf("cannot create Hierarchy reconciler: %s", err.Error())
 	}
 
 	// Create the ConfigReconciler.
 	cr := &ConfigReconciler{
 		Client:                 mgr.GetClient(),
-		Log:                    ctrl.Log.WithName("controllers").WithName("HNCConfiguration"),
+		Log:                    ctrl.Log.WithName("reconcilers").WithName("HNCConfiguration"),
 		Manager:                mgr,
 		Forest:                 f,
 		HierarchyConfigUpdates: hcChan,
 	}
 	if err := cr.SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("cannot create Config controller: %s", err.Error())
+		return fmt.Errorf("cannot create Config reconciler: %s", err.Error())
 	}
 
 	return nil

--- a/incubator/hnc/pkg/reconcilers/suite_test.go
+++ b/incubator/hnc/pkg/reconcilers/suite_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers_test
+package reconcilers_test
 
 import (
 	"context"
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/reconcilers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -36,7 +37,6 @@ import (
 
 	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/config"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/controllers"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/forest"
 )
 
@@ -55,7 +55,7 @@ func TestAPIs(t *testing.T) {
 
 	SetDefaultEventuallyTimeout(time.Second * 2)
 	RunSpecsWithDefaultAndCustomReporters(t,
-		"Controller Suite",
+		"Reconciler Suite",
 		[]Reporter{envtest.NewlineReporter{}})
 }
 
@@ -86,7 +86,7 @@ var _ = BeforeSuite(func(done Done) {
 		Scheme: scheme.Scheme,
 	})
 	Expect(err).ToNot(HaveOccurred())
-	err = controllers.Create(k8sManager, forest.NewForest(), 100)
+	err = reconcilers.Create(k8sManager, forest.NewForest(), 100)
 	Expect(err).ToNot(HaveOccurred())
 
 	k8sClient = k8sManager.GetClient()

--- a/incubator/hnc/pkg/reconcilers/test_helpers_test.go
+++ b/incubator/hnc/pkg/reconcilers/test_helpers_test.go
@@ -1,4 +1,4 @@
-package controllers_test
+package reconcilers_test
 
 import (
 	"context"


### PR DESCRIPTION
Replace "controller" with "reconciler" in hnc/pkg/controllers directory. "Controllers" can refer to both reconcilers and admission controllers. Since the controllers we implemented under hnc/pkg/controllers are actually reconcilers, using "reconciler" instead of "controller" would be more precise.