### PR TITLE
[Incubator][VC] apply leaderelection feature to vc-manager

### DIFF
--- a/incubator/virtualcluster/cmd/manager/main.go
+++ b/incubator/virtualcluster/cmd/manager/main.go
@@ -32,11 +32,15 @@ import (
 
 func main() {
 	var (
-		metricsAddr       string
-		masterProvisioner string
+		metricsAddr          string
+		masterProvisioner    string
+		leaderElection       bool
+		leaderElectionCmName string
 	)
 	flag.StringVar(&metricsAddr, "metrics-addr", ":0", "The address the metric endpoint binds to.")
 	flag.StringVar(&masterProvisioner, "master-prov", "native", "The underlying platform that will provision master for virtualcluster.")
+	flag.BoolVar(&leaderElection, "leader-election", true, "If enable leaderelection for vc-manager")
+	flag.StringVar(&leaderElectionCmName, "le-cm-name", "vc-manager-leaderelection-lock", "The name of the configmap that will be used as the resourcelook for leaderelection")
 	flag.Parse()
 	logf.SetLogger(logf.ZapLogger(false))
 	log := logf.Log.WithName("entrypoint")
@@ -51,7 +55,11 @@ func main() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	log.Info("setting up manager")
-	mgr, err := manager.New(cfg, manager.Options{MetricsBindAddress: metricsAddr})
+	mgr, err := manager.New(cfg, manager.Options{
+		MetricsBindAddress: metricsAddr,
+		LeaderElection:     leaderElection,
+		LeaderElectionID:   leaderElectionCmName,
+	})
 	if err != nil {
 		log.Error(err, "unable to set up overall controller manager")
 		os.Exit(1)

--- a/incubator/virtualcluster/config/setup/all_in_one.yaml
+++ b/incubator/virtualcluster/config/setup/all_in_one.yaml
@@ -92,6 +92,26 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   verbs:
   - get
@@ -190,7 +210,7 @@ spec:
       containers:
       - command:
         - manager
-        image: virtualcluster/manager-amd64 
+        image: virtualcluster/manager-amd64
         imagePullPolicy: Always
         name: vc-manager
 ---

--- a/incubator/virtualcluster/config/setup/all_in_one_aliyun.yaml
+++ b/incubator/virtualcluster/config/setup/all_in_one_aliyun.yaml
@@ -81,10 +81,31 @@ rules:
   - update
   - patch
   - delete
+
 - apiGroups:
   - ""
   resources:
   - secrets/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
   verbs:
   - get
   - update

--- a/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_native.go
+++ b/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_native.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/client-go/util/cert"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	tenancyv1alpha1 "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
@@ -171,18 +170,9 @@ func (mpn *MasterProvisionerNative) deployComponent(vc *tenancyv1alpha1.Virtualc
 		return err
 	}
 
-	err = controllerutil.SetControllerReference(vc, ssBdl.StatefulSet, mpn.scheme)
-	if err != nil {
-		return err
-	}
-
 	if ssBdl.Service != nil {
 		log.Info("deploying Service for master component", "component", ssBdl.Name)
 		err = mpn.Create(context.TODO(), ssBdl.Service)
-		if err != nil {
-			return err
-		}
-		err := controllerutil.SetControllerReference(vc, ssBdl.Service, mpn.scheme)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
fixes #466

1. applying the leaderelection feature of controller-runtime to
vc-manager
2. change the default number of replicas to 2
3. don't set ownerreference for cross-namespace objects