### PR TITLE
Fix a flaky object controller test

### DIFF
--- a/incubator/hnc/pkg/reconcilers/object_test.go
+++ b/incubator/hnc/pkg/reconcilers/object_test.go
@@ -118,6 +118,8 @@ var _ = Describe("Secret", func() {
 	It("should overwrite the propagated ones if the source is updated", func() {
 		setParent(ctx, barName, fooName)
 		setParent(ctx, bazName, barName)
+		// Wait 1 second to make sure the source get propagated.
+		time.Sleep(1 * time.Second)
 		Eventually(isModified(ctx, fooName, "foo-role")).Should(BeFalse())
 		Eventually(hasObject(ctx, "Role", barName, "foo-role")).Should(BeTrue())
 		Eventually(isModified(ctx, barName, "foo-role")).Should(BeFalse())


### PR DESCRIPTION
The flaky error is that when an initial propagation is not done, the
test expects to get the propagated object with success and see if it's
modified from the source but it failed when getting the object.

Added 1 second sleep to fix the flaky test.