### PR TITLE
[Incubator][VC]Increase the QPS and burst for syncer clients

### DIFF
--- a/incubator/virtualcluster/cmd/syncer/app/options/options.go
+++ b/incubator/virtualcluster/cmd/syncer/app/options/options.go
@@ -224,7 +224,13 @@ func createClients(config componentbaseconfig.ClientConnectionConfiguration, mas
 
 	restConfig.ContentConfig.ContentType = config.AcceptContentTypes
 	restConfig.QPS = config.QPS
+	if restConfig.QPS == 0 {
+		restConfig.QPS = constants.DefaultSyncerClientQPS
+	}
 	restConfig.Burst = int(config.Burst)
+	if restConfig.Burst == 0 {
+		restConfig.Burst = constants.DefaultSyncerClientBurst
+	}
 
 	superMasterClient, err := clientset.NewForConfig(restclient.AddUserAgent(restConfig, constants.ResourceSyncerUserAgent))
 	if err != nil {

--- a/incubator/virtualcluster/pkg/syncer/cluster/cluster.go
+++ b/incubator/virtualcluster/pkg/syncer/cluster/cluster.go
@@ -105,6 +105,12 @@ var _ mccontroller.ClusterInterface = &Cluster{}
 // New creates a new Cluster.
 func NewTenantCluster(key, namespace, name, uid string, vclister vclisters.VirtualclusterLister, configBytes []byte, o Options) (*Cluster, error) {
 	clusterRestConfig, err := clientcmd.RESTConfigFromKubeConfig(configBytes)
+	if clusterRestConfig.QPS == 0 {
+		clusterRestConfig.QPS = constants.DefaultSyncerClientQPS
+	}
+	if clusterRestConfig.Burst == 0 {
+		clusterRestConfig.Burst = constants.DefaultSyncerClientBurst
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to build rest config: %v", err)
 	}

--- a/incubator/virtualcluster/pkg/syncer/constants/constants.go
+++ b/incubator/virtualcluster/pkg/syncer/constants/constants.go
@@ -71,6 +71,10 @@ const (
 	MaxUwsRetryAttempts = 16
 
 	DefaultOpaqueMetaPrefix = "tenancy.x-k8s.io"
+
+	// Override the client-go default 5 qps and 10 burst, which are too samll for syncer.
+	DefaultSyncerClientQPS   = 1000
+	DefaultSyncerClientBurst = 2000
 )
 
 const (


### PR DESCRIPTION
The default client-go qps and burst is 5 and 10, which is way too small for syncer. 
Since tenant master has its own rate limit control, we enlarge the syncer client qps and burst default to 1000 and 2000. Even if syncer client hits "too many requests" error, the failed reconciling will be retried later.