### PR TITLE
Adds block_host_ipc test

### DIFF
--- a/benchmarks/e2e/tests/block_host_ipc/block_host_ipc.go
+++ b/benchmarks/e2e/tests/block_host_ipc/block_host_ipc.go
@@ -1,0 +1,42 @@
+package test
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/onsi/ginkgo"
+	configutil "sigs.k8s.io/multi-tenancy/benchmarks/e2e/config"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+)
+
+const (
+	expectedVal = "Host IPC is not allowed to be used"
+)
+
+var _ = framework.KubeDescribe("Tenants should not be allowed to share the HostIPC namespace.", func() {
+	var config *configutil.BenchmarkConfig
+	var tenantA configutil.TenantSpec
+	var user string
+	var err error
+
+	ginkgo.BeforeEach(func() {
+		config, err = configutil.ReadConfig(configutil.ConfigPath)
+		framework.ExpectNoError(err)
+
+		tenantA, err = config.GetValidTenant()
+		framework.ExpectNoError(err)
+		user = configutil.GetContextFromKubeconfig(tenantA.Kubeconfig)
+	})
+
+	ginkgo.It("validate tenants can't share HostIPC", func() {
+		ginkgo.By(fmt.Sprintf("tenant ${user} cannot create pod with HostIPC set to true", user))
+		kclient := configutil.NewKubeClientWithKubeconfig(tenantA.Kubeconfig)
+		// HostIPC set to true so that pod creation would fail
+		pod := e2epod.MakeSecPod(tenantA.Namespace, nil, nil, false, "", true, false, nil, nil)
+		_, err = kclient.CoreV1().Pods(tenantA.Namespace).Create(pod)
+		if !strings.Contains(err.Error(),expectedVal) {
+			framework.Failf("%s must be unable to create pod with HostIPC set to true", user)
+		}
+	})
+})

--- a/benchmarks/e2e/tests/e2e.go
+++ b/benchmarks/e2e/tests/e2e.go
@@ -17,6 +17,8 @@ import (
 	_ "sigs.k8s.io/multi-tenancy/benchmarks/e2e/tests/block_privileged_containers"
 	_ "sigs.k8s.io/multi-tenancy/benchmarks/e2e/tests/configure_ns_quotas"
 	_ "sigs.k8s.io/multi-tenancy/benchmarks/e2e/tests/create_role_bindings"
+    _ "sigs.k8s.io/multi-tenancy/benchmarks/e2e/tests/block_other_tenant_resources"
+	_ "sigs.k8s.io/multi-tenancy/benchmarks/e2e/tests/block_host_ipc"
 )
 
 // RunE2ETests runs the multi-tenancy benchmark tests


### PR DESCRIPTION
This PR fixes #408. It adds the test for[https://github.com/kubernetes-sigs/multi-tenancy/blob/master/benchmarks/e2e/tests/block_host_ipc/README.md](https://github.com/kubernetes-sigs/multi-tenancy/blob/master/benchmarks/e2e/tests/block_host_ipc/README.md)