### PR TITLE
[Incubator][VC]Sync non-service eps

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/constants/constants.go
+++ b/incubator/virtualcluster/pkg/syncer/constants/constants.go
@@ -65,8 +65,8 @@ const (
 	// DefaultvNodeGCGracePeriod is the grace period of time before deleting an orphan vNode in tenant master.
 	DefaultvNodeGCGracePeriod = time.Second * 120
 	// If Uws request keeps failing, stop retrying after MaxUwsRetryAttempts.
-	// According to controller workqueue default rate limiter algorithm, retry 13 times takes around 90 seconds.
-	MaxUwsRetryAttempts = 13
+	// According to controller workqueue default rate limiter algorithm, retry 16 times takes around 180 seconds.
+	MaxUwsRetryAttempts = 16
 
 	DefaultOpaqueMetaPrefix = "tenancy.x-k8s.io"
 )


### PR DESCRIPTION
For service with selector being set, the ep controller will handle the ep lifecycle. Syncer ignore those eps to avoid any possible conflicts. With this change, for all other eps, syncer will sync them to super master.

This change also bumps up the retry number to tolerate long syncer restart time. 