### PR TITLE
Corrects the kubeconfig in Benchmarks Readme

### DIFF
--- a/benchmarks/e2e/tests/block_multitenant_resources/README.md
+++ b/benchmarks/e2e/tests/block_multitenant_resources/README.md
@@ -28,7 +28,7 @@ The resources managed by the cluster administrator and that cannot be modified b
 	
 Run the following commands to retrieve the list of resources managed by the cluster administrator
 
-  	kubectl --kubeconfig=tenant-a -n a1 get all -l <key>=<value>
+  	kubectl --kubeconfig=cluster-admin -n a1 get all -l <key>=<value>
 
 For each returned by the first command verify that the resource cannot be modified by the tenant administrator:
 	

--- a/benchmarks/e2e/tests/block_other_tenant_resources/README.md
+++ b/benchmarks/e2e/tests/block_other_tenant_resources/README.md
@@ -24,7 +24,7 @@ Tenant resources should be isolated from other tenants.
 
 Run the following commands to retrieve the list of namespaced resources available in Tenant B
 
-  	kubectl --kubeconfig cluster-admin api-resources --namespaced=true
+  	kubectl --kubeconfig tenant-b api-resources --namespaced=true
 
 For each namespaced resource, and each verb (get, list, create, update, patch, watch, delete, and deletecollection) issue the following command
 	

--- a/benchmarks/e2e/tests/require_run_as_non_root/README.md
+++ b/benchmarks/e2e/tests/require_run_as_non_root/README.md
@@ -18,7 +18,7 @@ Linux
 
 **Rationale:**
 
-Pprocesses in containers run as the root user (uid 0), by default. To prevent potential compromise of container hosts, specify a least privileged user ID when building the container image and require that application containers run as non root users.
+Processes in containers run as the root user (uid 0), by default. To prevent potential compromise of container hosts, specify a least privileged user ID when building the container image and require that application containers run as non root users.
 
 **Audit:**
 


### PR DESCRIPTION
This pull request updates the readme to use the correct kubeconfig for the cluster administrator to avoid confusion.