### PR TITLE
Update HNS and HC reconcilers to allow hns creation

### DIFF
--- a/incubator/hnc/api/v1alpha1/hierarchical_namespace.go
+++ b/incubator/hnc/api/v1alpha1/hierarchical_namespace.go
@@ -19,8 +19,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Constant for the hierarchicalnamespaces resource type.
-const HierarchicalNamespaces string = "hierarchicalnamespaces"
+// Constants for the HierarchicalNamespace resource, kind and API version.
+const (
+	HierarchicalNamespaces           = "hierarchicalnamespaces"
+	HierarchicalNamespacesKind       = "HierarchicalNamespace"
+	HierarchicalNamespacesAPIVersion = "hnc.x-k8s.io/v1alpha1"
+)
 
 // HNSState describes the state of a hierarchical namespace. The state could be
 // "missing", "ok", "conflict" or "forbidden". The definitions will be described below.

--- a/incubator/hnc/pkg/forest/forest.go
+++ b/incubator/hnc/pkg/forest/forest.go
@@ -143,6 +143,7 @@ type Namespace struct {
 
 	// RequiredChildOf indicates that this namespace is being or was created solely to live as a
 	// subnamespace of the specified parent.
+	// TODO rename it to Owner. See issue - https://github.com/kubernetes-sigs/multi-tenancy/issues/469
 	RequiredChildOf string
 }
 

--- a/incubator/hnc/pkg/reconcilers/hierarchical_namespace.go
+++ b/incubator/hnc/pkg/reconcilers/hierarchical_namespace.go
@@ -16,8 +16,11 @@ limitations under the License.
 package reconcilers
 
 import (
+	"context"
+
 	"github.com/go-logr/logr"
 	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -30,7 +33,7 @@ type HierarchicalNamespaceReconciler struct {
 }
 
 // Reconcile sets up some basic variables and then calls the business logic.
-// It currently only generates some logs for testing.
+// It currently handles basic creation of namespace and hierarchyconfig.
 func (r *HierarchicalNamespaceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// TODO report error state if the webhook is bypassed - see issue
 	//  https://github.com/kubernetes-sigs/multi-tenancy/issues/459
@@ -38,10 +41,64 @@ func (r *HierarchicalNamespaceReconciler) Reconcile(req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
+	ctx := context.Background()
 	log := r.Log.WithValues("trigger", req.NamespacedName)
 	log.Info("Reconciling HNS")
 
+	// Names of the self-serve subnamespace and the parent namespace.
+	nm := req.Name
+	pnm := req.Namespace
+
+	// We want to trigger the hierarchyConfig reconciliation on the self-serve subnamespace, since
+	// the parent's 'requiredChildren' field will be deprecated. The HierarchyConfig Reconciler
+	// will do the real job of updating the hierarchy in the forest and creating namespaces and
+	// hierarchyconfig (hc) instances.
+	//
+	// Please note that the self-serve subnamespace and its hc object don't exist on apiserver for now.
+	// Just enqueuing an in-memory hc instance for hc reconciliation will lose the hc's parent field
+	// since the hc reconciler will get nothing from the apiserver and create an empty in-memory hc.
+	// Therefore, we need to create the hc instance on apiserver and thus its namespace. The creation of
+	// the hc instance on apiserver will trigger the hc reconciler, who will update the forest and create
+	// the parent hc instance if it doesn't already exist.
+	// TODO: Add hnc.x-k8s.io/owner annotation to hierarchical namespaces. See issue -
+	//  https://github.com/kubernetes-sigs/multi-tenancy/issues/473
+	if err := r.writeNamespace(ctx, log, nm); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if err := r.writeHierarchy(ctx, log, nm, pnm); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	return ctrl.Result{}, nil
+}
+
+func (r *HierarchicalNamespaceReconciler) writeNamespace(ctx context.Context, log logr.Logger, nm string) error {
+	inst := &corev1.Namespace{}
+	inst.ObjectMeta.Name = nm
+
+	log.Info("Creating namespace on apiserver")
+	if err := r.Create(ctx, inst); err != nil {
+		log.Error(err, "while creating on apiserver")
+		return err
+	}
+	return nil
+}
+
+func (r *HierarchicalNamespaceReconciler) writeHierarchy(ctx context.Context, log logr.Logger, nm, pnm string) error {
+	inst := &api.HierarchyConfiguration{
+		Spec: api.HierarchyConfigurationSpec{Parent: pnm},
+	}
+	inst.ObjectMeta.Name = api.Singleton
+	inst.ObjectMeta.Namespace = nm
+
+	log.Info("Creating singleton on apiserver")
+	if err := r.Create(ctx, inst); err != nil {
+		log.Error(err, "while creating on apiserver")
+		return err
+	}
+
+	return nil
 }
 
 func (r *HierarchicalNamespaceReconciler) SetupWithManager(mgr ctrl.Manager) error {


### PR DESCRIPTION
Create namespace and hierarchyconfig instances of the self-serve
subnamespace in the HNS reconciler.

Make changes to the HC reconciler to use the list of hns objects in the
namespace as requiredChildren instead of using the
spec.requiredChildren.

Tested on GKE cluster. First, added the
`enable-hierarchicalnamespace-reconciler` flag into the
config/default/manager_auth-proxy_patch.yaml file. Used `kubectl hns
create2 -n parent child` and found the hc and the hns objects were
created in the `parent` namespace. `child` namespace and its hc object
were also created. I also saw the test log in Stackdriver saying that
the `requiredChildOf` field of the subnamespace in the forest was set to
the `parent`.

Part of #457 