### PR TITLE
#445 - flag.Parse causes issue in go 1.13

### DIFF
--- a/benchmarks/config.yaml
+++ b/benchmarks/config.yaml
@@ -1,12 +1,12 @@
-# # cluster admin kubeconfig file
+# # path to cluster administrator's kubeconfig file
 # adminKubeconfig: 
 
-# # the tenant kubeconfig and its namespace
+# # path to the tenant's kubeconfig and its namespace
 # tenantA:
 #   kubeconfig: 
 #   namespace: 
 
-# # the tenant kubeconfig and its namespace
+# # path to the tenant's kubeconfig and its namespace
 # tenantB:
 #   kubeconfig: 
 #   namespace: 

--- a/benchmarks/e2e/tests/e2e.go
+++ b/benchmarks/e2e/tests/e2e.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/onsi/ginkgo"
 	gomega "github.com/onsi/gomega"
-
 	"k8s.io/component-base/logs"
 	ginkgowrapper "k8s.io/kubernetes/test/e2e/framework/ginkgowrapper"
 

--- a/benchmarks/e2e/tests/e2e_test.go
+++ b/benchmarks/e2e/tests/e2e_test.go
@@ -13,7 +13,6 @@ func handleFlags() {
 	config.CopyFlags(config.Flags, flag.CommandLine)
 	framework.RegisterCommonFlags(flag.CommandLine)
 	framework.RegisterClusterFlags(flag.CommandLine)
-	flag.Parse()
 }
 
 func init() {
@@ -22,5 +21,6 @@ func init() {
 }
 
 func TestE2E(t *testing.T) {
+	flag.Parse()
 	RunE2ETests(t)
 }


### PR DESCRIPTION
This PR fixes #445, the issue was due to the 1.13 go release, [notes](https://tip.golang.org/doc/go1.13#testing):
>Testing flags are now registered in the new Init function, which is invoked by the generated main function for the test. As a result, testing flags are now only registered when running a test binary, and packages that call flag.Parse during package initialization may cause tests to fail. 