### PR TITLE
[Incubator][VC]Downgrade log level for INFO logs

### DIFF
--- a/incubator/virtualcluster/cmd/syncer/app/options/options.go
+++ b/incubator/virtualcluster/cmd/syncer/app/options/options.go
@@ -77,12 +77,12 @@ func NewResourceSyncerOptions() (*ResourceSyncerOptions, error) {
 func (o *ResourceSyncerOptions) Flags() cliflag.NamedFlagSets {
 	fss := cliflag.NamedFlagSets{}
 
-	fs := fss.FlagSet("")
+	fs := fss.FlagSet("server")
 	fs.StringVar(&o.SuperMaster, "super-master", o.SuperMaster, "The address of the super master Kubernetes API server (overrides any value in super-master-kubeconfig).")
 	fs.StringVar(&o.ComponentConfig.ClientConnection.Kubeconfig, "super-master-kubeconfig", o.ComponentConfig.ClientConnection.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
 	fs.BoolVar(&o.ComponentConfig.DisableServiceAccountToken, "disable-service-account-token", o.ComponentConfig.DisableServiceAccountToken, "DisableServiceAccountToken indicates whether disable service account token automatically mounted.")
 
-	serverFlags := fss.FlagSet("server")
+	serverFlags := fss.FlagSet("metricsServer")
 	serverFlags.StringVar(&o.Address, "address", o.Address, "The server address.")
 	serverFlags.StringVar(&o.Port, "port", o.Port, "The server port.")
 	serverFlags.StringVar(&o.CertFile, "cert-file", o.CertFile, "CertFile is the file containing x509 Certificate for HTTPS.")

--- a/incubator/virtualcluster/pkg/syncer/resources/configmap/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/configmap/checker.go
@@ -115,7 +115,7 @@ func (c *controller) checkConfigMapsOfTenantCluster(clusterName string) {
 		klog.Errorf("error listing configmaps from cluster %s informer cache: %v", clusterName, err)
 		return
 	}
-	klog.Infof("check configmaps consistency in cluster %s", clusterName)
+	klog.V(4).Infof("check configmaps consistency in cluster %s", clusterName)
 	configMapList := listObj.(*v1.ConfigMapList)
 	for i, vConfigMap := range configMapList.Items {
 		targetNamespace := conversion.ToSuperMasterNamespace(clusterName, vConfigMap.Namespace)

--- a/incubator/virtualcluster/pkg/syncer/resources/configmap/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/configmap/dws.go
@@ -39,7 +39,7 @@ func (c *controller) StartDWS(stopCh <-chan struct{}) error {
 
 // The reconcile logic for tenant master configMap informer
 func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
-	klog.Infof("reconcile configmap %s/%s %s event for cluster %s", request.Namespace, request.Name, request.Event, request.Cluster.Name)
+	klog.V(4).Infof("reconcile configmap %s/%s %s event for cluster %s", request.Namespace, request.Name, request.Event, request.Cluster.Name)
 
 	switch request.Event {
 	case reconciler.AddEvent:

--- a/incubator/virtualcluster/pkg/syncer/resources/endpoints/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/endpoints/checker.go
@@ -85,7 +85,7 @@ func (c *controller) checkEndPointsOfTenantCluster(clusterName string) {
 		klog.Errorf("error listing endpoints from cluster %s informer cache: %v", clusterName, err)
 		return
 	}
-	klog.Infof("check endpoints consistency in cluster %s", clusterName)
+	klog.V(4).Infof("check endpoints consistency in cluster %s", clusterName)
 	epList := listObj.(*v1.EndpointsList)
 	for _, vEp := range epList.Items {
 		targetNamespace := conversion.ToSuperMasterNamespace(clusterName, vEp.Namespace)

--- a/incubator/virtualcluster/pkg/syncer/resources/event/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/event/uws.go
@@ -75,7 +75,7 @@ func (c *controller) processNextWorkItem() bool {
 		return true
 	}
 
-	klog.Infof("back populate event %+v", req.Key)
+	klog.V(4).Infof("back populate event %+v", req.Key)
 	err := c.backPopulate(req.Key)
 	if err == nil {
 		c.queue.Forget(obj)

--- a/incubator/virtualcluster/pkg/syncer/resources/namespace/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/namespace/checker.go
@@ -109,7 +109,7 @@ func (c *controller) checkNamespacesOfTenantCluster(clusterName string) {
 		klog.Errorf("error listing namespaces from cluster %s informer cache: %v", clusterName, err)
 		return
 	}
-	klog.Infof("check namespaces consistency in cluster %s", clusterName)
+	klog.V(4).Infof("check namespaces consistency in cluster %s", clusterName)
 	namespaceList := listObj.(*v1.NamespaceList)
 	for i, vNamespace := range namespaceList.Items {
 		targetNamespace := conversion.ToSuperMasterNamespace(clusterName, vNamespace.Name)

--- a/incubator/virtualcluster/pkg/syncer/resources/namespace/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/namespace/dws.go
@@ -40,7 +40,7 @@ func (c *controller) StartDWS(stopCh <-chan struct{}) error {
 
 // The reconcile logic for tenant master namespace informer
 func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
-	klog.Infof("reconcile namespace %s %s event for cluster %s", request.Name, request.Event, request.Cluster.Name)
+	klog.V(4).Infof("reconcile namespace %s %s event for cluster %s", request.Name, request.Event, request.Cluster.Name)
 
 	switch request.Event {
 	case reconciler.AddEvent:

--- a/incubator/virtualcluster/pkg/syncer/resources/node/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/node/dws.go
@@ -31,7 +31,7 @@ func (c *controller) StartDWS(stopCh <-chan struct{}) error {
 // The reconcile logic for tenant master node informer, the main purpose is to maintain
 // the nodeNameToCluster mapping
 func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
-	klog.Infof("reconcile node %s %s event for cluster %s", request.Name, request.Event, request.Cluster.Name)
+	klog.V(4).Infof("reconcile node %s %s event for cluster %s", request.Name, request.Event, request.Cluster.Name)
 	vNode := request.Obj.(*v1.Node)
 	if vNode.Labels[constants.LabelVirtualNode] != "true" {
 		// We only handle virtual nodes created by syncer

--- a/incubator/virtualcluster/pkg/syncer/resources/node/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/node/uws.go
@@ -94,7 +94,7 @@ func (c *controller) backPopulate(nodeName string) error {
 		return err
 	}
 	defer metrics.RecordUWSOperationDuration("node", time.Now())
-	klog.Infof("back populate node %s/%s", node.Namespace, node.Name)
+	klog.V(4).Infof("back populate node %s/%s", node.Namespace, node.Name)
 	c.Lock()
 	clusterList := c.nodeNameToCluster[node.Name]
 	c.Unlock()

--- a/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/checker.go
@@ -117,7 +117,7 @@ func (c *controller) checkPersistentVolumeOfTenantCluster(clusterName string) {
 		klog.Errorf("error listing pv from cluster %s informer cache: %v", clusterName, err)
 		return
 	}
-	klog.Infof("check pv consistency in cluster %s", clusterName)
+	klog.V(4).Infof("check pv consistency in cluster %s", clusterName)
 	pvList := listObj.(*v1.PersistentVolumeList)
 	for _, vPV := range pvList.Items {
 		pPV, err := c.pvLister.Get(vPV.Name)

--- a/incubator/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/checker.go
@@ -100,7 +100,7 @@ func (c *controller) checkPVCOfTenantCluster(clusterName string) {
 		klog.Errorf("error listing PVCs from cluster %s informer cache: %v", clusterName, err)
 		return
 	}
-	klog.Infof("check PVCs consistency in cluster %s", clusterName)
+	klog.V(4).Infof("check PVCs consistency in cluster %s", clusterName)
 	pvcList := listObj.(*v1.PersistentVolumeClaimList)
 	for i, vPVC := range pvcList.Items {
 		targetNamespace := conversion.ToSuperMasterNamespace(clusterName, vPVC.Namespace)

--- a/incubator/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/dws.go
@@ -39,7 +39,7 @@ func (c *controller) StartDWS(stopCh <-chan struct{}) error {
 
 // The reconcile logic for tenant master pvc informer
 func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
-	klog.Infof("reconcile pvc %s %s event for cluster %s", request.Name, request.Event, request.Cluster.Name)
+	klog.V(4).Infof("reconcile pvc %s %s event for cluster %s", request.Name, request.Event, request.Cluster.Name)
 
 	switch request.Event {
 	case reconciler.AddEvent:

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/checker.go
@@ -217,7 +217,7 @@ func (c *controller) checkPodsOfTenantCluster(clusterName string) {
 		klog.Errorf("error listing pods from cluster %s informer cache: %v", clusterName, err)
 		return
 	}
-	klog.Infof("check pods consistency in cluster %s", clusterName)
+	klog.V(4).Infof("check pods consistency in cluster %s", clusterName)
 	podList := listObj.(*v1.PodList)
 	for i, vPod := range podList.Items {
 		if vPod.Spec.NodeName != "" && !isPodScheduled(&vPod) {

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/dws.go
@@ -43,7 +43,7 @@ func (c *controller) StartDWS(stopCh <-chan struct{}) error {
 }
 
 func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
-	klog.Infof("reconcile pod %s/%s %s event for cluster %s", request.Namespace, request.Name, request.Event, request.Cluster.Name)
+	klog.V(4).Infof("reconcile pod %s/%s %s event for cluster %s", request.Namespace, request.Name, request.Event, request.Cluster.Name)
 	vPod := request.Obj.(*v1.Pod)
 	c.updateClusterVNodePodMap(request.Cluster.Name, vPod, request.Event)
 

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/metrics"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/resources/node"
 )
@@ -77,7 +78,7 @@ func (c *controller) processNextWorkItem() bool {
 		return true
 	}
 
-	klog.Infof("back populate pod %+v", req.Key)
+	klog.V(4).Infof("back populate pod %+v", req.Key)
 	err := c.backPopulate(req.Key)
 	if err == nil {
 		c.queue.Forget(obj)
@@ -106,6 +107,7 @@ func (c *controller) backPopulate(key string) error {
 		return nil
 	}
 
+	defer metrics.RecordUWSOperationDuration("pod", time.Now())
 	pPod, err := c.podLister.Pods(pNamespace).Get(pName)
 	if err != nil {
 		if errors.IsNotFound(err) {

--- a/incubator/virtualcluster/pkg/syncer/resources/secret/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/secret/checker.go
@@ -74,7 +74,7 @@ func (c *controller) checkSecrets() {
 		return
 	}
 
-	klog.Infof("check secrets consistency in super")
+	klog.V(4).Infof("check secrets consistency in super")
 	for _, pSecret := range secretList {
 		// service account token type secret are managed by super individually.
 		if pSecret.Type == v1.SecretTypeServiceAccountToken {
@@ -129,7 +129,7 @@ func (c *controller) checkSecretOfTenantCluster(clusterName string) {
 		klog.Errorf("error listing secrets from cluster %s informer cache: %v", clusterName, err)
 		return
 	}
-	klog.Infof("check secrets consistency in cluster %s", clusterName)
+	klog.V(4).Infof("check secrets consistency in cluster %s", clusterName)
 	secretList := listObj.(*v1.SecretList)
 	for i, vSecret := range secretList.Items {
 		targetNamespace := conversion.ToSuperMasterNamespace(clusterName, vSecret.Namespace)

--- a/incubator/virtualcluster/pkg/syncer/resources/secret/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/secret/dws.go
@@ -41,7 +41,7 @@ func (c *controller) StartDWS(stopCh <-chan struct{}) error {
 
 // The reconcile logic for tenant master secret informer
 func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
-	klog.Infof("reconcile secret %s/%s %s event for cluster %s", request.Namespace, request.Name, request.Event, request.Cluster.Name)
+	klog.V(4).Infof("reconcile secret %s/%s %s event for cluster %s", request.Namespace, request.Name, request.Event, request.Cluster.Name)
 
 	switch request.Event {
 	case reconciler.AddEvent:

--- a/incubator/virtualcluster/pkg/syncer/resources/service/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/service/checker.go
@@ -100,7 +100,7 @@ func (c *controller) checkServicesOfTenantCluster(clusterName string) {
 		klog.Errorf("error listing services from cluster %s informer cache: %v", clusterName, err)
 		return
 	}
-	klog.Infof("check services consistency in cluster %s", clusterName)
+	klog.V(4).Infof("check services consistency in cluster %s", clusterName)
 	svcList := listObj.(*v1.ServiceList)
 	for i, vService := range svcList.Items {
 		targetNamespace := conversion.ToSuperMasterNamespace(clusterName, vService.Namespace)

--- a/incubator/virtualcluster/pkg/syncer/resources/service/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/service/dws.go
@@ -38,7 +38,7 @@ func (c *controller) StartDWS(stopCh <-chan struct{}) error {
 }
 
 func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
-	klog.Infof("reconcile service %s/%s %s event for cluster %s", request.Namespace, request.Name, request.Event, request.Cluster.Name)
+	klog.V(4).Infof("reconcile service %s/%s %s event for cluster %s", request.Namespace, request.Name, request.Event, request.Cluster.Name)
 
 	switch request.Event {
 	case reconciler.AddEvent:

--- a/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/checker.go
@@ -107,7 +107,7 @@ func (c *controller) checkServiceAccountsOfTenantCluster(clusterName string) {
 		klog.Errorf("error listing serviceaccounts from cluster %s informer cache: %v", clusterName, err)
 		return
 	}
-	klog.Infof("check serviceaccounts consistency in cluster %s", clusterName)
+	klog.V(4).Infof("check serviceaccounts consistency in cluster %s", clusterName)
 	saList := listObj.(*v1.ServiceAccountList)
 	for i, vSa := range saList.Items {
 		targetNamespace := conversion.ToSuperMasterNamespace(clusterName, vSa.Namespace)

--- a/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/dws.go
@@ -39,7 +39,7 @@ func (c *controller) StartDWS(stopCh <-chan struct{}) error {
 
 // The reconcile logic for tenant master service account informer
 func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
-	klog.Infof("reconcile service account %s/%s %s event for cluster %s", request.Namespace, request.Name, request.Event, request.Cluster.Name)
+	klog.V(4).Infof("reconcile service account %s/%s %s event for cluster %s", request.Namespace, request.Name, request.Event, request.Cluster.Name)
 
 	switch request.Event {
 	case reconciler.AddEvent:

--- a/incubator/virtualcluster/pkg/syncer/resources/storageclass/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/storageclass/checker.go
@@ -99,7 +99,7 @@ func (c *controller) checkStorageClassOfTenantCluster(clusterName string) {
 		klog.Errorf("error listing storageclass from cluster %s informer cache: %v", clusterName, err)
 		return
 	}
-	klog.Infof("check storageclass consistency in cluster %s", clusterName)
+	klog.V(4).Infof("check storageclass consistency in cluster %s", clusterName)
 	scList := listObj.(*v1.StorageClassList)
 	for i, vStorageClass := range scList.Items {
 		pStorageClass, err := c.storageclassLister.Get(vStorageClass.Name)


### PR DESCRIPTION
We should rely more on the counters reported by metrics server instead of watching for INFO logs. This change downgrades many syncer INFO logs.