### PR TITLE
[Incubator][VC]Use workqueue NumRequeues API to avoid infinite retry

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/constants/constants.go
+++ b/incubator/virtualcluster/pkg/syncer/constants/constants.go
@@ -61,8 +61,9 @@ const (
 
 	// DefaultvNodeGCGracePeriod is the grace period of time before deleting an orphan vNode in tenant master.
 	DefaultvNodeGCGracePeriod = time.Second * 120
-	// If Uws request keeps failing, stop retrying after DefaultUwsRetryTimePeriod.
-	DefaultUwsRetryTimePeriod = time.Second * 300
+	// If Uws request keeps failing, stop retrying after MaxUwsRetryAttempts.
+	// According to controller workqueue default rate limiter algorithm, retry 13 times takes around 90 seconds.
+	MaxUwsRetryAttempts = 13
 
 	DefaultOpaqueMetaPrefix = "tenancy.x-k8s.io"
 )

--- a/incubator/virtualcluster/pkg/syncer/reconciler/reconciler.go
+++ b/incubator/virtualcluster/pkg/syncer/reconciler/reconciler.go
@@ -17,7 +17,6 @@ limitations under the License.
 package reconciler
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 
@@ -60,8 +59,7 @@ type Reconciler interface {
 }
 
 type UwsRequest struct {
-	Key              string
-	FirstFailureTime *metav1.Time
+	Key string
 	// Optional, in many cases, the cluster name is unknown when uws request is created
 	ClusterName string
 }

--- a/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/checker.go
@@ -150,6 +150,9 @@ func (c *controller) checkPersistentVolumeOfTenantCluster(clusterName string) {
 		if updatedPVSpec != nil {
 			atomic.AddUint64(&numSpecMissMatchedPVs, 1)
 			klog.Warningf("spec of pv %v diff in super&tenant master %s", vPV.Name, clusterName)
+			if boundPersistentVolume(pPV) {
+				c.enqueuePersistentVolume(pPV)
+			}
 		}
 	}
 }

--- a/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/uws.go
@@ -83,15 +83,10 @@ func (c *controller) processNextWorkItem() bool {
 	}
 
 	utilruntime.HandleError(fmt.Errorf("error processing persistentvolume %v (will retry): %v", req.Key, err))
-	if req.FirstFailureTime == nil {
-		now := metav1.Now()
-		req.FirstFailureTime = &now
-	} else {
-		if metav1.Now().After(req.FirstFailureTime.Add(constants.DefaultUwsRetryTimePeriod)) {
-			klog.Warningf("Persistentvolume uws request is dropped due to timeout: %v", req)
-			c.queue.Forget(obj)
-			return true
-		}
+	if c.queue.NumRequeues(req) >= constants.MaxUwsRetryAttempts {
+		klog.Warningf("Persistentvolume uws request is dropped due to reaching max retry limit: %v", req)
+		c.queue.Forget(obj)
+		return true
 	}
 	c.queue.AddRateLimited(obj)
 	return true

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/checker.go
@@ -275,12 +275,18 @@ func (c *controller) checkPodsOfTenantCluster(clusterName string) {
 		if updatedPod != nil {
 			atomic.AddUint64(&numSpecMissMatchedPods, 1)
 			klog.Warningf("spec of pod %v/%v diff in super&tenant master", vPod.Namespace, vPod.Name)
+			if assignedPod(pPod) {
+				c.enqueuePod(pPod)
+			}
 		}
 
 		updatedMeta := conversion.Equality(spec).CheckUWObjectMetaEquality(&pPod.ObjectMeta, &podList.Items[i].ObjectMeta)
 		if updatedMeta != nil {
 			atomic.AddUint64(&numUWMetaMissMatchedPods, 1)
 			klog.Warningf("UWObjectMeta of pod %v/%v diff in super&tenant master", vPod.Namespace, vPod.Name)
+			if assignedPod(pPod) {
+				c.enqueuePod(pPod)
+			}
 		}
 	}
 }

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
@@ -86,15 +86,10 @@ func (c *controller) processNextWorkItem() bool {
 	}
 
 	utilruntime.HandleError(fmt.Errorf("error processing pod %v (will retry): %v", req.Key, err))
-	if req.FirstFailureTime == nil {
-		now := metav1.Now()
-		req.FirstFailureTime = &now
-	} else {
-		if metav1.Now().After(req.FirstFailureTime.Add(constants.DefaultUwsRetryTimePeriod)) {
-			klog.Warningf("Pod uws request is dropped due to timeout: %v", req)
-			c.queue.Forget(obj)
-			return true
-		}
+	if c.queue.NumRequeues(req) >= constants.MaxUwsRetryAttempts {
+		klog.Warningf("Pod uws request is dropped due to reaching max retry limit: %v", req)
+		c.queue.Forget(obj)
+		return true
 	}
 	c.queue.AddRateLimited(obj)
 	return true

--- a/incubator/virtualcluster/pkg/syncer/resources/service/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/service/checker.go
@@ -144,6 +144,9 @@ func (c *controller) checkServicesOfTenantCluster(clusterName string) {
 		if updatedService != nil {
 			atomic.AddUint64(&numMissMatchedServices, 1)
 			klog.Warningf("spec of service %v/%v diff in super&tenant master", vService.Namespace, vService.Name)
+			if isLoadBalancerService(pService) {
+				c.enqueueService(pService)
+			}
 		}
 	}
 }

--- a/incubator/virtualcluster/pkg/syncer/resources/storageclass/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/storageclass/checker.go
@@ -130,6 +130,10 @@ func (c *controller) checkStorageClassOfTenantCluster(clusterName string) {
 		if updatedStorageClass != nil {
 			atomic.AddUint64(&numMissMatchedStorageClasses, 1)
 			klog.Warningf("spec of storageClass %v diff in super&tenant master", vStorageClass.Name)
+			if publicStorageClass(pStorageClass) {
+				key, _ := cache.DeletionHandlingMetaNamespaceKeyFunc(pStorageClass)
+				c.queue.Add(reconciler.UwsRequest{Key: key, ClusterName: clusterName})
+			}
 		}
 	}
 }


### PR DESCRIPTION
We should avoid adding dynamic field in workqueue request to avoid parallel reconcile. This change mainly does the following:

1) Remove FirstFailureTime field from UWS request struct;
2) Use workqueue NumRequeues API to bound the number of failure retries;
3) Add requeue in checker in case uws consistency check fails;