### PR TITLE
Add `allowCascadingDelete` to HC.spec and enable `kubectl`

### DIFF
--- a/incubator/hnc/api/v1alpha1/hierarchy_types.go
+++ b/incubator/hnc/api/v1alpha1/hierarchy_types.go
@@ -63,6 +63,10 @@ type HierarchyConfigurationSpec struct {
 	// Parent indicates the parent of this namespace, if any.
 	Parent string `json:"parent,omitempty"`
 
+	// AllowCascadingDelete indicates if the self-serve subnamespaces of this namespace are allowed
+	// to cascading delete.
+	AllowCascadingDelete bool `json:"allowCascadingDelete"`
+
 	// RequiredChildren indicates the required subnamespaces of this namespace. If they do not exist,
 	// the HNC will create them, allowing users without privileges to create namespaces to get child
 	// namespaces anyway.

--- a/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hierarchyconfigurations.yaml
+++ b/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hierarchyconfigurations.yaml
@@ -34,6 +34,10 @@ spec:
         spec:
           description: HierarchySpec defines the desired state of Hierarchy
           properties:
+            allowCascadingDelete:
+              description: AllowCascadingDelete indicates if the self-serve subnamespaces
+                of this namespace are allowed to cascading delete.
+              type: boolean
             parent:
               description: Parent indicates the parent of this namespace, if any.
               type: string
@@ -45,6 +49,8 @@ spec:
               items:
                 type: string
               type: array
+          required:
+          - allowCascadingDelete
           type: object
         status:
           description: HierarchyStatus defines the observed state of Hierarchy


### PR DESCRIPTION
Add `allowCascadingDelete` to HC.spec. Enable `kubectl hns set parent
--allowCascadingDelete=true/false` to set the spec.

Tested manually on GKE.

Fixes #480 . Part of #457 