### PR TITLE
Adds block_host_pid test

### DIFF
--- a/benchmarks/e2e/tests/block_host_pid/block_host_pid.go
+++ b/benchmarks/e2e/tests/block_host_pid/block_host_pid.go
@@ -24,7 +24,8 @@ var _ = framework.KubeDescribe("Tenants should not be allowed to share the host 
 		config, err = configutil.ReadConfig(configutil.ConfigPath)
 		framework.ExpectNoError(err)
 
-		tenantA = config.GetValidTenant()
+		tenantA, err = config.GetValidTenant()
+		framework.ExpectNoError(err)
 		user = configutil.GetContextFromKubeconfig(tenantA.Kubeconfig)
 	})
 

--- a/benchmarks/e2e/tests/block_host_pid/block_host_pid.go
+++ b/benchmarks/e2e/tests/block_host_pid/block_host_pid.go
@@ -1,0 +1,41 @@
+package tenantaccess
+
+import (
+"fmt"
+"strings"
+
+"github.com/onsi/ginkgo"
+configutil "sigs.k8s.io/multi-tenancy/benchmarks/e2e/config"
+"k8s.io/kubernetes/test/e2e/framework"
+e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+)
+
+const (
+	expectedVal = "Host PID is not allowed to be used"
+)
+
+var _ = framework.KubeDescribe("Tenants should not be allowed to share the host process ID (PID) namespace", func() {
+	var config *configutil.BenchmarkConfig
+	var tenantA configutil.TenantSpec
+	var user string
+	var err error
+
+	ginkgo.BeforeEach(func() {
+		config, err = configutil.ReadConfig(configutil.ConfigPath)
+		framework.ExpectNoError(err)
+
+		tenantA = config.GetValidTenant()
+		user = configutil.GetContextFromKubeconfig(tenantA.Kubeconfig)
+	})
+
+	ginkgo.It("validate tenants can't share HostPID namespace", func() {
+		ginkgo.By(fmt.Sprintf("tenant ${user} cannot create pod with PID set to true", user))
+		kclient := configutil.NewKubeClientWithKubeconfig(tenantA.Kubeconfig)
+		// HostPID set to true so that pod creation would fail
+		pod := e2epod.MakeSecPod(tenantA.Namespace, nil, nil, false, "", false, true, nil, nil)
+		_, err = kclient.CoreV1().Pods(tenantA.Namespace).Create(pod)
+		if !strings.Contains(err.Error(),expectedVal) {
+			framework.Failf("%s must be unable to create pod with HostPID set to true", user)
+		}
+	})
+})

--- a/benchmarks/e2e/tests/e2e.go
+++ b/benchmarks/e2e/tests/e2e.go
@@ -13,6 +13,7 @@ import (
 	_ "sigs.k8s.io/multi-tenancy/benchmarks/e2e/tests/block_cluster_resources"
 	_ "sigs.k8s.io/multi-tenancy/benchmarks/e2e/tests/configure_ns_quotas"
 	_ "sigs.k8s.io/multi-tenancy/benchmarks/e2e/tests/block_privileged_containers"
+	_ "sigs.k8s.io/multi-tenancy/benchmarks/e2e/tests/block_host_pid"
 )
 
 // RunE2ETests runs the multi-tenancy benchmark tests


### PR DESCRIPTION
Fixes #407. It adds the test for [https://github.com/kubernetes-sigs/multi-tenancy/blob/master/benchmarks/e2e/tests/block_host_pid/README.md](https://github.com/kubernetes-sigs/multi-tenancy/blob/master/benchmarks/e2e/tests/block_host_pid/README.md)