### PR TITLE
Renames github.com/realshuting to sigs.k8s.io for uniformity

### DIFF
--- a/benchmarks/e2e/tests/block_cluster_resources/block_cluster_resources.go
+++ b/benchmarks/e2e/tests/block_cluster_resources/block_cluster_resources.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo"
-	configutil "github.com/realshuting/multi-tenancy/benchmarks/e2e/config"
+	configutil "sigs.k8s.io/multi-tenancy/benchmarks/e2e/config"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 

--- a/benchmarks/e2e/tests/configure_ns_quotas/configure_ns_quotas.go
+++ b/benchmarks/e2e/tests/configure_ns_quotas/configure_ns_quotas.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 
 	"github.com/onsi/ginkgo"
-	configutil "github.com/realshuting/multi-tenancy/benchmarks/e2e/config"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
+	configutil "sigs.k8s.io/multi-tenancy/benchmarks/e2e/config"
 )
 
 const (

--- a/benchmarks/e2e/tests/e2e.go
+++ b/benchmarks/e2e/tests/e2e.go
@@ -9,8 +9,8 @@ import (
 	ginkgowrapper "k8s.io/kubernetes/test/e2e/framework/ginkgowrapper"
 
 	// test sources
-	_ "github.com/realshuting/multi-tenancy/benchmarks/e2e/tests/block_cluster_resources"
-	_ "github.com/realshuting/multi-tenancy/benchmarks/e2e/tests/configure_ns_quotas"
+	_ "sigs.k8s.io/multi-tenancy/benchmarks/e2e/tests/block_cluster_resources"
+	_ "sigs.k8s.io/multi-tenancy/benchmarks/e2e/tests/configure_ns_quotas"
 )
 
 // RunE2ETests runs the multi-tenancy benchmark tests

--- a/benchmarks/go.mod
+++ b/benchmarks/go.mod
@@ -1,4 +1,4 @@
-module github.com/realshuting/multi-tenancy/benchmarks
+module sigs.k8s.io/multi-tenancy/benchmarks
 
 go 1.12
 


### PR DESCRIPTION
This pull request renames the go.mod to "sigs.k8s.io/multitenancy" and also updates the imports in different files