### PR TITLE
Implement cascading delete for self-serve namespaces

### DIFF
--- a/incubator/hnc/api/v1alpha1/hierarchical_namespace.go
+++ b/incubator/hnc/api/v1alpha1/hierarchical_namespace.go
@@ -21,8 +21,10 @@ import (
 
 // Constants for the hierarchicalnamespaces resource type and namespace annotation.
 const (
-	HierarchicalNamespaces = "hierarchicalnamespaces"
-	AnnotationOwner        = MetaGroup + "/owner"
+	HierarchicalNamespaces           = "hierarchicalnamespaces"
+	HierarchicalNamespacesKind       = "HierarchicalNamespace"
+	HierarchicalNamespacesAPIVersion = MetaGroup + "/v1alpha1"
+	AnnotationOwner                  = MetaGroup + "/owner"
 )
 
 // HNSState describes the state of a hierarchical namespace. The state could be

--- a/incubator/hnc/api/v1alpha1/hierarchy_types.go
+++ b/incubator/hnc/api/v1alpha1/hierarchy_types.go
@@ -39,6 +39,7 @@ const (
 	CritParentInvalid    Code = "CRIT_PARENT_INVALID"
 	CritAncestor         Code = "CRIT_ANCESTOR"
 	SubnamespaceConflict Code = "SUBNAMESPACE_CONFLICT"
+	HNSMissing           Code = "HNS_MISSING"
 	CannotUpdate         Code = "CANNOT_UPDATE_OBJECT"
 	CannotPropagate      Code = "CANNOT_PROPAGATE_OBJECT"
 )


### PR DESCRIPTION
This allows cascading deletion on an HNS or an owner namespace based on
if an owner or the namespace has spec.allowCascadingDelete field set to
true. If not, the owned namespace will have HNS_MISSING condition.

Additional fields are added to the forest to indicate if the namespace
is being deleted and if it allows cascading delete. Finalizers are added
to all HC and HNS instances, which will only be removed if the cascading
deletion is finished from that point.

The creation/deletion of namespaces are handled by HC Reconciler.

Manually tested on GKE cluster with three levels of owned namespaces and
unowned namespaces. Owned namespaces are created using 'k hns create2'
and the allowCascadingDelete is toggled by 'k hns set <ns>
--allowCascadingDelete='. The owned namespaces were cascading deleted
when allowCascadingDelete is set. Otherwise, they got HNS_MISSING
condition.

Part of #457 