### PR TITLE
[Incubator][VC]Update ClusterVNodePodMap when vPod is deleted

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/resources/pod/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/checker.go
@@ -245,6 +245,8 @@ func (c *controller) checkPodsOfTenantCluster(clusterName string) {
 				deleteOptions.Preconditions = metav1.NewUIDPreconditions(string(vPod.UID))
 				if err = client.CoreV1().Pods(vPod.Namespace).Delete(vPod.Name, deleteOptions); err != nil {
 					klog.Errorf("error deleting pod %v/%v in cluster %s: %v", vPod.Namespace, vPod.Name, clusterName, err)
+				} else if vPod.Spec.NodeName != "" && isPodScheduled(&vPod) {
+					c.updateClusterVNodePodMap(clusterName, vPod.Spec.NodeName, string(vPod.UID), reconciler.DeleteEvent)
 				}
 			} else {
 				// pPod not found and vPod still exists, we need to create pPod again

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
@@ -238,7 +238,12 @@ func (c *controller) backPopulate(key string) error {
 			klog.V(4).Infof("delete virtual pPod %s/%s with grace period seconds %v", vPod.Namespace, vPod.Name, *pPod.DeletionGracePeriodSeconds)
 			deleteOptions := metav1.NewDeleteOptions(*pPod.DeletionGracePeriodSeconds)
 			deleteOptions.Preconditions = metav1.NewUIDPreconditions(string(vPod.UID))
-			return tenantClient.CoreV1().Pods(vPod.Namespace).Delete(vPod.Name, deleteOptions)
+			if err = tenantClient.CoreV1().Pods(vPod.Namespace).Delete(vPod.Name, deleteOptions); err != nil {
+				return err
+			}
+			if vPod.Spec.NodeName != "" && isPodScheduled(vPod) {
+				c.updateClusterVNodePodMap(clusterName, vPod.Spec.NodeName, string(vPod.UID), reconciler.DeleteEvent)
+			}
 		}
 	}
 


### PR DESCRIPTION
Since DWS logic is restructured, we cannot track vPod delete event from dws. This change ensures ClusterVNodePodMap is updated when vPod is successfully deleted from tenant master.