### PR TITLE
Enables benchmark test to be run in go1.13

### DIFF
--- a/benchmarks/e2e/tests/e2e.go
+++ b/benchmarks/e2e/tests/e2e.go
@@ -14,6 +14,11 @@ import (
 	_ "github.com/realshuting/multi-tenancy/benchmarks/e2e/tests/configure_ns_quotas"
 )
 
+var _ = func() bool {
+	testing.Init()
+	return true
+}()
+
 // RunE2ETests runs the multi-tenancy benchmark tests
 func RunE2ETests(t *testing.T) {
 	logs.InitLogs()


### PR DESCRIPTION
Running the benchmark test in Go version 1.13 produces an error. An issue was filed for it in the Go repository [here](https://github.com/golang/go/issues/31859). I have added the workaround for this so that the test runs in Go 1.13