### PR TITLE
Validate RBAC roles and bindings generated by tenant reconciler

### DIFF
--- a/tenant/pkg/controller/tenant/tenant_controller_suite.go
+++ b/tenant/pkg/controller/tenant/tenant_controller_suite.go
@@ -17,38 +17,12 @@ limitations under the License.
 package tenant
 
 import (
-	stdlog "log"
-	"os"
-	"path/filepath"
-	"sync"
-	"testing"
-
-	"github.com/kubernetes-sigs/multi-tenancy/tenant/pkg/apis"
 	"github.com/onsi/gomega"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sync"
 )
 
-var cfg *rest.Config
-
-func TestMain(m *testing.M) {
-	t := &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds")},
-	}
-	apis.AddToScheme(scheme.Scheme)
-
-	var err error
-	if cfg, err = t.Start(); err != nil {
-		stdlog.Fatal(err)
-	}
-
-	code := m.Run()
-	t.Stop()
-	os.Exit(code)
-}
 
 // SetupTestReconcile returns a reconcile.Reconcile implementation that delegates to inner and
 // writes the request to requests after Reconcile is finished.
@@ -72,4 +46,12 @@ func StartTestManager(mgr manager.Manager, g *gomega.GomegaWithT) (chan struct{}
 		g.Expect(mgr.Start(stop)).NotTo(gomega.HaveOccurred())
 	}()
 	return stop, wg
+}
+
+func SetupNewReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return newReconciler(mgr)
+}
+
+func AddManager(mgr manager.Manager, r reconcile.Reconciler) error {
+	return add(mgr, r)
 }

--- a/tenant/pkg/controller/tenant/tenant_controller_test.go
+++ b/tenant/pkg/controller/tenant/tenant_controller_test.go
@@ -17,6 +17,13 @@ limitations under the License.
 package tenant
 
 import (
+	"github.com/kubernetes-sigs/multi-tenancy/tenant/pkg/apis"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	stdlog "log"
+	"os"
+	"path/filepath"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"testing"
 	"time"
 
@@ -37,6 +44,25 @@ var c client.Client
 var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo"}}
 
 const timeout = time.Second * 5
+
+var cfg *rest.Config
+
+func TestMain(m *testing.M) {
+	t := &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds")},
+	}
+	apis.AddToScheme(scheme.Scheme)
+
+	var err error
+	if cfg, err = t.Start(); err != nil {
+		stdlog.Fatal(err)
+	}
+
+	code := m.Run()
+	t.Stop()
+	os.Exit(code)
+}
+
 
 func TestReconcile(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)

--- a/tenant/pkg/controller/tenantnamespace/tenantnamespace_controller_suite_test.go
+++ b/tenant/pkg/controller/tenantnamespace/tenantnamespace_controller_suite_test.go
@@ -19,6 +19,8 @@ package tenantnamespace
 import (
 	stdlog "log"
 	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -35,13 +37,13 @@ var cfg *rest.Config
 
 func TestMain(m *testing.M) {
 	t := &envtest.Environment{
-		//CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds")},
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds")},
 		UseExistingCluster:true,
 	}
 	apis.AddToScheme(scheme.Scheme)
 
 	var err error
-	if cfg, err = t.Start(); err != nil {
+	if cfg, err = t.Start(); err != nil && !(strings.Contains(err.Error(), "customresourcedefinitions.apiextensions.k8s.io") && strings.Contains(err.Error(), "already exists") && (strings.Contains(err.Error(), "tenants.tenancy.x-k8s.io") || strings.Contains(err.Error(), "tenantnamespaces.tenancy.x-k8s.io"))) {
 		stdlog.Fatal(err)
 	}
 

--- a/tenant/pkg/controller/tenantnamespace/tenantnamespace_controller_suite_test.go
+++ b/tenant/pkg/controller/tenantnamespace/tenantnamespace_controller_suite_test.go
@@ -19,7 +19,6 @@ package tenantnamespace
 import (
 	stdlog "log"
 	"os"
-	"path/filepath"
 	"sync"
 	"testing"
 
@@ -36,7 +35,8 @@ var cfg *rest.Config
 
 func TestMain(m *testing.M) {
 	t := &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds")},
+		//CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds")},
+		UseExistingCluster:true,
 	}
 	apis.AddToScheme(scheme.Scheme)
 

--- a/tenant/pkg/controller/tenantnamespace/tenantnamespace_helper.go
+++ b/tenant/pkg/controller/tenantnamespace/tenantnamespace_helper.go
@@ -1,0 +1,60 @@
+package tenantnamespace
+
+import (
+	"bytes"
+	"encoding/base64"
+	"html/template"
+)
+
+const (
+	cfgTemplate = `
+kind: Config
+apiVersion: v1
+users:
+- name: {{ .username }}
+  user:
+    token: {{ .token }}
+clusters:
+- name: {{ .cluster }}
+  cluster:
+    certificate-authority-data: {{ .ca }}
+    server: {{ .master }}
+contexts:
+- context:
+    cluster: {{ .cluster }}
+    user: {{ .username }}
+  name: default
+current-context: default
+preferences: {}
+`
+)
+
+func GenerateCfgStr(clusterName string, ip string, ca, token []byte, username string) (string, error) {
+	de := base64.StdEncoding.EncodeToString(token)
+	r, _ := base64.StdEncoding.DecodeString(de)
+	ctx := map[string]string{
+		"ca":       base64.StdEncoding.EncodeToString(ca),
+		"token":    string(r),
+		"username": username,
+		"master":   ip,
+		"cluster":  clusterName,
+	}
+
+	return getTemplateContent(cfgTemplate, ctx)
+}
+
+// getTemplateContent fills out the kubeconfig templates based on the context
+func getTemplateContent(kubeConfigTmpl string, context interface{}) (string, error) {
+	t, tmplPrsErr := template.New("test").Parse(kubeConfigTmpl)
+	if tmplPrsErr != nil {
+		return "", tmplPrsErr
+	}
+	writer := bytes.NewBuffer([]byte{})
+	if err := t.Execute(writer, context); nil != err {
+		return "", err
+	}
+
+	return writer.String(), nil
+}
+
+


### PR DESCRIPTION
1. start tenant and tenantnamespace controller
2. create tenant admin and nonadmin ser
3. validate tenantadmin is able to create tenantnamespace, whereas nonadmin user is not