### PR TITLE
[Incubator][VC]Avoid using Secret/SA name in Labels

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/constants/constants.go
+++ b/incubator/virtualcluster/pkg/syncer/constants/constants.go
@@ -33,10 +33,13 @@ const (
 	LabelOwnerReferences = "tenancy.x-k8s.io/ownerReferences"
 	// LabelClusterIP is the cluster ip of the corresponding service in tenant namespace.
 	LabelClusterIP = "tenancy.x-k8s.io/clusterIP"
-	// LabelServiceAccountName is the service account name related to the secret.
-	LabelServiceAccountName = "tenancy.x-k8s.io/service-account.name"
 	// LabelSecretName is the service account token secret name in tenant namespace.
 	LabelSecretName = "tenancy.x-k8s.io/secret.name"
+
+	// LabelServiceAccountUID is the tenant service account UID related to the secret.
+	LabelServiceAccountUID = "tenancy.x-k8s.io/service-account.UID"
+	// LabelSecretUID is the service account token secret UID in tenant namespace.
+	LabelSecretUID = "tenancy.x-k8s.io/secret.UID"
 
 	// UwsControllerWorkersHigh is the quantity of the worker routine for a resource that generates high number of uws requests.
 	UwsControllerWorkerHigh = 10

--- a/incubator/virtualcluster/pkg/syncer/conversion/helper_test.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/helper_test.go
@@ -128,7 +128,7 @@ func Test_mutateContainerSecret(t *testing.T) {
 	saSecret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "service-token-secret",
-			Labels: map[string]string{
+			Annotations: map[string]string{
 				constants.LabelSecretName: "service-token-secret-tenant",
 			},
 		},

--- a/incubator/virtualcluster/pkg/syncer/conversion/mutate.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/mutate.go
@@ -107,7 +107,7 @@ func PodMutateDefault(vPod *v1.Pod, SASecret *v1.Secret, services []*v1.Service,
 		}
 
 		for i, volume := range p.pPod.Spec.Volumes {
-			if volume.Name == SASecret.Labels[constants.LabelSecretName] {
+			if volume.Name == SASecret.Annotations[constants.LabelSecretName] {
 				p.pPod.Spec.Volumes[i].Name = SASecret.Name
 				p.pPod.Spec.Volumes[i].Secret.SecretName = SASecret.Name
 			}
@@ -146,7 +146,7 @@ func mutateContainerEnv(c *v1.Container, vPod *v1.Pod, serviceEnvMap map[string]
 
 func mutateContainerSecret(c *v1.Container, SASecret *v1.Secret) {
 	for j, volumeMount := range c.VolumeMounts {
-		if volumeMount.Name == SASecret.Labels[constants.LabelSecretName] {
+		if volumeMount.Name == SASecret.Annotations[constants.LabelSecretName] {
 			c.VolumeMounts[j].Name = SASecret.Name
 		}
 	}
@@ -374,9 +374,16 @@ func (s *saSecretMutator) Mutate(vSecret *v1.Secret, clusterName string) {
 	if labels == nil {
 		labels = make(map[string]string)
 	}
-	labels[constants.LabelSecretName] = vSecret.Name
-	labels[constants.LabelServiceAccountName] = vSecret.GetAnnotations()[v1.ServiceAccountNameKey]
+	annotations := s.pSecret.GetAnnotations()
+	if annotations == nil {
+		labels = make(map[string]string)
+	}
+
+	annotations[constants.LabelSecretName] = vSecret.Name
+	labels[constants.LabelSecretUID] = string(vSecret.UID)
+	labels[constants.LabelServiceAccountUID] = vSecret.GetAnnotations()[v1.ServiceAccountUIDKey]
 	s.pSecret.SetLabels(labels)
+	s.pSecret.SetAnnotations(annotations)
 
 	s.pSecret.Name = ""
 	s.pSecret.GenerateName = vSecret.GetAnnotations()[v1.ServiceAccountNameKey] + "-token-"

--- a/incubator/virtualcluster/pkg/syncer/conversion/mutate.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/mutate.go
@@ -376,7 +376,7 @@ func (s *saSecretMutator) Mutate(vSecret *v1.Secret, clusterName string) {
 	}
 	annotations := s.pSecret.GetAnnotations()
 	if annotations == nil {
-		labels = make(map[string]string)
+		annotations = make(map[string]string)
 	}
 
 	annotations[constants.LabelSecretName] = vSecret.Name

--- a/incubator/virtualcluster/pkg/syncer/resources/secret/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/secret/checker.go
@@ -91,7 +91,7 @@ func (c *controller) checkSecrets() {
 		// virtual service account token type secret
 		vSecretName := pSecret.Name
 		if saName := pSecret.GetAnnotations()[v1.ServiceAccountNameKey]; saName != "" {
-			vSecretName = pSecret.GetLabels()[constants.LabelSecretName]
+			vSecretName = pSecret.GetAnnotations()[constants.LabelSecretName]
 		}
 		// check whether secret is exists in tenant.
 		vSecretObj, err := c.multiClusterSecretController.Get(clusterName, vNamespace, vSecretName)
@@ -171,7 +171,7 @@ func (c *controller) checkSecretOfTenantCluster(clusterName string) {
 
 func (c *controller) checkServiceAccountTokenTypeSecretOfTenantCluster(clusterName, targetNamespace string, vSecret *v1.Secret) {
 	secretList, err := c.secretLister.Secrets(targetNamespace).List(labels.SelectorFromSet(map[string]string{
-		constants.LabelSecretName: vSecret.Name,
+		constants.LabelSecretUID: string(vSecret.UID),
 	}))
 	if errors.IsNotFound(err) || len(secretList) == 0 {
 		if err := c.multiClusterSecretController.RequeueObject(clusterName, vSecret, reconciler.AddEvent); err != nil {


### PR DESCRIPTION
SA and secret name can be as long as 253 characters but the Label value max length is limited to 63 characters. We should not use name in Labels to identify pSecret that represents tenant service account secret. 

In this change, we switch to use sa/secret UID to identify pSecret that represents tenant service account secret. 