### PR TITLE
[Incubator][VC] allow vn-agent to forward request to super master if kubelet-client-crt is not available

### DIFF
--- a/incubator/virtualcluster/README.md
+++ b/incubator/virtualcluster/README.md
@@ -66,6 +66,10 @@ cp ~/.minikube/client.crt ~/.minikube/client.key .
 # create secret
 kubectl create secret generic vc-kubelet-client --from-file=./client.crt --from-file=./client.key --namespace vc-manager
 ```
+If the client certificates are not available, vn-agent will first forward 
+the request to the super master, and then the super master will send the request to
+the corresponding kubelet. To enable this, we comment out lines after 
+"- --cert-dir=/etc/vn-agent/" the all_in_one.yaml
 <br />
 <br />
 

--- a/incubator/virtualcluster/cmd/vn-agent/app/options/options.go
+++ b/incubator/virtualcluster/cmd/vn-agent/app/options/options.go
@@ -78,13 +78,16 @@ func (o *Options) Flags() cliflag.NamedFlagSets {
 
 // Config is the config to create a vn-agent server handler.
 func (o *Options) Config() (*config.Config, *ServerOption, error) {
-	kubeletClientCertPair, err := tls.LoadX509KeyPair(o.KubeletOption.CertFile, o.KubeletOption.KeyFile)
-	if err != nil {
-		return nil, nil, errors.Wrapf(err, "failed to load kubelet tls config")
+	if o.KubeletOption.CertFile != "" && o.KubeletOption.KeyFile != "" {
+		kubeletClientCertPair, err := tls.LoadX509KeyPair(o.KubeletOption.CertFile, o.KubeletOption.KeyFile)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "failed to load kubelet tls config")
+		}
+		return &config.Config{
+			KubeletClientCert: &kubeletClientCertPair,
+			KubeletServerHost: fmt.Sprintf("https://127.0.0.1:%v", o.KubeletOption.Port),
+		}, &o.ServerOption, nil
 	}
 
-	return &config.Config{
-		KubeletClientCert: kubeletClientCertPair,
-		KubeletServerHost: fmt.Sprintf("https://127.0.0.1:%v", o.KubeletOption.Port),
-	}, &o.ServerOption, nil
+	return &config.Config{KubeletClientCert: nil}, &o.ServerOption, nil
 }

--- a/incubator/virtualcluster/config/setup/all_in_one.yaml
+++ b/incubator/virtualcluster/config/setup/all_in_one.yaml
@@ -259,6 +259,43 @@ spec:
           imagePullPolicy: Always
           name: vc-syncer
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: vn-agent-role
+rules:
+- apiGroups: 
+  - ""
+  resources: 
+  - pods
+  - pods/log
+  - pods/exec
+  - pods/portforward
+  verbs:
+  - get
+  - list
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vn-agent-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vn-agent-role
+subjects:
+- kind: ServiceAccount
+  name: vn-agent
+  namespace: vc-manager
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vn-agent
+  namespace: vc-manager
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -276,6 +313,7 @@ spec:
       labels:
         app: vn-agent
     spec:
+      serviceAccountName: vn-agent
       hostNetwork: true
       containers:
         - command:

--- a/incubator/virtualcluster/config/setup/all_in_one_aliyun.yaml
+++ b/incubator/virtualcluster/config/setup/all_in_one_aliyun.yaml
@@ -260,6 +260,43 @@ spec:
           imagePullPolicy: Always
           name: vc-syncer
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: vn-agent-role
+rules:
+- apiGroups: 
+  - ""
+  resources: 
+  - pods
+  - pods/log
+  - pods/exec
+  - pods/portforward
+  verbs:
+  - get
+  - list
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vn-agent-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vn-agent-role
+subjects:
+- kind: ServiceAccount
+  name: vn-agent
+  namespace: vc-manager
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vn-agent
+  namespace: vc-manager
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -277,20 +314,13 @@ spec:
       labels:
         app: vn-agent
     spec:
+      serviceAccountName: vn-agent 
       hostNetwork: true
       containers:
-        - command:
+        - name: vn-agent 
+          command:
           - vn-agent
+          args:
           - --cert-dir=/etc/vn-agent/
-          - --kubelet-client-certificate=/etc/vn-agent/pki/client.crt
-          - --kubelet-client-key=/etc/vn-agent/pki/client.key
           image: registry.cn-hangzhou.aliyuncs.com/virtualcluster/vn-agent-amd64
           imagePullPolicy: Always
-          name: vn-agent
-          volumeMounts:
-          - name: kubelet-client-cert
-            mountPath: /etc/vn-agent/pki/
-      volumes:
-      - name: kubelet-client-cert
-        secret:
-          secretName: vc-kubelet-client

--- a/incubator/virtualcluster/pkg/controller/util/kube/util.go
+++ b/incubator/virtualcluster/pkg/controller/util/kube/util.go
@@ -81,6 +81,7 @@ func WaitStatefulSetReady(cli client.Client, namespace, name string, timeOutSec,
 			}, sts); err != nil {
 				return err
 			}
+
 			if sts.Status.ReadyReplicas == *sts.Spec.Replicas {
 				return nil
 			}

--- a/incubator/virtualcluster/pkg/vn-agent/config/config.go
+++ b/incubator/virtualcluster/pkg/vn-agent/config/config.go
@@ -30,6 +30,6 @@ type TLSOptions struct {
 
 // Config holds the config of the server.
 type Config struct {
-	KubeletClientCert tls.Certificate
+	KubeletClientCert *tls.Certificate
 	KubeletServerHost string
 }

--- a/incubator/virtualcluster/pkg/vn-agent/server/server_test.go
+++ b/incubator/virtualcluster/pkg/vn-agent/server/server_test.go
@@ -120,7 +120,7 @@ func newServerTestWithDebug(enableDebugging, redirectContainerStreaming bool, st
 	}
 
 	server, err := NewServer(&config.Config{
-		KubeletClientCert: kubeletClientCert,
+		KubeletClientCert: &kubeletClientCert,
 		KubeletServerHost: fv.kubeletServer.testHTTPServer.URL,
 	})
 	if err != nil {


### PR DESCRIPTION
1. translate the  url for super master
2. parse `URL.Rawquery` for streaming connection
3. create serviceaccount `vn-agent` to access pod and related subresources (log, exec, portforward) 
4. use the bearer token of the vn-agent's serviceaccount to connect to super master
