### PR TITLE
[Incubator][VC]Make DWS request only contain immutable fields

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/cluster/cluster.go
+++ b/incubator/virtualcluster/pkg/syncer/cluster/cluster.go
@@ -29,6 +29,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	clientgocache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -291,6 +292,7 @@ func (c *Cluster) Start() error {
 func (c *Cluster) WaitForCacheSync() bool {
 	ca, err := c.getCache()
 	if err != nil {
+		klog.Errorf("Fail to get cache: %v", err)
 		return false
 	}
 	return ca.WaitForCacheSync(c.stopCh)

--- a/incubator/virtualcluster/pkg/syncer/handler/enqueue_object.go
+++ b/incubator/virtualcluster/pkg/syncer/handler/enqueue_object.go
@@ -27,27 +27,29 @@ type EnqueueRequestForObject struct {
 	Queue   Queue
 }
 
-func (e *EnqueueRequestForObject) enqueue(obj interface{}, event reconciler.EventType) {
+func (e *EnqueueRequestForObject) enqueue(obj interface{}) {
 	o, err := meta.Accessor(obj)
 	if err != nil {
 		return
 	}
 
-	r := reconciler.Request{Cluster: e.Cluster, Event: event, Obj: obj}
+	r := reconciler.Request{}
+	r.ClusterName = e.Cluster.Name
 	r.Namespace = o.GetNamespace()
 	r.Name = o.GetName()
+	r.UID = string(o.GetUID())
 
 	e.Queue.Add(r)
 }
 
 func (e *EnqueueRequestForObject) OnAdd(obj interface{}) {
-	e.enqueue(obj, reconciler.AddEvent)
+	e.enqueue(obj)
 }
 
 func (e *EnqueueRequestForObject) OnUpdate(oldObj, newObj interface{}) {
-	e.enqueue(newObj, reconciler.UpdateEvent)
+	e.enqueue(newObj)
 }
 
 func (e *EnqueueRequestForObject) OnDelete(obj interface{}) {
-	e.enqueue(obj, reconciler.DeleteEvent)
+	e.enqueue(obj)
 }

--- a/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
+++ b/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
@@ -321,9 +321,12 @@ func (c *MultiClusterController) RequeueObject(clusterName string, obj interface
 	if cluster == nil {
 		return fmt.Errorf("could not find cluster %s", clusterName)
 	}
-	r := reconciler.Request{Cluster: cluster.GetClientInfo(), Event: event, Obj: obj}
+	//FIXME: we dont need event here.
+	r := reconciler.Request{}
+	r.ClusterName = clusterName
 	r.Namespace = o.GetNamespace()
 	r.Name = o.GetName()
+	r.UID = string(o.GetUID())
 
 	c.Queue.Add(r)
 	return nil
@@ -369,9 +372,9 @@ func (c *MultiClusterController) processNextWorkItem() bool {
 		// Return true, don't take a break
 		return true
 	}
-	if c.getCluster(req.Cluster.Name) == nil {
+	if c.getCluster(req.ClusterName) == nil {
 		// The virtual cluster has been removed, do not reconcile for its dws requests.
-		klog.Warningf("The cluster %s has been removed, drop the dws request %v", req.Cluster.Name, req)
+		klog.Warningf("The cluster %s has been removed, drop the dws request %v", req.ClusterName, req)
 		c.Queue.Forget(obj)
 		return true
 	}

--- a/incubator/virtualcluster/pkg/syncer/reconciler/reconciler.go
+++ b/incubator/virtualcluster/pkg/syncer/reconciler/reconciler.go
@@ -45,17 +45,13 @@ const (
 )
 
 // Request contains the information needed by a multicluster Reconciler to Reconcile:
-// a context, namespace, and name.
+// It ONLY contains the meta that can uniquely identify an object without any state information which can lead to parallel reconcile.
 type Request struct {
-	Cluster *ClusterInfo
+	ClusterName string
 	types.NamespacedName
-	Event EventType
-	Obj   interface{}
+	UID string
 }
 
-// Result is the return type of a Reconciler's Reconcile method.
-// By default, the Request is forgotten after it's been processed,
-// but you can also requeue it immediately, or after some time.
 type Result reconcile.Result
 
 // Reconciler is the interface used by a Controller to reconcile.

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
@@ -130,6 +130,9 @@ func (c *controller) backPopulate(key string) error {
 		return fmt.Errorf("could not find pPod %s/%s's vPod in controller cache %v", vNamespace, pName, err)
 	}
 	vPod := vPodObj.(*v1.Pod)
+	if pPod.Annotations[constants.LabelUID] != string(vPod.UID) {
+		return fmt.Errorf("BackPopulated pPod %s/%s delegated UID is different from updated object.", pPod.Namespace, pPod.Name)
+	}
 
 	tenantClient, err := c.multiClusterPodController.GetClusterClient(clusterName)
 	if err != nil {

--- a/incubator/virtualcluster/pkg/syncer/resources/secret/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/secret/dws.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
@@ -41,100 +40,93 @@ func (c *controller) StartDWS(stopCh <-chan struct{}) error {
 
 // The reconcile logic for tenant master secret informer
 func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
-	klog.V(4).Infof("reconcile secret %s/%s %s event for cluster %s", request.Namespace, request.Name, request.Event, request.Cluster.Name)
+	klog.V(4).Infof("reconcile secret %s/%s for cluster %s", request.Namespace, request.Name, request.ClusterName)
+	targetNamespace := conversion.ToSuperMasterNamespace(request.ClusterName, request.Namespace)
+	vSecretObj, err := c.multiClusterSecretController.Get(request.ClusterName, request.Namespace, request.Name)
+	vExists := true
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return reconciler.Result{Requeue: true}, err
+		}
+		vExists = false
+	}
+	// FIXME: Do we need to add sa name in the selector?
+	pExists := true
+	var pSecret *v1.Secret
+	secretList, err := c.secretLister.Secrets(targetNamespace).List(labels.SelectorFromSet(map[string]string{
+		constants.LabelSecretName: request.Name,
+	}))
+	if err != nil && !errors.IsNotFound(err) {
+		return reconciler.Result{Requeue: true}, err
+	}
+	if len(secretList) != 0 {
+		// This is service account vSecret
+		pSecret = secretList[0]
+	} else {
+		// We need to use name to search again for normal vScrect
+		pSecret, err = c.secretLister.Secrets(targetNamespace).Get(request.Name)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				return reconciler.Result{Requeue: true}, err
+			}
+			pExists = false
+		}
+	}
 
-	switch request.Event {
-	case reconciler.AddEvent:
-		err := c.reconcileSecretCreate(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.Secret))
+	if vExists && !pExists {
+		vSecret := vSecretObj.(*v1.Secret)
+		err := c.reconcileSecretCreate(request.ClusterName, targetNamespace, vSecret)
 		if err != nil {
-			klog.Errorf("failed reconcile secret %s/%s CREATE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
+			klog.Errorf("failed reconcile secret %s/%s CREATE of cluster %s %v", request.Namespace, request.Name, request.ClusterName, err)
 			return reconciler.Result{Requeue: true}, err
 		}
-	case reconciler.UpdateEvent:
-		err := c.reconcileSecretUpdate(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.Secret))
+	} else if !vExists && pExists {
+		err := c.reconcileSecretRemove(request.ClusterName, targetNamespace, request.Name, pSecret)
 		if err != nil {
-			klog.Errorf("failed reconcile secret %s/%s CREATE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
+			klog.Errorf("failed reconcile secret %s/%s DELETE of cluster %s %v", request.Namespace, request.Name, request.ClusterName, err)
 			return reconciler.Result{Requeue: true}, err
 		}
-	case reconciler.DeleteEvent:
-		err := c.reconcileSecretRemove(request.Cluster.Name, request.Namespace, request.Name, request.Obj.(*v1.Secret))
+	} else if vExists && pExists {
+		vSecret := vSecretObj.(*v1.Secret)
+		err := c.reconcileSecretUpdate(request.ClusterName, targetNamespace, pSecret, vSecret)
 		if err != nil {
-			klog.Errorf("failed reconcile secret %s/%s DELETE of cluster %s %v", request.Namespace, request.Name, request.Cluster.Name, err)
+			klog.Errorf("failed reconcile secret %s/%s UPDATE of cluster %s %v", request.Namespace, request.Name, request.ClusterName, err)
 			return reconciler.Result{Requeue: true}, err
 		}
+	} else {
+		// object is gone.
 	}
 	return reconciler.Result{}, nil
 }
 
-func (c *controller) reconcileSecretCreate(cluster, namespace, name string, secret *v1.Secret) error {
+func (c *controller) reconcileSecretCreate(clusterName, targetNamespace string, secret *v1.Secret) error {
 	switch secret.Type {
 	case v1.SecretTypeServiceAccountToken:
-		return c.reconcileServiceAccountSecretCreate(cluster, namespace, name, secret)
+		return c.reconcileServiceAccountSecretCreate(clusterName, targetNamespace, secret)
 	default:
-		return c.reconcileNormalSecretCreate(cluster, namespace, name, secret)
+		return c.reconcileNormalSecretCreate(clusterName, targetNamespace, secret)
 	}
 }
 
-func (c *controller) reconcileServiceAccountSecretCreate(cluster, namespace, name string, vSecret *v1.Secret) error {
-	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
-	saName := vSecret.GetAnnotations()[v1.ServiceAccountNameKey]
-
-	secretList, err := c.secretLister.Secrets(targetNamespace).List(labels.SelectorFromSet(map[string]string{
-		constants.LabelServiceAccountName: saName,
-		constants.LabelSecretName:         vSecret.Name,
-	}))
-	if err != nil && !errors.IsNotFound(err) {
-		return err
-	}
-	if len(secretList) > 0 {
-		return serviceAccountSecretUpdate(c.secretClient.Secrets(targetNamespace), secretList, vSecret)
-	}
-
-	newObj, err := conversion.BuildMetadata(cluster, targetNamespace, vSecret)
+func (c *controller) reconcileServiceAccountSecretCreate(clusterName, targetNamespace string, vSecret *v1.Secret) error {
+	newObj, err := conversion.BuildMetadata(clusterName, targetNamespace, vSecret)
 	if err != nil {
 		return err
 	}
 
 	pSecret := newObj.(*v1.Secret)
-	conversion.VC(c.multiClusterSecretController, "").ServiceAccountTokenSecret(pSecret).Mutate(vSecret, cluster)
+	conversion.VC(c.multiClusterSecretController, "").ServiceAccountTokenSecret(pSecret).Mutate(vSecret, clusterName)
 
 	_, err = c.secretClient.Secrets(targetNamespace).Create(pSecret)
 	if errors.IsAlreadyExists(err) {
-		klog.Infof("secret %s/%s of cluster %s already exist in super master", namespace, name, cluster)
+		klog.Infof("secret %s/%s of cluster %s already exist in super master", targetNamespace, pSecret.Name, clusterName)
 		return nil
 	}
 
 	return err
 }
 
-func (c *controller) reconcileServiceAccountSecretUpdate(cluster, namespace, name string, vSecret *v1.Secret) error {
-	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
-
-	saName := vSecret.Annotations[v1.ServiceAccountNameKey]
-
-	secretList, err := c.secretLister.Secrets(targetNamespace).List(labels.SelectorFromSet(map[string]string{
-		constants.LabelServiceAccountName: saName,
-		constants.LabelSecretName:         vSecret.Name,
-	}))
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-	if len(secretList) == 0 {
-		return nil
-	}
-
-	return serviceAccountSecretUpdate(c.secretClient.Secrets(targetNamespace), secretList, vSecret)
-}
-
-func serviceAccountSecretUpdate(secretClient corev1.SecretInterface, secretList []*v1.Secret, vSecret *v1.Secret) error {
-	if len(secretList) == 0 {
-		return nil
-	}
-	pSecret := secretList[0]
-
+func (c *controller) reconcileServiceAccountSecretUpdate(clusterName, targetNamespace string, pSecret, vSecret *v1.Secret) error {
 	updatedBinaryData, equal := conversion.Equality(nil).CheckBinaryDataEquality(pSecret.Data, vSecret.Data)
 	if equal {
 		return nil
@@ -142,7 +134,7 @@ func serviceAccountSecretUpdate(secretClient corev1.SecretInterface, secretList 
 
 	updatedSecret := pSecret.DeepCopy()
 	updatedSecret.Data = updatedBinaryData
-	_, err := secretClient.Update(pSecret)
+	_, err := c.secretClient.Secrets(targetNamespace).Update(updatedSecret)
 	if err != nil {
 		return err
 	}
@@ -150,47 +142,32 @@ func serviceAccountSecretUpdate(secretClient corev1.SecretInterface, secretList 
 	return nil
 }
 
-func (c *controller) reconcileNormalSecretCreate(cluster, namespace, name string, secret *v1.Secret) error {
-	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
-	_, err := c.secretLister.Secrets(targetNamespace).Get(name)
-	if err == nil {
-		return c.reconcileNormalSecretUpdate(cluster, namespace, name, secret)
-	}
-
-	newObj, err := conversion.BuildMetadata(cluster, targetNamespace, secret)
+func (c *controller) reconcileNormalSecretCreate(clusterName, targetNamespace string, secret *v1.Secret) error {
+	newObj, err := conversion.BuildMetadata(clusterName, targetNamespace, secret)
 	if err != nil {
 		return err
 	}
 
 	_, err = c.secretClient.Secrets(targetNamespace).Create(newObj.(*v1.Secret))
 	if errors.IsAlreadyExists(err) {
-		klog.Infof("secret %s/%s of cluster %s already exist in super master", namespace, name, cluster)
+		klog.Infof("secret %s/%s of cluster %s already exist in super master", targetNamespace, secret.Name, clusterName)
 		return nil
 	}
 
 	return err
 }
 
-func (c *controller) reconcileSecretUpdate(cluster, namespace, name string, secret *v1.Secret) error {
-	switch secret.Type {
+func (c *controller) reconcileSecretUpdate(clusterName, targetNamespace string, pSecret, vSecret *v1.Secret) error {
+	switch vSecret.Type {
 	case v1.SecretTypeServiceAccountToken:
-		return c.reconcileServiceAccountSecretUpdate(cluster, namespace, name, secret)
+		return c.reconcileServiceAccountSecretUpdate(clusterName, targetNamespace, pSecret, vSecret)
 	default:
-		return c.reconcileNormalSecretUpdate(cluster, namespace, name, secret)
+		return c.reconcileNormalSecretUpdate(clusterName, targetNamespace, pSecret, vSecret)
 	}
 }
 
-func (c *controller) reconcileNormalSecretUpdate(cluster, namespace, name string, vSecret *v1.Secret) error {
-	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
-	pSecret, err := c.secretLister.Secrets(targetNamespace).Get(name)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-
-	spec, err := c.multiClusterSecretController.GetSpec(cluster)
+func (c *controller) reconcileNormalSecretUpdate(clusterName, targetNamespace string, pSecret, vSecret *v1.Secret) error {
+	spec, err := c.multiClusterSecretController.GetSpec(clusterName)
 	if err != nil {
 		return err
 	}
@@ -205,30 +182,28 @@ func (c *controller) reconcileNormalSecretUpdate(cluster, namespace, name string
 	return nil
 }
 
-func (c *controller) reconcileSecretRemove(cluster, namespace, name string, secret *v1.Secret) error {
+func (c *controller) reconcileSecretRemove(clusterName, targetNamespace, name string, secret *v1.Secret) error {
 	switch secret.Type {
 	case v1.SecretTypeServiceAccountToken:
-		return c.reconcileServiceAccountTokenSecretRemove(cluster, namespace, name, secret)
+		return c.reconcileServiceAccountTokenSecretRemove(clusterName, targetNamespace, name)
 	default:
-		return c.reconcileNormalSecretRemove(cluster, namespace, name, secret)
+		return c.reconcileNormalSecretRemove(clusterName, targetNamespace, name)
 	}
 }
 
-func (c *controller) reconcileNormalSecretRemove(cluster, namespace, name string, secret *v1.Secret) error {
-	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
+func (c *controller) reconcileNormalSecretRemove(clusterName, targetNamespace, name string) error {
 	opts := &metav1.DeleteOptions{
 		PropagationPolicy: &constants.DefaultDeletionPolicy,
 	}
 	err := c.secretClient.Secrets(targetNamespace).Delete(name, opts)
 	if errors.IsNotFound(err) {
-		klog.Warningf("secret %s/%s of cluster is not found in super master", namespace, name)
+		klog.Warningf("secret %s/%s of cluster is not found in super master", targetNamespace, name)
 		return nil
 	}
 	return err
 }
 
-func (c *controller) reconcileServiceAccountTokenSecretRemove(cluster, namespace, name string, vSecret *v1.Secret) error {
-	targetNamespace := conversion.ToSuperMasterNamespace(cluster, namespace)
+func (c *controller) reconcileServiceAccountTokenSecretRemove(clusterName, targetNamespace, name string) error {
 	opts := &metav1.DeleteOptions{
 		PropagationPolicy: &constants.DefaultDeletionPolicy,
 	}
@@ -238,7 +213,7 @@ func (c *controller) reconcileServiceAccountTokenSecretRemove(cluster, namespace
 		}).String(),
 	})
 	if errors.IsNotFound(err) {
-		klog.Warningf("secret %s/%s of cluster is not found in super master", namespace, name)
+		klog.Warningf("secret %s/%s of cluster is not found in super master", targetNamespace, name)
 		return nil
 	}
 	return err

--- a/incubator/virtualcluster/pkg/syncer/resources/service/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/service/uws.go
@@ -128,6 +128,9 @@ func (c *controller) backPopulate(key string) error {
 		return fmt.Errorf("could not find pService %s/%s's vService in controller cache %v", vNamespace, pName, err)
 	}
 	vService := vServiceObj.(*v1.Service)
+	if pService.Annotations[constants.LabelUID] != string(vService.UID) {
+		return fmt.Errorf("BackPopulated pService %s/%s delegated UID is different from updated object.", pService.Namespace, pService.Name)
+	}
 
 	tenantClient, err := c.multiClusterServiceController.GetClusterClient(clusterName)
 	if err != nil {


### PR DESCRIPTION
This change makes sure the request in DWS queue does not contain any mutable fields which can potentially cause parallel reconcile for the same object. 

Since event_type is removed, the DWS reconcile logic of figuring out whether it is Add or Update or Delete is changed by checking current tenant/super master informer cache.

We also add UID consistency check for Pod/Service/Namespace objects (other resources will be handled in future change) in order to avoid confusing update/create sync events when the object with the same name is frequently created and deleted.