### PR TITLE
Implement a validation controller for hncconfigurations resource.

### DIFF
--- a/incubator/hnc/cmd/manager/main.go
+++ b/incubator/hnc/cmd/manager/main.go
@@ -159,6 +159,11 @@ func main() {
 			Log:    ctrl.Log.WithName("validators").WithName("Object"),
 			Forest: f,
 		}})
+
+		// Create webhook for the config
+		mgr.GetWebhookServer().Register(validators.ConfigServingPath, &webhook.Admission{Handler: &validators.HNCConfig{
+			Log: ctrl.Log.WithName("validators").WithName("HNCConfig"),
+		}})
 	}
 
 	setupLog.Info("starting manager")

--- a/incubator/hnc/config/webhook/manifests.yaml
+++ b/incubator/hnc/config/webhook/manifests.yaml
@@ -29,6 +29,25 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-hnc-x-k8s-io-v1alpha1-hncconfigurations
+  failurePolicy: Fail
+  name: hncconfigurations.hnc.x-k8s.io
+  rules:
+  - apiGroups:
+    - hnc.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - hncconfigurations
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-objects
   failurePolicy: Ignore
   name: secrets.objects.hnc.x-k8s.io

--- a/incubator/hnc/pkg/validators/hierarchy.go
+++ b/incubator/hnc/pkg/validators/hierarchy.go
@@ -452,6 +452,8 @@ func codeFromReason(reason metav1.StatusReason) int32 {
 		return 409
 	case metav1.StatusReasonBadRequest:
 		return 400
+	case metav1.StatusReasonInvalid:
+		return 422
 	case metav1.StatusReasonInternalError:
 		return 500
 	default:

--- a/incubator/hnc/pkg/validators/hncconfig.go
+++ b/incubator/hnc/pkg/validators/hncconfig.go
@@ -1,0 +1,182 @@
+package validators
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"k8s.io/api/admission/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+)
+
+// ConfigServingPath is where the validator will run. Must be kept in sync with the
+// kubebuilder markers below.
+const (
+	ConfigServingPath = "/validate-hnc-x-k8s-io-v1alpha1-hncconfigurations"
+)
+
+// Note: the validating webhook FAILS CLOSE. This means that if the webhook goes down, all further
+// changes are denied.
+//
+// +kubebuilder:webhook:path=/validate-hnc-x-k8s-io-v1alpha1-hncconfigurations,mutating=false,failurePolicy=fail,groups="hnc.x-k8s.io",resources=hncconfigurations,verbs=create;update;delete,versions=v1alpha1,name=hncconfigurations.hnc.x-k8s.io
+
+type HNCConfig struct {
+	Log       logr.Logger
+	validator gvkValidator
+	decoder   *admission.Decoder
+}
+
+// gvkValidator checks if a resource exists. The check should typically be performed against the apiserver,
+// but need to be stubbed out during unit testing.
+type gvkValidator interface {
+	// Exists takes a GVK, and returns true if the GVK exists in the apiserver.
+	Exists(ctx context.Context, gvk schema.GroupVersionKind) (bool, error)
+}
+
+type gvkSet map[schema.GroupVersionKind]bool
+
+func (c *HNCConfig) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if isHNCServiceAccount(&req.AdmissionRequest.UserInfo) {
+		return allow("HNC SA")
+	}
+
+	if req.Operation == v1beta1.Delete {
+		if req.Name == "config" {
+			return deny(metav1.StatusReasonForbidden, "Deleting the 'config' object is forbidden")
+		} else {
+			// We allow deleting other objects. If the validation controller has always been running, we should not
+			// enter this case because objects of other names cannot be created. If users somehow bypass the
+			// validation controller and create objects of other names, we will allow them to delete the objects.
+			return allow("")
+		}
+	}
+
+	inst := &api.HNCConfiguration{}
+	if err := c.decoder.Decode(req, inst); err != nil {
+		c.Log.Error(err, "Couldn't decode request")
+		return deny(metav1.StatusReasonBadRequest, err.Error())
+	}
+
+	resp := c.handle(ctx, inst)
+	c.Log.Info("Handled", "allowed", resp.Allowed, "code", resp.Result.Code, "reason", resp.Result.Reason, "message", resp.Result.Message)
+	return resp
+}
+
+// handle implements the validation logic of this validator for Create and Update operations,
+// allowing it to be more easily unit tested (ie without constructing a full admission.Request).
+func (c *HNCConfig) handle(ctx context.Context, inst *api.HNCConfiguration) admission.Response {
+	if inst.GetName() != "config" {
+		return deny(metav1.StatusReasonInvalid, fmt.Sprintf("Wrong singleton name: %s; the name should be 'config'", inst.GetName()))
+	}
+
+	roleExist := false
+	roleBindingExist := false
+	ts := gvkSet{}
+	for _, t := range inst.Spec.Types {
+		if rp := c.isTypeConfigured(t, ts); !rp.Allowed {
+			return rp
+		}
+
+		if c.isRBAC(t, "Role") {
+			if rp := c.validateRBAC(t.Mode, "Role"); !rp.Allowed {
+				return rp
+			}
+			roleExist = true
+		} else if c.isRBAC(t, "RoleBinding") {
+			if rp := c.validateRBAC(t.Mode, "RoleBinding"); !rp.Allowed {
+				return rp
+			}
+			roleBindingExist = true
+		} else {
+			if rp := c.validateType(ctx, t, ts); !rp.Allowed {
+				return rp
+			}
+		}
+	}
+	if !roleExist {
+		return deny(metav1.StatusReasonInvalid, "Configuration for Role is missing")
+	}
+	if !roleBindingExist {
+		return deny(metav1.StatusReasonInvalid, "Configuration for RoleBinding is missing")
+	}
+	return allow("")
+}
+
+// Validate if the configuration of a type already exists. Each type should only have one configuration.
+func (c *HNCConfig) isTypeConfigured(t api.TypeSynchronizationSpec, ts gvkSet) admission.Response {
+	gvk := schema.FromAPIVersionAndKind(t.APIVersion, t.Kind)
+	if exists := ts[gvk]; exists {
+		return deny(metav1.StatusReasonInvalid, fmt.Sprintf("Duplicate configurations for %s", gvk))
+	}
+	ts[gvk] = true
+	return allow("")
+}
+
+func (c *HNCConfig) isRBAC(t api.TypeSynchronizationSpec, kind string) bool {
+	return t.APIVersion == "rbac.authorization.k8s.io/v1" && t.Kind == kind
+}
+
+// The mode of Role and RoleBinding should be either unset or set to the propagate mode.
+func (c *HNCConfig) validateRBAC(mode api.SynchronizationMode, kind string) admission.Response {
+	if mode == api.Propagate || mode == "" {
+		return allow("")
+	}
+	return deny(metav1.StatusReasonInvalid, fmt.Sprintf("Invalid mode of %s; current mode: %s; expected mode %s", kind, mode, api.Propagate))
+}
+
+// validateType validates a non-RBAC type.
+func (c *HNCConfig) validateType(ctx context.Context, t api.TypeSynchronizationSpec, ts gvkSet) admission.Response {
+	gvk := schema.FromAPIVersionAndKind(t.APIVersion, t.Kind)
+
+	// Validate if the GVK exists in the apiserver.
+	exists, err := c.validator.Exists(ctx, gvk)
+	if !exists {
+		return deny(metav1.StatusReasonInvalid,
+			fmt.Sprintf("Cannot find the %s in the apiserver with error: %s", gvk, err.Error()))
+	}
+
+	// The mode of a type should be either unset or set to one of the supported modes.
+	if t.Mode != api.Propagate && t.Mode != api.Remove && t.Mode != api.Ignore && t.Mode != "" {
+		return deny(metav1.StatusReasonInvalid, fmt.Sprintf("Unrecognized mode '%s' for %s", t.Mode, gvk))
+	}
+
+	return allow("")
+}
+
+// realGVKValidator implements gvkValidator, and is not used during unit tests.
+type realGVKValidator struct {
+	client client.Client
+}
+
+// Exists validates if a given GVK exists in the apiserver. The method tries to get an object of the
+// GVK from the apiserver. If the error returned from the apiserver is not IsNotFound, we will assume the
+// GVK does not exist.
+func (r *realGVKValidator) Exists(ctx context.Context, gvk schema.GroupVersionKind) (bool, error) {
+	inst := &unstructured.Unstructured{}
+	inst.SetGroupVersionKind(gvk)
+	err := r.client.Get(ctx, types.NamespacedName{Name: "nm"}, inst)
+	// We try to get an object of the given GVK with name "nm". It is possible that the
+	// object does not exist. Therefore, we will ignore the IsNotFound error.
+	if err != nil && !errors.IsNotFound(err) {
+		return false, err
+	}
+	return true, nil
+}
+
+func (c *HNCConfig) InjectClient(cl client.Client) error {
+	c.validator = &realGVKValidator{client: cl}
+	return nil
+}
+
+func (c *HNCConfig) InjectDecoder(d *admission.Decoder) error {
+	c.decoder = d
+	return nil
+}

--- a/incubator/hnc/pkg/validators/hncconfig_test.go
+++ b/incubator/hnc/pkg/validators/hncconfig_test.go
@@ -1,0 +1,239 @@
+package validators
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+	. "github.com/onsi/gomega"
+	"k8s.io/api/admission/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestDeletingConfigObject(t *testing.T) {
+	t.Run("Delete config object", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		req := admission.Request{
+			AdmissionRequest: v1beta1.AdmissionRequest{
+				Operation: v1beta1.Delete,
+				Name:      "config",
+			}}
+		config := &HNCConfig{}
+
+		got := config.Handle(context.Background(), req)
+
+		logResult(t, got.AdmissionResponse.Result)
+		g.Expect(got.AdmissionResponse.Allowed).Should(BeFalse())
+	})
+}
+
+func TestDeletingOtherObject(t *testing.T) {
+	t.Run("Delete config object", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		req := admission.Request{
+			AdmissionRequest: v1beta1.AdmissionRequest{
+				Operation: v1beta1.Delete,
+				Name:      "other",
+			}}
+		config := &HNCConfig{}
+
+		got := config.Handle(context.Background(), req)
+
+		logResult(t, got.AdmissionResponse.Result)
+		g.Expect(got.AdmissionResponse.Allowed).Should(BeTrue())
+	})
+}
+
+func TestInvalidName(t *testing.T) {
+	t.Run("Invalid config name", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		c := &api.HNCConfiguration{Spec: api.HNCConfigurationSpec{Types: []api.TypeSynchronizationSpec{
+			{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
+			{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "propagate"},
+		}}}
+		// Name should be "config"
+		c.Name = "invalid-name"
+		config := &HNCConfig{}
+
+		got := config.handle(context.Background(), c)
+
+		logResult(t, got.AdmissionResponse.Result)
+		g.Expect(got.AdmissionResponse.Allowed).Should(BeFalse())
+	})
+}
+
+func TestRBACTypes(t *testing.T) {
+	config := &HNCConfig{}
+
+	tests := []struct {
+		name    string
+		configs []api.TypeSynchronizationSpec
+		allow   bool
+	}{
+		{
+			name: "Correct RBAC config with propagate mode",
+			configs: []api.TypeSynchronizationSpec{
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "propagate"},
+			},
+			allow: true,
+		},
+		{
+			name: "Correct RBAC config with unset mode",
+			configs: []api.TypeSynchronizationSpec{
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding"},
+			},
+			allow: true,
+		},
+		{
+			name: "Missing Role",
+			configs: []api.TypeSynchronizationSpec{
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "propagate"},
+			},
+			allow: false,
+		}, {
+			name: "Missing RoleBinding",
+			configs: []api.TypeSynchronizationSpec{
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
+			},
+			allow: false,
+		}, {
+			name: "Incorrect Role mode",
+			configs: []api.TypeSynchronizationSpec{
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "ignore"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "propagate"},
+			},
+			allow: false,
+		}, {
+			name: "Incorrect RoleBinding mode",
+			configs: []api.TypeSynchronizationSpec{
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "ignore"},
+			},
+			allow: false,
+		}, {
+			name: "Duplicate RBAC types with different modes",
+			configs: []api.TypeSynchronizationSpec{
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "propagate"},
+			},
+			allow: false,
+		},
+		{
+			name: "Duplicate RBAC types with the same mode",
+			configs: []api.TypeSynchronizationSpec{
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "propagate"},
+			},
+			allow: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			c := &api.HNCConfiguration{Spec: api.HNCConfigurationSpec{Types: tc.configs}}
+			c.Name = "config"
+
+			got := config.handle(context.Background(), c)
+
+			logResult(t, got.AdmissionResponse.Result)
+			g.Expect(got.AdmissionResponse.Allowed).Should(Equal(tc.allow))
+		})
+	}
+}
+
+func TestNonRBACTypes(t *testing.T) {
+	f := fakeGVKValidator{"CronTab"}
+	tests := []struct {
+		name      string
+		configs   []api.TypeSynchronizationSpec
+		validator fakeGVKValidator
+		allow     bool
+	}{
+		{
+			name: "Correct Non-RBAC types config",
+			configs: []api.TypeSynchronizationSpec{
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "propagate"},
+				{APIVersion: "v1", Kind: "Secret", Mode: "ignore"},
+				{APIVersion: "v1", Kind: "ResourceQuota"},
+			},
+			validator: f,
+			allow:     true,
+		},
+		{
+			name: "Resource does not exist",
+			configs: []api.TypeSynchronizationSpec{
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "propagate"},
+				// "CronTab" kind does not exist in "v1"
+				{APIVersion: "v1", Kind: "CronTab", Mode: "ignore"},
+			},
+			validator: f,
+			allow:     false,
+		},
+		{
+			name: "Unrecognized mode",
+			configs: []api.TypeSynchronizationSpec{
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "propagate"},
+				// "delete" mode is unsupported
+				{APIVersion: "v1", Kind: "Secret", Mode: "delete"},
+			},
+			validator: f,
+			allow:     false,
+		}, {
+			name: "Duplicate types with different modes",
+			configs: []api.TypeSynchronizationSpec{
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "propagate"},
+				{APIVersion: "v1", Kind: "Secret", Mode: "ignore"},
+				{APIVersion: "v1", Kind: "Secret", Mode: "propagate"},
+			},
+			validator: f,
+			allow:     false,
+		}, {
+			name: "Duplicate types with the same mode",
+			configs: []api.TypeSynchronizationSpec{
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "propagate"},
+				{APIVersion: "v1", Kind: "Secret", Mode: "ignore"},
+				{APIVersion: "v1", Kind: "Secret", Mode: "ignore"},
+			},
+			validator: f,
+			allow:     false,
+		}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			c := &api.HNCConfiguration{Spec: api.HNCConfigurationSpec{Types: tc.configs}}
+			c.Name = "config"
+			config := &HNCConfig{validator: tc.validator}
+
+			got := config.handle(context.Background(), c)
+
+			logResult(t, got.AdmissionResponse.Result)
+			g.Expect(got.AdmissionResponse.Allowed).Should(Equal(tc.allow))
+		})
+	}
+}
+
+// fakeGVKValidator implements gvkValidator. Any kind that are in the slice are denied; anything else
+// is allowed.
+type fakeGVKValidator []string
+
+func (f fakeGVKValidator) Exists(_ context.Context, gvk schema.GroupVersionKind) (bool, error) {
+	for _, k := range f {
+		if k == gvk.Kind {
+			return false, fmt.Errorf("%s does not exist", gvk)
+		}
+	}
+	return true, nil
+}


### PR DESCRIPTION
This PR implements a validation controller for hncconfigurations resource. 

Specifically, following requests will be denied by the controller:
 - Missing RBAC configuration
 - Non-default RBAC mode
 - At least one type in the configuration does not exist in the cluster
 - Invalid object name (the name should be config)
 - Unrecognizable mode
 - Multiple configurations for the same type
 - Delete `config` object

Tested: unit tests, GKE cluster
Issue: #411