### PR TITLE
Adds .gitignore file

### DIFF
--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,0 +1,1 @@
+tests.test


### PR DESCRIPTION
This test adds a .gitignore file to prevent adding the tests.test file that is generated when running the benchmark test