### PR TITLE
Create the empty HierarchicalNamespaceReconciler

### DIFF
--- a/incubator/hnc/api/v1alpha1/hierarchical_namespace.go
+++ b/incubator/hnc/api/v1alpha1/hierarchical_namespace.go
@@ -20,14 +20,15 @@ import (
 )
 
 // HNSState describes the state of a hierarchical namespace. The state could be
-// "missing", "ok" or "conflict". The definitions will be described below.
+// "missing", "ok", "conflict" or "forbidden". The definitions will be described below.
 type HNSState string
 
 // HNSStates, which are documented in the comment to HierarchicalNamespaceStatus.State.
 const (
-	Missing  HNSState = "missing"
-	Ok       HNSState = "ok"
-	Conflict HNSState = "conflict"
+	Missing   HNSState = "missing"
+	Ok        HNSState = "ok"
+	Conflict  HNSState = "conflict"
+	Forbidden HNSState = "forbidden"
 )
 
 // HierarchicalNamespaceStatus defines the observed state of HierarchicalNamespace.
@@ -41,8 +42,11 @@ type HierarchicalNamespaceStatus struct {
 	//
 	// - "ok": the child namespace exists.
 	//
-	// - "conflict": a namespace of the same name already exists. If the validation webhook
-	// works properly, this should never happen since the HNS won't be created at the first place.
+	// - "conflict": a namespace of the same name already exists. The admission controller
+	// will attempt to prevent this.
+	//
+	// - "forbidden": the HNS was created in a namespace that doesn't allow children, such
+	// as kube-system or hnc-system. The admission controller will attempt to prevent this.
 	State HNSState `json:"status,omitempty"`
 }
 

--- a/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hierarchicalnamespaces.yaml
+++ b/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hierarchicalnamespaces.yaml
@@ -42,9 +42,10 @@ spec:
                 the supported values are: \n - \"missing\": the child namespace has
                 not been created yet. This should be the default state when the HNS
                 is just created. \n - \"ok\": the child namespace exists. \n - \"conflict\":
-                a namespace of the same name already exists. If the validation webhook
-                works properly, this should never happen since the HNS won't be created
-                at the first place."
+                a namespace of the same name already exists. The admission controller
+                will attempt to prevent this. \n - \"forbidden\": the HNS was created
+                in a namespace that doesn't allow children, such as kube-system or
+                hnc-system. The admission controller will attempt to prevent this."
               type: string
           type: object
       type: object

--- a/incubator/hnc/pkg/reconcilers/hierarchical_namespace.go
+++ b/incubator/hnc/pkg/reconcilers/hierarchical_namespace.go
@@ -1,0 +1,51 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcilers
+
+import (
+	"github.com/go-logr/logr"
+	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// HierarchicalNamespaceReconciler reconciles HierarchicalNamespace CRs to make sure
+// all the hierarchical namespaces are properly maintained.
+type HierarchicalNamespaceReconciler struct {
+	client.Client
+	Log logr.Logger
+}
+
+// Reconcile sets up some basic variables and then calls the business logic.
+// It currently only generates some logs for testing.
+func (r *HierarchicalNamespaceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	// TODO report error state if the webhook is bypassed - see issue
+	//  https://github.com/kubernetes-sigs/multi-tenancy/issues/459
+	if ex[req.Namespace] {
+		return ctrl.Result{}, nil
+	}
+
+	log := r.Log.WithValues("trigger", req.NamespacedName)
+	log.Info("Reconciling HNS")
+
+	return ctrl.Result{}, nil
+}
+
+func (r *HierarchicalNamespaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&api.HierarchicalNamespace{}).
+		Complete(r)
+}

--- a/incubator/hnc/pkg/reconcilers/hnc_config.go
+++ b/incubator/hnc/pkg/reconcilers/hnc_config.go
@@ -126,8 +126,8 @@ func (r *ConfigReconciler) createObjectReconcilers(inst *api.HNCConfiguration) e
 	// reconcilers. It is sufficient because both write and read access to the list are guarded by the same mutex.
 	//
 	// We use the forest mutex to guard ObjectReconciler creation together with types list modification so that the
-	// forest cannot be changed by the HierarchyReconciler until both actions are finished. If we do not use the
-	// forest mutex to guard both actions, HierarchyReconciler might change the forest structure and read the types list
+	// forest cannot be changed by the HierarchyConfigReconciler until both actions are finished. If we do not use the
+	// forest mutex to guard both actions, HierarchyConfigReconciler might change the forest structure and read the types list
 	// from the forest for the object reconciliation, after we create ObjectReconcilers but before we write the
 	// ObjectReconcilers to the types list. As a result, objects of the newly added types might not be propagated correctly
 	// using the latest forest structure.

--- a/incubator/hnc/pkg/reconcilers/object.go
+++ b/incubator/hnc/pkg/reconcilers/object.go
@@ -57,7 +57,7 @@ type ObjectReconciler struct {
 	client.Client
 	Log logr.Logger
 
-	// Forest is the in-memory forest managed by the HierarchyReconciler.
+	// Forest is the in-memory forest managed by the HierarchyConfigReconciler.
 	Forest *forest.Forest
 
 	// GVK is the group/version/kind handled by this reconciler.
@@ -74,7 +74,7 @@ type ObjectReconciler struct {
 
 // +kubebuilder:rbac:groups=*,resources=*,verbs=get;list;watch;create;update;patch;delete
 
-// SyncNamespace can be called manually by the HierarchyReconciler when the hierarchy changes.
+// SyncNamespace can be called manually by the HierarchyConfigReconciler when the hierarchy changes.
 // It enqueues all the current objects in the namespace and local copies of the original objects
 // in the ancestors.
 func (r *ObjectReconciler) SyncNamespace(ctx context.Context, log logr.Logger, ns string) error {

--- a/incubator/hnc/pkg/reconcilers/setup.go
+++ b/incubator/hnc/pkg/reconcilers/setup.go
@@ -24,8 +24,8 @@ var ex = map[string]bool{
 func Create(mgr ctrl.Manager, f *forest.Forest, maxReconciles int) error {
 	hcChan := make(chan event.GenericEvent)
 
-	// Create the HierarchyReconciler.
-	hr := &HierarchyReconciler{
+	// Create the HierarchyConfigReconciler.
+	hr := &HierarchyConfigReconciler{
 		Client:   mgr.GetClient(),
 		Log:      ctrl.Log.WithName("reconcilers").WithName("Hierarchy"),
 		Forest:   f,
@@ -45,6 +45,15 @@ func Create(mgr ctrl.Manager, f *forest.Forest, maxReconciles int) error {
 	}
 	if err := cr.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("cannot create Config reconciler: %s", err.Error())
+	}
+
+	// Create HierarchicalNamespaceReconciler.
+	hnsr := &HierarchicalNamespaceReconciler{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("reconcilers").WithName("HierarchicalNamespace"),
+	}
+	if err := hnsr.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("cannot create HierarchicalNamespace reconciler: %s", err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
Create the empty HierarchicalNamespaceReconciler to only generate a log
with the information of the object being reconciled and setup with
controller manager.

Add "forbidden" state to CRD status.
Rename HierarchyReconciler to HierarchyConfigReconciler.

Tested on GKE: I created a sample hns object and found the log of
reconciling that hns object in Stackdriver.

Part of #457 