### PR TITLE
Support 'ignore' mode in ConfigReconciler.

### DIFF
--- a/incubator/hnc/api/v1alpha1/hnc_config.go
+++ b/incubator/hnc/api/v1alpha1/hnc_config.go
@@ -55,7 +55,8 @@ type TypeSynchronizationSpec struct {
 	APIVersion string `json:"apiVersion,omitempty"`
 	// Kind to be configured.
 	Kind string `json:"kind,omitempty"`
-	// Synchronization mode of the kind.
+	// Synchronization mode of the kind. If the field is empty, it will be treated
+	// as "propagate". An unsupported mode will be treated as "ignore".
 	// +optional
 	Mode SynchronizationMode `json:"mode,omitempty"`
 }

--- a/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
+++ b/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
@@ -50,7 +50,9 @@ spec:
                     description: Kind to be configured.
                     type: string
                   mode:
-                    description: Synchronization mode of the kind.
+                    description: Synchronization mode of the kind. If the field is
+                      empty, it will be treated as "propagate". An unsupported mode
+                      will be treated as "ignore".
                     type: string
                 type: object
               type: array


### PR DESCRIPTION
This PR adds the support for 'ignore' mode in ConfigReconciler. Specifically, it adds following features:

- If the mode of a type is set to 'ignore', the corresponding object reconciler will ignore all subsequent reconciliations (e.g., new or changed objects will not be propagated).
- If the mode of a type is changed from 'ignore' to 'propagate', reconciliations for all existing objects of the type in the cluster will be triggered.
- If a mode of a type is unrecognized, it will be treated as 'ignore'.
- If a mode of a type is unset, it will be treated as 'propagate'.

Tested: GKE cluster; unit tests.

Design doc: http://bit.ly/hnc-type-configuration
Issue: #411