### PR TITLE
[Incubator][VC]Add UID check for configMap/EP/PVC/Secret/SA resources

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/resources/endpoints/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/endpoints/checker.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/metrics"
 )
@@ -98,6 +99,11 @@ func (c *controller) checkEndPointsOfTenantCluster(clusterName string) {
 		}
 		if err != nil {
 			klog.Errorf("error getting pEp %s/%s from super master cache: %v", targetNamespace, vEp.Name, err)
+			continue
+		}
+		if pEp.Annotations[constants.LabelUID] != string(vEp.UID) {
+			klog.Errorf("pEndpoints %s/%s delegated UID is different from updated object.", targetNamespace, pEp.Name)
+			continue
 		}
 		updated := conversion.Equality(nil).CheckEndpointsEquality(pEp, &vEp)
 		if updated != nil {

--- a/incubator/virtualcluster/pkg/syncer/resources/secret/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/secret/dws.go
@@ -60,8 +60,16 @@ func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, e
 		return reconciler.Result{Requeue: true}, err
 	}
 	if len(secretList) != 0 {
-		// This is service account vSecret
-		pSecret = secretList[0]
+		// This is service account vSecret, it is unlikely we have a dup name in super but
+		for i, each := range secretList {
+			if each.Annotations[constants.LabelUID] == request.UID {
+				pSecret = secretList[i]
+				break
+			}
+		}
+		if pSecret == nil {
+			return reconciler.Result{Requeue: true}, fmt.Errorf("There are pSecrets that represent vSerect %s/%s but the UID is unmatched.", request.Namespace, request.Name)
+		}
 	} else {
 		// We need to use name to search again for normal vScrect
 		pSecret, err = c.secretLister.Secrets(targetNamespace).Get(request.Name)
@@ -75,20 +83,20 @@ func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, e
 
 	if vExists && !pExists {
 		vSecret := vSecretObj.(*v1.Secret)
-		err := c.reconcileSecretCreate(request.ClusterName, targetNamespace, vSecret)
+		err := c.reconcileSecretCreate(request.ClusterName, targetNamespace, request.UID, vSecret)
 		if err != nil {
 			klog.Errorf("failed reconcile secret %s/%s CREATE of cluster %s %v", request.Namespace, request.Name, request.ClusterName, err)
 			return reconciler.Result{Requeue: true}, err
 		}
 	} else if !vExists && pExists {
-		err := c.reconcileSecretRemove(request.ClusterName, targetNamespace, request.Name, pSecret)
+		err := c.reconcileSecretRemove(request.ClusterName, targetNamespace, request.UID, request.Name, pSecret)
 		if err != nil {
 			klog.Errorf("failed reconcile secret %s/%s DELETE of cluster %s %v", request.Namespace, request.Name, request.ClusterName, err)
 			return reconciler.Result{Requeue: true}, err
 		}
 	} else if vExists && pExists {
 		vSecret := vSecretObj.(*v1.Secret)
-		err := c.reconcileSecretUpdate(request.ClusterName, targetNamespace, pSecret, vSecret)
+		err := c.reconcileSecretUpdate(request.ClusterName, targetNamespace, request.UID, pSecret, vSecret)
 		if err != nil {
 			klog.Errorf("failed reconcile secret %s/%s UPDATE of cluster %s %v", request.Namespace, request.Name, request.ClusterName, err)
 			return reconciler.Result{Requeue: true}, err
@@ -99,12 +107,12 @@ func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, e
 	return reconciler.Result{}, nil
 }
 
-func (c *controller) reconcileSecretCreate(clusterName, targetNamespace string, secret *v1.Secret) error {
+func (c *controller) reconcileSecretCreate(clusterName, targetNamespace, requestUID string, secret *v1.Secret) error {
 	switch secret.Type {
 	case v1.SecretTypeServiceAccountToken:
 		return c.reconcileServiceAccountSecretCreate(clusterName, targetNamespace, secret)
 	default:
-		return c.reconcileNormalSecretCreate(clusterName, targetNamespace, secret)
+		return c.reconcileNormalSecretCreate(clusterName, targetNamespace, requestUID, secret)
 	}
 }
 
@@ -142,31 +150,38 @@ func (c *controller) reconcileServiceAccountSecretUpdate(clusterName, targetName
 	return nil
 }
 
-func (c *controller) reconcileNormalSecretCreate(clusterName, targetNamespace string, secret *v1.Secret) error {
+func (c *controller) reconcileNormalSecretCreate(clusterName, targetNamespace, requestUID string, secret *v1.Secret) error {
 	newObj, err := conversion.BuildMetadata(clusterName, targetNamespace, secret)
 	if err != nil {
 		return err
 	}
 
-	_, err = c.secretClient.Secrets(targetNamespace).Create(newObj.(*v1.Secret))
+	pSecret, err := c.secretClient.Secrets(targetNamespace).Create(newObj.(*v1.Secret))
 	if errors.IsAlreadyExists(err) {
-		klog.Infof("secret %s/%s of cluster %s already exist in super master", targetNamespace, secret.Name, clusterName)
-		return nil
+		if pSecret.Annotations[constants.LabelUID] == requestUID {
+			klog.Infof("secret %s/%s of cluster %s already exist in super master", targetNamespace, secret.Name, clusterName)
+			return nil
+		} else {
+			return fmt.Errorf("pSecret %s/%s exists but its delegated object UID is different.", targetNamespace, pSecret.Name)
+		}
 	}
 
 	return err
 }
 
-func (c *controller) reconcileSecretUpdate(clusterName, targetNamespace string, pSecret, vSecret *v1.Secret) error {
+func (c *controller) reconcileSecretUpdate(clusterName, targetNamespace, requestUID string, pSecret, vSecret *v1.Secret) error {
 	switch vSecret.Type {
 	case v1.SecretTypeServiceAccountToken:
 		return c.reconcileServiceAccountSecretUpdate(clusterName, targetNamespace, pSecret, vSecret)
 	default:
-		return c.reconcileNormalSecretUpdate(clusterName, targetNamespace, pSecret, vSecret)
+		return c.reconcileNormalSecretUpdate(clusterName, targetNamespace, requestUID, pSecret, vSecret)
 	}
 }
 
-func (c *controller) reconcileNormalSecretUpdate(clusterName, targetNamespace string, pSecret, vSecret *v1.Secret) error {
+func (c *controller) reconcileNormalSecretUpdate(clusterName, targetNamespace, requestUID string, pSecret, vSecret *v1.Secret) error {
+	if pSecret.Annotations[constants.LabelUID] != requestUID {
+		return fmt.Errorf("pEndpoints %s/%s delegated UID is different from updated object.", targetNamespace, pSecret.Name)
+	}
 	spec, err := c.multiClusterSecretController.GetSpec(clusterName)
 	if err != nil {
 		return err
@@ -182,16 +197,19 @@ func (c *controller) reconcileNormalSecretUpdate(clusterName, targetNamespace st
 	return nil
 }
 
-func (c *controller) reconcileSecretRemove(clusterName, targetNamespace, name string, secret *v1.Secret) error {
+func (c *controller) reconcileSecretRemove(clusterName, targetNamespace, requestUID, name string, secret *v1.Secret) error {
 	switch secret.Type {
 	case v1.SecretTypeServiceAccountToken:
 		return c.reconcileServiceAccountTokenSecretRemove(clusterName, targetNamespace, name)
 	default:
-		return c.reconcileNormalSecretRemove(clusterName, targetNamespace, name)
+		return c.reconcileNormalSecretRemove(clusterName, targetNamespace, requestUID, name, secret)
 	}
 }
 
-func (c *controller) reconcileNormalSecretRemove(clusterName, targetNamespace, name string) error {
+func (c *controller) reconcileNormalSecretRemove(clusterName, targetNamespace, requestUID, name string, pSecret *v1.Secret) error {
+	if pSecret.Annotations[constants.LabelUID] != requestUID {
+		return fmt.Errorf("To be deleted pSecret %s/%s delegated UID is different from deleted object.", targetNamespace, pSecret.Name)
+	}
 	opts := &metav1.DeleteOptions{
 		PropagationPolicy: &constants.DefaultDeletionPolicy,
 	}


### PR DESCRIPTION
This change adds UID check for rest of resources that have DWS in order to avoid any mis-creating/updating super master objects in case syncer has been offlined for a while. 