### PR TITLE
Handle multiple configurations of the same type in ConfigReconciler

### DIFF
--- a/incubator/hnc/api/v1alpha1/hnc_config.go
+++ b/incubator/hnc/api/v1alpha1/hnc_config.go
@@ -45,8 +45,9 @@ const (
 // HNCConfigurationCondition codes. *All* codes must also be documented in the
 // comment to HNCConfigurationCondition.Code.
 const (
-	CritSingletonNameInvalid       HNCConfigurationCode = "critSingletonNameInvalid"
-	ObjectReconcilerCreationFailed HNCConfigurationCode = "objectReconcilerCreationFailed"
+	CritSingletonNameInvalid         HNCConfigurationCode = "critSingletonNameInvalid"
+	ObjectReconcilerCreationFailed   HNCConfigurationCode = "objectReconcilerCreationFailed"
+	MultipleConfigurationsForOneType HNCConfigurationCode = "multipleConfigurationsForOneType"
 )
 
 // TypeSynchronizationSpec defines the desired synchronization state of a specific kind.
@@ -133,6 +134,9 @@ type HNCConfigurationCondition struct {
 	//
 	// - "objectReconcilerCreationFailed": an error exists when creating the object
 	// reconciler for the type specified in Msg.
+	//
+	// - "multipleConfigurationsForOneType": Multiple configurations exist for the type specified
+	// in the Msg. One type should only have one configuration.
 	Code HNCConfigurationCode `json:"code"`
 
 	// A human-readable description of the condition, if the `code` field is not

--- a/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
+++ b/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
@@ -80,7 +80,9 @@ spec:
                       the specified singleton name is invalid. The name should be
                       the same as HNCConfigSingleton. \n - \"objectReconcilerCreationFailed\":
                       an error exists when creating the object reconciler for the
-                      type specified in Msg."
+                      type specified in Msg. \n - \"multipleConfigurationsForOneType\":
+                      Multiple configurations exist for the type specified in the
+                      Msg. One type should only have one configuration."
                     type: string
                   msg:
                     description: A human-readable description of the condition, if


### PR DESCRIPTION
This PR handles multiple configurations of the same type in ConfigReconciler. If there are multiple configurations for the same type, only the first configuration will be followed, the rest will be ignored.

Tested:unit tests, GKE cluster

Issue: #411 