### PR TITLE
Add `kubectl hns create2` to only create hns in parent namespace

### DIFF
--- a/incubator/hnc/api/v1alpha1/hierarchical_namespace.go
+++ b/incubator/hnc/api/v1alpha1/hierarchical_namespace.go
@@ -19,6 +19,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// Constant for the hierarchicalnamespaces resource type.
+const HierarchicalNamespaces string = "hierarchicalnamespaces"
+
 // HNSState describes the state of a hierarchical namespace. The state could be
 // "missing", "ok", "conflict" or "forbidden". The definitions will be described below.
 type HNSState string

--- a/incubator/hnc/api/v1alpha1/hierarchy_types.go
+++ b/incubator/hnc/api/v1alpha1/hierarchy_types.go
@@ -21,8 +21,8 @@ import (
 
 // Constants for types and well-known names
 const (
-	Singleton = "hierarchy"
-	Resource  = "hierarchyconfigurations"
+	Singleton               = "hierarchy"
+	HierarchyConfigurations = "hierarchyconfigurations"
 )
 
 // Constants for labels and annotations

--- a/incubator/hnc/pkg/kubectl/create2.go
+++ b/incubator/hnc/pkg/kubectl/create2.go
@@ -1,0 +1,46 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var create2Cmd = &cobra.Command{
+	Use:   "create2 -n parent child",
+	Short: "Creates a subnamespace under the given parent.",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		parent, _ := cmd.Flags().GetString("namespace")
+		if parent == "" {
+			fmt.Println("Error: parent must be set via --namespace or -n")
+			os.Exit(1)
+		}
+		// Create the hns instance, the custom resource representing the self-serve subnamespace.
+		// TODO: ensure the specified child doesn't already exist and the parent is allowed
+		//  to create self-serve subnamespaces through the admission controller. See issue
+		//  https://github.com/kubernetes-sigs/multi-tenancy/issues/458
+		client.createHierarchicalNamespace(parent, args[0])
+	},
+}
+
+func newCreate2Cmd() *cobra.Command {
+	create2Cmd.Flags().StringP("namespace", "n", "", "The parent namespace for the new self-serve subnamespace")
+	return create2Cmd
+}


### PR DESCRIPTION
Add a new `kubectl hns create` command `create2` to only create hns
instances in the parent namespace when creating subnamespaces.
Currently, `create` creates the hc singleton in the parent namespace.
`create2` will replace the current `create` when the hns reconciler is
implemented. The hc singletons will then be created by the hc or the hns
reconciler.

Tested on GKE cluster. I created a subnamespace using "kubectl hns
create2 -n parent child". The "child" hns instance was created in the
"parent" namespace and no "hierarchy" singleton hc instance was created
by this command. Then I saw the hns reconciler log on the hns instance
in Stackdriver.

Part of #457 