### PR TITLE
[Incubator][VC]Add owner reference for all namespaces created by syncer and vcmanager

### DIFF
--- a/incubator/virtualcluster/pkg/controller/util/kube/util.go
+++ b/incubator/virtualcluster/pkg/controller/util/kube/util.go
@@ -32,8 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	tenancyv1alpha1 "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
 )
 
 // the namespace of the pod can be found in this file
@@ -90,48 +88,24 @@ func WaitStatefulSetReady(cli client.Client, namespace, name string, timeOutSec,
 	}
 }
 
-// CreateVCNS creates namespace 'nsName' by client 'cli' and add annotation
-// related to 'cluster'
-func CreateVCNS(cli client.Client, cluster, nsName string) error {
-	ns := &v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: nsName,
-		},
-	}
-	superNs, err := conversion.BuildSuperMasterNamespace(cluster, ns)
-	if err != nil {
-		return err
-	}
-	err = cli.Create(context.TODO(), superNs)
-	if apierrors.IsAlreadyExists(err) {
-		return nil
-	}
-	return err
-}
-
-// CreateNS creates namespace 'nsName' by client 'cli'
-func CreateNS(cli client.Client, nsName string) error {
+// CreateRootNS creates the root namespace for the vc
+func CreateRootNS(cli client.Client, nsName, vcName, vcUID string) error {
 	err := cli.Create(context.TODO(), &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nsName,
+			OwnerReferences: []metav1.OwnerReference{
+				metav1.OwnerReference{
+					APIVersion: tenancyv1alpha1.SchemeGroupVersion.String(),
+					Kind:       "Virtualcluster",
+					Name:       vcName,
+					UID:        types.UID(vcUID),
+				}},
 		},
 	})
 	if apierrors.IsAlreadyExists(err) {
 		return nil
 	}
 	return err
-}
-
-// RemoveNS removes namespace 'nsName' by client 'cli'
-func RemoveNS(cli client.Client, nsName string) error {
-	if err := cli.Delete(context.TODO(), &v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: nsName,
-		},
-	}); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-	return nil
 }
 
 // AnnotateVC add the annotation('key'='val') to the Virtualcluster 'vc'
@@ -158,48 +132,4 @@ func RetryPatchVCOnConflict(ctx context.Context, cli client.Client, vc *tenancyv
 		}
 		return patchErr
 	})
-}
-
-// isAffiliated checks if the given namespace is related to vc, i.e. contains
-// annotation "tenancy.x-k8s.io/cluster":conversion.ToClusterKey(vc)
-// NOTE the root ns doesn't contain this annotation
-func isAffiliated(ns *v1.Namespace, vc *tenancyv1alpha1.Virtualcluster) bool {
-	var tmpVcName string
-	for k, v := range ns.GetAnnotations() {
-		if k == constants.LabelCluster {
-			tmpVcName = v
-			break
-		}
-	}
-	if tmpVcName != "" && tmpVcName == conversion.ToClusterKey(vc) {
-		return true
-	}
-	return false
-
-}
-
-// DeleteAffiliatedNs deletes namespaces affiliated to the target virtualcluster
-func DeleteAffiliatedNs(cli client.Client, vc *tenancyv1alpha1.Virtualcluster, log logr.Logger) error {
-	// delete all related ns, except the root ns
-	nsLst := &v1.NamespaceList{}
-	if err := cli.List(context.TODO(), nsLst); err != nil {
-		log.Error(err, "fail to list all namespaces")
-		return err
-	}
-	for _, ns := range nsLst.Items {
-		if isAffiliated(&ns, vc) {
-			// remove related ns
-			if err := RemoveNS(cli, ns.GetName()); err != nil {
-				log.Error(err, "fail to delete the namespace", "ns", ns.GetName())
-				return err
-			}
-			log.Info("namespace is deleted", "ns", ns.GetName())
-		}
-	}
-	// delete the root ns
-	if err := RemoveNS(cli, conversion.ToClusterKey(vc)); err != nil {
-		log.Error(err, "fail to delete the root namespace", "ns", conversion.ToClusterKey(vc))
-		return err
-	}
-	return nil
 }

--- a/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_aliyun.go
+++ b/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_aliyun.go
@@ -493,13 +493,8 @@ PollASK:
 
 	// 4. create the root namesapce of the Virtualcluster
 	vcNs := conversion.ToClusterKey(vc)
-	// remove root ns if exist.
-	// NOTE rootNS may exist for debugging purposes if creation fail
-	err = kubeutil.RemoveNS(mpa, vcNs)
-	if err != nil {
-		return err
-	}
-	err = kubeutil.CreateNS(mpa, vcNs)
+
+	err = kubeutil.CreateRootNS(mpa, vcNs, vc.Name, string(vc.UID))
 	if err != nil {
 		return err
 	}
@@ -574,7 +569,6 @@ PollASK:
 // the ASK will be deleted
 func (mpa *MasterProvisionerAliyun) DeleteVirtualCluster(vc *tenancyv1alpha1.Virtualcluster) error {
 	log.Info("deleting the ASK of the virtualcluster", "vc-name", vc.Name)
-	defer kubeutil.DeleteAffiliatedNs(mpa, vc, log)
 	aliyunAKID, aliyunAKSrt, err := mpa.getAliyunAKPair()
 	if err != nil {
 		return err

--- a/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_native.go
+++ b/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_native.go
@@ -73,7 +73,7 @@ func (mpn *MasterProvisionerNative) CreateVirtualCluster(vc *tenancyv1alpha1.Vir
 	rootNS := conversion.ToClusterKey(vc)
 
 	// 1. create the root ns
-	err = kubeutil.CreateNS(mpn, rootNS)
+	err = kubeutil.CreateRootNS(mpn, rootNS, vc.Name, string(vc.UID))
 	if err != nil {
 		return err
 	}
@@ -301,7 +301,7 @@ func (mpn *MasterProvisionerNative) createPKI(vc *tenancyv1alpha1.Virtualcluster
 }
 
 func (mpn *MasterProvisionerNative) DeleteVirtualCluster(vc *tenancyv1alpha1.Virtualcluster) error {
-	return kubeutil.DeleteAffiliatedNs(mpn, vc, log)
+	return nil
 }
 
 func (mpn *MasterProvisionerNative) GetMasterProvisioner() string {

--- a/incubator/virtualcluster/pkg/syncer/conversion/helper.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/helper.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	listersv1 "k8s.io/client-go/listers/core/v1"
@@ -121,7 +122,7 @@ func BuildMetadata(cluster, targetNamespace string, obj runtime.Object) (runtime
 	return target, nil
 }
 
-func BuildSuperMasterNamespace(cluster string, obj runtime.Object) (runtime.Object, error) {
+func BuildSuperMasterNamespace(cluster, vcName, vcUID string, obj runtime.Object) (runtime.Object, error) {
 	target := obj.DeepCopyObject()
 	m, err := meta.Accessor(target)
 	if err != nil {
@@ -141,6 +142,14 @@ func BuildSuperMasterNamespace(cluster string, obj runtime.Object) (runtime.Obje
 
 	targetName := ToSuperMasterNamespace(cluster, m.GetName())
 	m.SetName(targetName)
+	owner := []metav1.OwnerReference{
+		metav1.OwnerReference{
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+			Kind:       "Virtualcluster",
+			Name:       vcName,
+			UID:        types.UID(vcUID),
+		}}
+	m.SetOwnerReferences(owner)
 	return target, nil
 }
 

--- a/incubator/virtualcluster/pkg/syncer/handler/enqueue_object.go
+++ b/incubator/virtualcluster/pkg/syncer/handler/enqueue_object.go
@@ -23,8 +23,8 @@ import (
 )
 
 type EnqueueRequestForObject struct {
-	Cluster *reconciler.ClusterInfo
-	Queue   Queue
+	ClusterName string
+	Queue       Queue
 }
 
 func (e *EnqueueRequestForObject) enqueue(obj interface{}) {
@@ -34,7 +34,7 @@ func (e *EnqueueRequestForObject) enqueue(obj interface{}) {
 	}
 
 	r := reconciler.Request{}
-	r.ClusterName = e.Cluster.Name
+	r.ClusterName = e.ClusterName
 	r.Namespace = o.GetNamespace()
 	r.Name = o.GetName()
 	r.UID = string(o.GetUID())

--- a/incubator/virtualcluster/pkg/syncer/reconciler/reconciler.go
+++ b/incubator/virtualcluster/pkg/syncer/reconciler/reconciler.go
@@ -18,22 +18,9 @@ package reconciler
 
 import (
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/rest"
 
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
-
-type ClusterInfo struct {
-	Name   string
-	Config *rest.Config
-}
-
-func NewClusterInfo(name string, config *rest.Config) *ClusterInfo {
-	return &ClusterInfo{
-		Name:   name,
-		Config: config,
-	}
-}
 
 type EventType string
 

--- a/incubator/virtualcluster/pkg/syncer/resources/namespace/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/namespace/dws.go
@@ -85,7 +85,12 @@ func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, e
 }
 
 func (c *controller) reconcileNamespaceCreate(clusterName, targetNamespace, requestUID string, vNamespace *v1.Namespace) error {
-	newObj, err := conversion.BuildSuperMasterNamespace(clusterName, vNamespace)
+	vcName, vcUID, err := c.multiClusterNamespaceController.GetOwnerInfo(clusterName)
+	if err != nil {
+		return err
+	}
+
+	newObj, err := conversion.BuildSuperMasterNamespace(clusterName, vcName, vcUID, vNamespace)
 	if err != nil {
 		return err
 	}

--- a/incubator/virtualcluster/pkg/syncer/syncer.go
+++ b/incubator/virtualcluster/pkg/syncer/syncer.go
@@ -267,7 +267,7 @@ func (s *Syncer) addCluster(key string, vc *v1alpha1.Virtualcluster) error {
 		return fmt.Errorf("failed to get secret (%s) for virtual cluster in root namespace %s: %v", KubeconfigAdmin, clusterName, err)
 	}
 
-	tenantCluster, err := cluster.NewTenantCluster(clusterName, vc.Namespace, vc.Name, s.lister, adminKubeConfigSecret.Data[KubeconfigAdmin], cluster.Options{})
+	tenantCluster, err := cluster.NewTenantCluster(clusterName, vc.Namespace, vc.Name, string(vc.UID), s.lister, adminKubeConfigSecret.Data[KubeconfigAdmin], cluster.Options{})
 	if err != nil {
 		return fmt.Errorf("failed to new tenant cluster %s/%s: %v", vc.Namespace, vc.Name, err)
 	}


### PR DESCRIPTION
This change adds owner reference to all namespaces that are associated with a virtualcluster object. This greatly simplifies the tenant objects clean up. 

This change also removes reconciler.ClusterInfo struct which is not necessary. 