### PR TITLE
Change StatusReasonInvalid to StatusReasonForbidden in hncconfig.go

### DIFF
--- a/incubator/hnc/pkg/validators/hncconfig_test.go
+++ b/incubator/hnc/pkg/validators/hncconfig_test.go
@@ -229,11 +229,11 @@ func TestNonRBACTypes(t *testing.T) {
 // is allowed.
 type fakeGVKValidator []string
 
-func (f fakeGVKValidator) Exists(_ context.Context, gvk schema.GroupVersionKind) (bool, error) {
+func (f fakeGVKValidator) Exists(_ context.Context, gvk schema.GroupVersionKind) error {
 	for _, k := range f {
 		if k == gvk.Kind {
-			return false, fmt.Errorf("%s does not exist", gvk)
+			return fmt.Errorf("%s does not exist", gvk)
 		}
 	}
-	return true, nil
+	return nil
 }


### PR DESCRIPTION
Unlike `StatusReasonForbidden`, `StatusReasonInvalid` does not show custom text in terminal when sending an invalid request to the apiserver (see details [here](https://github.com/kubernetes-sigs/multi-tenancy/pull/522#discussion_r395117111)). We will contact the controller-runtime team for trouble shooting. In the meantime, we will use `StatusReasonForbidden` so that users can see detailed reason of denying a request.

This PR also does the following refactoring to address comments in #522 :
 -  Make `Exists` only return an error
 - Change `if` statement to `switch` in the `validateType` method

Issue: #411 