### PR TITLE
Rename ns.RequiredChildOf to ns.Owner in forest

### DIFF
--- a/incubator/hnc/pkg/forest/forest.go
+++ b/incubator/hnc/pkg/forest/forest.go
@@ -154,10 +154,9 @@ type Namespace struct {
 	// on this namespace.
 	conditions conditions
 
-	// TODO rename it to Owner. See issue - https://github.com/kubernetes-sigs/multi-tenancy/issues/469
-	// RequiredChildOf indicates that this namespace is being or was created solely to live as a
+	// Owner indicates that this namespace is being or was created solely to live as a
 	// subnamespace of the specified parent.
-	RequiredChildOf string
+	Owner string
 }
 
 type condition struct {
@@ -271,7 +270,7 @@ func (ns *Namespace) OwnedNames() []string {
 	}
 	nms := []string{}
 	for nm, ns := range ns.forest.namespaces {
-		if ns.RequiredChildOf == ns.name {
+		if ns.Owner == ns.name {
 			nms = append(nms, nm)
 		}
 	}

--- a/incubator/hnc/pkg/reconcilers/hierarchical_namespace.go
+++ b/incubator/hnc/pkg/reconcilers/hierarchical_namespace.go
@@ -135,9 +135,7 @@ func (r *HierarchicalNamespaceReconciler) syncMissing(log logr.Logger, inst *api
 
 	// Set the "Owner" in the forest of the hierarchical namespace to the current namespace.
 	log.Info("Setting the subnamespace's owner in the forest", "owner", pnm, "namespace", nm)
-	// TODO rename RequiredChildOf to Owner in the forest. See issue:
-	//  https://github.com/kubernetes-sigs/multi-tenancy/issues/469
-	ns.RequiredChildOf = pnm
+	ns.Owner = pnm
 
 	// Enqueue the not-yet existent self-serve subnamespace. The HierarchyConfig reconciler will
 	// create the namespace and the HierarchyConfig instances on apiserver accordingly.
@@ -158,7 +156,7 @@ func (r *HierarchicalNamespaceReconciler) syncExisting(log logr.Logger, inst *ap
 		// or a human manually created the namespace with the right annotation but no HC.
 		// Both cases meant to create this namespace as HNS.
 		log.Info("Setting the subnamespace's owner in the forest", "owner", pnm, "namespace", nm)
-		ns.RequiredChildOf = pnm
+		ns.Owner = pnm
 		r.hcr.enqueueAffected(log, "updated subnamespace", nm)
 
 		// We will set it as "Conflict" though it's just a short transient state. Once the hc is

--- a/incubator/hnc/pkg/validators/hierarchy.go
+++ b/incubator/hnc/pkg/validators/hierarchy.go
@@ -169,9 +169,9 @@ func (v *Hierarchy) checkParent(ns, curParent, newParent *forest.Namespace) admi
 		return deny(metav1.StatusReasonConflict, "Illegal parent: "+reason)
 	}
 
-	// Prevent changing parent of a required child
-	if ns.RequiredChildOf != "" && ns.RequiredChildOf != newParent.Name() {
-		reason := fmt.Sprintf("Cannot set the parent of %q to %q because it's a required child of %q", ns.Name(), newParent.Name(), ns.RequiredChildOf)
+	// Prevent changing parent of an owned child
+	if ns.Owner != "" && ns.Owner != newParent.Name() {
+		reason := fmt.Sprintf("Cannot set the parent of %q to %q because it's a self-serve subnamespace of %q", ns.Name(), newParent.Name(), ns.Owner)
 		return deny(metav1.StatusReasonConflict, "Illegal parent: "+reason)
 	}
 
@@ -186,7 +186,7 @@ func (v *Hierarchy) checkRequiredChildren(ns *forest.Namespace, requiredChildren
 			continue
 		}
 		// If this is already a child, or is about to be, no problem.
-		if cns.Parent() == ns || (cns.Parent() == nil && cns.RequiredChildOf == ns.Name()) {
+		if cns.Parent() == ns || (cns.Parent() == nil && cns.Owner == ns.Name()) {
 			continue
 		}
 		reason := fmt.Sprintf("Cannot set %q as the required child of %q because it already exists and is not a child of %q", cns.Name(), ns.Name(), ns.Name())

--- a/incubator/hnc/pkg/validators/hierarchy_test.go
+++ b/incubator/hnc/pkg/validators/hierarchy_test.go
@@ -21,7 +21,7 @@ func TestStructure(t *testing.T) {
 	//     -> fooRC (RequiredChild of foo)
 	foo := createNS(f, "foo", nil)
 	bar := createNS(f, "bar", nil)
-	createRCNS(f, "fooRC", foo)
+	createOwnedNS(f, "fooRC", foo)
 	createNS(f, "baz", nil)
 	bar.SetParent(foo)
 	h := &Hierarchy{Forest: f}
@@ -162,12 +162,12 @@ func createNS(f *forest.Forest, nnm string, ue []string) *forest.Namespace {
 	return ns
 }
 
-// createRCNS creates rc (requiredChild) and sets its parent and requiredChildOf to nm and sets it
+// createOwnedNS creates a namespace and sets its parent and owner to nm and sets it
 // to existing.
-func createRCNS(f *forest.Forest, rc string, p *forest.Namespace) *forest.Namespace {
+func createOwnedNS(f *forest.Forest, rc string, p *forest.Namespace) *forest.Namespace {
 	ns := f.Get(rc)
 	ns.SetParent(p)
-	ns.RequiredChildOf = p.Name()
+	ns.Owner = p.Name()
 	ns.SetExists()
 	return ns
 }


### PR DESCRIPTION
Rename ns.Owner field so that it can be used in the cascading deletion
implementation.
Tested by 'make test' and 'make test HNS=1'
This commit fixes #469. Part of #457 .