### PR TITLE
[Incubatore][VC]encode admin-kubeconfig in base64 before adding it to the annotation

### DIFF
--- a/incubator/virtualcluster/cmd/manager/main.go
+++ b/incubator/virtualcluster/cmd/manager/main.go
@@ -35,7 +35,7 @@ func main() {
 		metricsAddr       string
 		masterProvisioner string
 	)
-	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-addr", ":0", "The address the metric endpoint binds to.")
 	flag.StringVar(&masterProvisioner, "master-prov", "native", "The underlying platform that will provision master for virtualcluster.")
 	flag.Parse()
 	logf.SetLogger(logf.ZapLogger(false))

--- a/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_aliyun.go
+++ b/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_aliyun.go
@@ -18,6 +18,7 @@ package virtualcluster
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -440,7 +441,7 @@ func (mpa *MasterProvisionerAliyun) CreateVirtualCluster(vc *tenancyv1alpha1.Vir
 		clsState string
 		clsSlbId string
 	)
-	creationTimeout := time.After(100 * time.Second)
+	creationTimeout := time.After(600 * time.Second)
 	clsID, err = sendCreationRequest(cli, vc.Name, askCfg)
 	if err != nil {
 		if !isSDKErr(err) {
@@ -536,7 +537,8 @@ PollASK:
 		return err
 	}
 	log.Info("cluster ID has been added to vc as an annotation", "vc", vc.GetName(), "cluster-id", clsID)
-	err = kubeutil.AnnotateVC(mpa, vc, AnnotationKubeconfig, kbCfg, log)
+	kbCfgB64 := base64.StdEncoding.EncodeToString([]byte(kbCfg))
+	err = kubeutil.AnnotateVC(mpa, vc, AnnotationKubeconfig, kbCfgB64, log)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
1. change metric-address of the controller manager to ":0" to prevent port collision
2. change ask timeout to 600 seconds
3. encode admin-kubeconfig in base64 before adding it to the annotation