### PR TITLE
Exclude "kube-public" namespace in HNC

### DIFF
--- a/incubator/hnc/pkg/reconcilers/setup.go
+++ b/incubator/hnc/pkg/reconcilers/setup.go
@@ -14,6 +14,7 @@ import (
 // TODO make the exclusion configurable - https://github.com/kubernetes-sigs/multi-tenancy/issues/374
 var EX = map[string]bool{
 	"kube-system":  true,
+	"kube-public":  true,
 	"hnc-system":   true,
 	"cert-manager": true,
 }


### PR DESCRIPTION
"kube-public" is a namespace that is currently used to make "cluster-info" configmap readable to all users (see details in https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cluster-lifecycle/bootstrap-discovery.md#new-kube-public-namespace). HNC shouldn't reconcile objects in "kube-public" namespace. 