### PR TITLE
[MTB] Adds block_ns_quota test

### DIFF
--- a/benchmarks/e2e/config/config.go
+++ b/benchmarks/e2e/config/config.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 )
 
-const ConfigPath = "./config.yaml"
+const ConfigPath = "../../config.yaml"
 
 type BenchmarkConfig struct {
 	Adminkubeconfig string     `yaml:"adminKubeconfig"`

--- a/benchmarks/e2e/tests/block_ns_quotas/block_ns_quota.go
+++ b/benchmarks/e2e/tests/block_ns_quotas/block_ns_quota.go
@@ -1,0 +1,44 @@
+package block_ns_quotas
+
+import (
+	"fmt"
+	"github.com/onsi/ginkgo"
+	configutil "github.com/realshuting/multi-tenancy/benchmarks/e2e/config"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"os"
+	"time"
+)
+
+const (
+	expectedVal = "no"
+)
+
+var _ = framework.KubeDescribe("test tenant permission", func() {
+	var config *configutil.BenchmarkConfig
+	var tenantA configutil.TenantSpec
+	var user string
+	var err error
+
+	ginkgo.BeforeEach(func() {
+		config, err = configutil.ReadConfig(configutil.ConfigPath)
+		framework.ExpectNoError(err)
+
+		tenantA = config.GetValidTenant()
+		os.Setenv("KUBECONFIG", tenantA.Kubeconfig)
+		user = configutil.GetContextFromKubeconfig(tenantA.Kubeconfig)
+	})
+
+	ginkgo.It("delete resource quota", func() {
+		ginkgo.By(fmt.Sprintf("tenant %s cannot delete resource quota", user))
+		nsFlag := fmt.Sprintf("--namespace=%s", tenantA.Namespace)
+		verbs := []string{"get", "update", "patch", "delete", "deletecollection"}
+		for _, verb := range verbs {
+			_, errNew := framework.LookForString(expectedVal, time.Minute, func() string {
+				_, err := framework.RunKubectl("auth","can-i", verb, "quota", nsFlag)
+				return err.Error()
+			})
+
+			framework.ExpectNoError(errNew)
+		}
+	})
+})

--- a/benchmarks/e2e/tests/e2e.go
+++ b/benchmarks/e2e/tests/e2e.go
@@ -10,6 +10,7 @@ import (
 
 	// test sources
 	_ "github.com/realshuting/multi-tenancy/benchmarks/e2e/tests/block_cluster_resources"
+	_ "github.com/realshuting/multi-tenancy/benchmarks/e2e/tests/block_ns_quotas"
 	_ "github.com/realshuting/multi-tenancy/benchmarks/e2e/tests/configure_ns_quotas"
 )
 


### PR DESCRIPTION
This adds test for [Block modification of resource quotas](https://github.com/kubernetes-sigs/multi-tenancy/blob/master/benchmarks/e2e/tests/block_ns_quotas/README.md). Fixes #258 