### PR TITLE
Enable hns reconciler to create namespace

### DIFF
--- a/incubator/hnc/Makefile
+++ b/incubator/hnc/Makefile
@@ -27,6 +27,11 @@ CRD_OPTIONS ?= "crd:trivialVersions=true"
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 GOBIN ?= $(shell go env GOPATH)/bin
 
+# Set default to not use HNS reconciler
+ifeq (,${HNS})
+HNS=0
+endif
+
 # Get check sum value of krew archive
 KREW_CKSM=$(shell sha256sum bin/kubectl-hierarchical_namespaces.tar.gz | cut -d " " -f 1)
 
@@ -36,7 +41,12 @@ all: test docker-build
 
 # Run tests
 test: build
-	go test ./api/... ./cmd/... ./pkg/... -coverprofile cover.out
+	# run tests in all directories except ./pkg/reconcilers/
+	go test ./api/... ./cmd/... `go list ./pkg/... | grep -v reconcilers` -coverprofile cover.out
+	# separately run tests in ./pkg/reconcilers/
+	# by default it will not use the HNS reconciler
+	# with HNS=1 it will use the new HNS reconciler
+	go test ./pkg/reconcilers/... -enable-hierarchicalnamespace-reconciler=${HNS} -coverprofile cover.out
 
 # Builds all binaries (manager and kubectl) and manifests
 build: generate fmt vet manifests

--- a/incubator/hnc/api/v1alpha1/hierarchical_namespace.go
+++ b/incubator/hnc/api/v1alpha1/hierarchical_namespace.go
@@ -19,8 +19,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Constant for the hierarchicalnamespaces resource type.
-const HierarchicalNamespaces string = "hierarchicalnamespaces"
+// Constants for the hierarchicalnamespaces resource type and namespace annotation.
+const (
+	HierarchicalNamespaces = "hierarchicalnamespaces"
+	AnnotationOwner        = MetaGroup + "/owner"
+)
 
 // HNSState describes the state of a hierarchical namespace. The state could be
 // "missing", "ok", "conflict" or "forbidden". The definitions will be described below.

--- a/incubator/hnc/pkg/forest/forest.go
+++ b/incubator/hnc/pkg/forest/forest.go
@@ -141,6 +141,7 @@ type Namespace struct {
 	// on this namespace.
 	conditions conditions
 
+	// TODO rename it to Owner. See issue - https://github.com/kubernetes-sigs/multi-tenancy/issues/469
 	// RequiredChildOf indicates that this namespace is being or was created solely to live as a
 	// subnamespace of the specified parent.
 	RequiredChildOf string
@@ -247,6 +248,20 @@ func (ns *Namespace) ChildNames() []string {
 		nms = append(nms, k)
 	}
 	sort.Strings(nms)
+	return nms
+}
+
+// OwnedNames returns a list of names of the owned namespaces or nil if there's none.
+func (ns *Namespace) OwnedNames() []string {
+	if len(ns.forest.namespaces) == 0 {
+		return nil
+	}
+	nms := []string{}
+	for nm, ns := range ns.forest.namespaces {
+		if ns.RequiredChildOf == ns.name {
+			nms = append(nms, nm)
+		}
+	}
 	return nms
 }
 

--- a/incubator/hnc/pkg/reconcilers/hierarchical_namespace.go
+++ b/incubator/hnc/pkg/reconcilers/hierarchical_namespace.go
@@ -18,6 +18,7 @@ package reconcilers
 import (
 	"github.com/go-logr/logr"
 	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/forest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -27,10 +28,13 @@ import (
 type HierarchicalNamespaceReconciler struct {
 	client.Client
 	Log logr.Logger
+
+	forest *forest.Forest
+	hcr    *HierarchyConfigReconciler
 }
 
-// Reconcile sets up some basic variables and then calls the business logic.
-// It currently only generates some logs for testing.
+// Reconcile sets up some basic variables and then calls the business logic. It currently
+// only handles the creation of the namespaces but no deletion or state reporting yet.
 func (r *HierarchicalNamespaceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// TODO report error state if the webhook is bypassed - see issue
 	//  https://github.com/kubernetes-sigs/multi-tenancy/issues/459
@@ -40,6 +44,25 @@ func (r *HierarchicalNamespaceReconciler) Reconcile(req ctrl.Request) (ctrl.Resu
 
 	log := r.Log.WithValues("trigger", req.NamespacedName)
 	log.Info("Reconciling HNS")
+
+	// Names of the hierarchical namespace and the current namespace.
+	nm := req.Name
+	pnm := req.Namespace
+
+	// Set RequiredChildOf (Owner) in the forest of the hierarchical namespace to the
+	// current namespace.
+	// TODO rename RequiredChildOf to Owner in the forest. See issue:
+	//  https://github.com/kubernetes-sigs/multi-tenancy/issues/469
+	r.forest.Get(nm).RequiredChildOf = pnm
+
+	// Enqueue the in-momery hierarchyConfig instance of the hierarchical namespace.
+	// The hierarchyConfig reconciler will create the namespace and hierarchyConfig
+	// instances on apiserver accordingly.
+	reason := "new/updated hierarchical namespace"
+	r.hcr.enqueueAffected(log, reason, nm)
+
+	// TODO sync with forest to report conflicts in hns.Status.State. See issue:
+	//  https://github.com/kubernetes-sigs/multi-tenancy/issues/487
 
 	return ctrl.Result{}, nil
 }

--- a/incubator/hnc/pkg/reconcilers/hierarchical_namespace_test.go
+++ b/incubator/hnc/pkg/reconcilers/hierarchical_namespace_test.go
@@ -1,0 +1,82 @@
+package reconcilers_test
+
+import (
+	"context"
+
+	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Hierarchy", func() {
+	ctx := context.Background()
+
+	var (
+		fooName string
+		barName string
+	)
+
+	BeforeEach(func() {
+		if !enableHNSReconciler {
+			Skip("Skipping hierarchical namespace tests when the hns reconciler is not enabled.")
+		}
+
+		fooName = createNS(ctx, "foo")
+		barName = createNSName("bar")
+
+		// Create "bar" hns in "foo" namespace
+		foo_hns_bar := newHierarchicalNamespace(barName, fooName)
+		updateHierarchicalNamespace(ctx, foo_hns_bar)
+	})
+
+	It("should set the self-serve subnamespace as a child on the current namespace", func() {
+		Eventually(func() []string {
+			fooHier := getHierarchy(ctx, fooName)
+			return fooHier.Status.Children
+		}).Should(Equal([]string{barName}))
+	})
+
+	It("should set the current namespace as the parent of the self-serve subnamespace", func() {
+		Eventually(func() string {
+			barHier := getHierarchy(ctx, barName)
+			return barHier.Spec.Parent
+		}).Should(Equal(fooName))
+	})
+
+	It("should create the self-serve subnamespace", func() {
+		nnm := types.NamespacedName{Name: barName}
+		ns := &corev1.Namespace{}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, nnm, ns)
+		}).Should(Succeed())
+	})
+
+	It("should set the self-serve subnamespace's owner annotation to the current namespace", func() {
+		Eventually(getNamespaceAnnotation(ctx, barName, api.AnnotationOwner)).Should(Equal(fooName))
+	})
+})
+
+func newHierarchicalNamespace(hnsnm, nm string) *api.HierarchicalNamespace {
+	hns := &api.HierarchicalNamespace{}
+	hns.ObjectMeta.Namespace = nm
+	hns.ObjectMeta.Name = hnsnm
+	return hns
+}
+
+func updateHierarchicalNamespace(ctx context.Context, hns *api.HierarchicalNamespace) {
+	if hns.CreationTimestamp.IsZero() {
+		ExpectWithOffset(1, k8sClient.Create(ctx, hns)).Should(Succeed())
+	} else {
+		ExpectWithOffset(1, k8sClient.Update(ctx, hns)).Should(Succeed())
+	}
+}
+
+func getNamespaceAnnotation(ctx context.Context, nnm, annotation string) func() string {
+	return func() string {
+		ns := getNamespace(ctx, nnm)
+		val, _ := ns.GetAnnotations()[annotation]
+		return val
+	}
+}

--- a/incubator/hnc/pkg/reconcilers/hierarchy_config_test.go
+++ b/incubator/hnc/pkg/reconcilers/hierarchy_config_test.go
@@ -137,6 +137,9 @@ var _ = Describe("Hierarchy", func() {
 	})
 
 	It("should create a child namespace if requested", func() {
+		if enableHNSReconciler {
+			return
+		}
 		// Create a namespace with a required child
 		fooHier := newHierarchy(fooName)
 		fooHier.Spec.RequiredChildren = []string{barName}
@@ -152,6 +155,9 @@ var _ = Describe("Hierarchy", func() {
 	})
 
 	It("should set RequiredChildConflict condition if a required child cannot be set", func() {
+		if enableHNSReconciler {
+			return
+		}
 		bazName := createNS(ctx, "baz")
 
 		// Make baz a child of foo
@@ -178,6 +184,9 @@ var _ = Describe("Hierarchy", func() {
 	})
 
 	It("should clear RequiredChildConflict condition if the parent removes the required child", func() {
+		if enableHNSReconciler {
+			return
+		}
 		bazName := createNS(ctx, "baz")
 
 		// Make baz a child of foo

--- a/incubator/hnc/pkg/reconcilers/setup.go
+++ b/incubator/hnc/pkg/reconcilers/setup.go
@@ -27,14 +27,14 @@ func Create(mgr ctrl.Manager, f *forest.Forest, maxReconciles int, enableHNSReco
 	// Create different reconcilers based on if the enableHNSReconciler flag is set or not.
 	if enableHNSReconciler {
 		// Create the HierarchyConfigReconciler with HNSReconciler enabled.
-		hr := &HierarchyConfigReconciler{
+		hcr := &HierarchyConfigReconciler{
 			Client:               mgr.GetClient(),
 			Log:                  ctrl.Log.WithName("reconcilers").WithName("Hierarchy"),
 			Forest:               f,
 			Affected:             hcChan,
 			HNSReconcilerEnabled: true,
 		}
-		if err := hr.SetupWithManager(mgr, maxReconciles); err != nil {
+		if err := hcr.SetupWithManager(mgr, maxReconciles); err != nil {
 			return fmt.Errorf("cannot create Hierarchy reconciler: %s", err.Error())
 		}
 
@@ -42,6 +42,8 @@ func Create(mgr ctrl.Manager, f *forest.Forest, maxReconciles int, enableHNSReco
 		hnsr := &HierarchicalNamespaceReconciler{
 			Client: mgr.GetClient(),
 			Log:    ctrl.Log.WithName("reconcilers").WithName("HierarchicalNamespace"),
+			forest: f,
+			hcr:    hcr,
 		}
 		if err := hnsr.SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("cannot create HierarchicalNamespace reconciler: %s", err.Error())


### PR DESCRIPTION
In the hns reconciler, update the forest and enqueue in-memory
hierarchyConfig instance for hierarchyConfig reconciler to reconcile.
The hierarchyConfig reconciler will create the namespace with Owner
annotation and create/update both the parent and child hierarchyConfig
instances. If the hns reconciler is enabled by the flag, the hc
reconciler will get all hns objects from the forest instead of using the
"RequiredChildren" field in the hc spec.

Add integration tests with flag "make test HNS=1".

Tested by integration tests and manually with "kubectl hns create2 -n
parent child". The "child" namespace was created with Owner annotation
set to "parent".

Part of #457 . Fixes #473 .