### PR TITLE
Set an object reconciler to "ignore" mode if its corresponding type is removed from the HNCConfiguration Spec

### DIFF
--- a/incubator/hnc/pkg/reconcilers/hnc_config_test.go
+++ b/incubator/hnc/pkg/reconcilers/hnc_config_test.go
@@ -192,6 +192,28 @@ var _ = Describe("HNCConfiguration", func() {
 		Eventually(hasObject(ctx, "ResourceQuota", barName, "foo-resource-quota")).Should(BeTrue())
 		Expect(objectInheritedFrom(ctx, "ResourceQuota", barName, "foo-resource-quota")).Should(Equal(fooName))
 	})
+
+	It("should stop propagating objects if a type is first set to propagate mode then removed from the spec", func() {
+		addToHNCConfig(ctx, "v1", "Secret", api.Propagate)
+		setParent(ctx, barName, fooName)
+		makeObject(ctx, "Secret", fooName, "foo-sec")
+
+		// "foo-sec" should propagate from foo to bar.
+		Eventually(hasObject(ctx, "Secret", barName, "foo-sec")).Should(BeTrue())
+		Expect(objectInheritedFrom(ctx, "Secret", barName, "foo-sec")).Should(Equal(fooName))
+
+		removeHNCConfigType(ctx, "v1", "Secret")
+		// Give foo another secret.
+		makeObject(ctx, "Secret", fooName, "foo-sec-2")
+
+		// Foo should have "foo-sec-2" because we created there.
+		Eventually(hasObject(ctx, "Secret", fooName, "foo-sec-2")).Should(BeTrue())
+		// Sleep to give "foo-sec-2" a chance to propagate from foo to bar, if it could.
+		time.Sleep(sleepTime)
+		// "foo-role-2" should not propagate from foo to bar because the reconciliation request is ignored.
+		Expect(hasObject(ctx, "Secret", barName, "foo-sec-2")()).Should(BeFalse())
+
+	})
 })
 
 func hasTypeWithMode(apiVersion, kind string, mode api.SynchronizationMode, config *api.HNCConfiguration) func() bool {
@@ -270,6 +292,25 @@ func updateHNCConfigSpec(ctx context.Context, prevApiVersion, newApiVersion, pre
 				break
 			}
 		}
+		return updateHNCConfig(ctx, c)
+	}).Should(Succeed())
+}
+
+func removeHNCConfigType(ctx context.Context, apiVersion, kind string) {
+	Eventually(func() error {
+		c := getHNCConfig(ctx)
+		i := 0
+		for ; i < len(c.Spec.Types); i++ {
+			if c.Spec.Types[i].APIVersion == apiVersion && c.Spec.Types[i].Kind == kind {
+				break
+			}
+		}
+		// The type does not exist. Nothing to remove.
+		if i == len(c.Spec.Types) {
+			return nil
+		}
+		c.Spec.Types[i] = c.Spec.Types[len(c.Spec.Types)-1]
+		c.Spec.Types = c.Spec.Types[:len(c.Spec.Types)-1]
 		return updateHNCConfig(ctx, c)
 	}).Should(Succeed())
 }


### PR DESCRIPTION
If a type is removed from the HNCConfiguration Spec, we will set the corresponding object reconciler to "ignore" mode. 

Ideally, we should shut down the corresponding object reconciler. Gracefully terminating an object reconciler is still under
development (https://github.com/kubernetes-sigs/controller-runtime/issues/764). Once the feature is released, we will see if we can shut down the object reconciler instead of setting it to "ignore" mode.

Tested: GKE, unit tests

Design doc: http://bit.ly/hnc-type-configuration
Issue: #411