### PR TITLE
[Incubator][VC]Delete vPod if pPod is evicted

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/resources/pod/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/checker.go
@@ -219,6 +219,21 @@ func (c *controller) checkPods() {
 	metrics.CheckerMissMatchStats.WithLabelValues("numUWMetaMissMatchedPods").Set(float64(numUWMetaMissMatchedPods))
 }
 
+func (c *controller) forceDeletevPod(clusterName string, vPod *v1.Pod) {
+	client, err := c.multiClusterPodController.GetClusterClient(clusterName)
+	if err != nil {
+		klog.Errorf("error getting cluster %s clientset: %v", clusterName, err)
+	} else {
+		deleteOptions := metav1.NewDeleteOptions(0)
+		deleteOptions.Preconditions = metav1.NewUIDPreconditions(string(vPod.UID))
+		if err = client.CoreV1().Pods(vPod.Namespace).Delete(vPod.Name, deleteOptions); err != nil {
+			klog.Errorf("error deleting pod %v/%v in cluster %s: %v", vPod.Namespace, vPod.Name, clusterName, err)
+		} else if vPod.Spec.NodeName != "" {
+			c.updateClusterVNodePodMap(clusterName, vPod.Spec.NodeName, string(vPod.UID), reconciler.DeleteEvent)
+		}
+	}
+}
+
 // checkPodsOfTenantCluster checks to see if pods in specific cluster keeps consistency.
 func (c *controller) checkPodsOfTenantCluster(clusterName string) {
 	listObj, err := c.multiClusterPodController.List(clusterName)
@@ -238,25 +253,21 @@ func (c *controller) checkPodsOfTenantCluster(clusterName string) {
 		if errors.IsNotFound(err) {
 			// pPod not found and vPod is under deletion, we need to delete vPod manually
 			if vPod.DeletionTimestamp != nil {
-				client, err := c.multiClusterPodController.GetClusterClient(clusterName)
-				if err != nil {
-					klog.Errorf("error getting cluster %s clientset: %v", clusterName, err)
-					continue
-				}
 				// since pPod not found in super master, we can force delete vPod
-				deleteOptions := metav1.NewDeleteOptions(0)
-				deleteOptions.Preconditions = metav1.NewUIDPreconditions(string(vPod.UID))
-				if err = client.CoreV1().Pods(vPod.Namespace).Delete(vPod.Name, deleteOptions); err != nil {
-					klog.Errorf("error deleting pod %v/%v in cluster %s: %v", vPod.Namespace, vPod.Name, clusterName, err)
-				} else if vPod.Spec.NodeName != "" && isPodScheduled(&vPod) {
-					c.updateClusterVNodePodMap(clusterName, vPod.Spec.NodeName, string(vPod.UID), reconciler.DeleteEvent)
-				}
+				c.forceDeletevPod(clusterName, &vPod)
 			} else {
-				// pPod not found and vPod still exists, we need to create pPod again
-				if err := c.multiClusterPodController.RequeueObject(clusterName, &podList.Items[i]); err != nil {
-					klog.Errorf("error requeue vpod %v/%v in cluster %s: %v", vPod.Namespace, vPod.Name, clusterName, err)
+				// pPod not found and vPod still exists, the pPod may be deleted manually or by controller pod eviction.
+				// If the vPod has not been bound yet, we can create pPod again.
+				// If the vPod has been bound, we'd better delete the vPod since the new pPod may have a different nodename.
+				if isPodScheduled(&vPod) {
+					c.forceDeletevPod(clusterName, &vPod)
+					metrics.CheckerRemedyStats.WithLabelValues("numDeletedTenantPodsDueToSuperEviction").Inc()
 				} else {
-					metrics.CheckerRemedyStats.WithLabelValues("numRequeuedTenantPods").Inc()
+					if err := c.multiClusterPodController.RequeueObject(clusterName, &podList.Items[i]); err != nil {
+						klog.Errorf("error requeue vpod %v/%v in cluster %s: %v", vPod.Namespace, vPod.Name, clusterName, err)
+					} else {
+						metrics.CheckerRemedyStats.WithLabelValues("numRequeuedTenantPods").Inc()
+					}
 				}
 			}
 			continue
@@ -270,7 +281,16 @@ func (c *controller) checkPodsOfTenantCluster(clusterName string) {
 			klog.Errorf("Found pPod %s/%s delegated UID is different from tenant object.", targetNamespace, pPod.Name)
 			continue
 		}
-
+		if pPod.Spec.NodeName != vPod.Spec.NodeName {
+			// If pPod can be deleted arbitrarily, e.g., evicted by node controller, this inconsistency may happen.
+			// For example, if pPod is deleted just before uws tries to bind the vPod and dws gets a request from checker or
+			// user update at the same time, a new pPod is going to be created potentially in a differnt node.
+			// However, uws bound vPod to a wrong node already. There is no easy remediation besides deleting tenant pod.
+			c.forceDeletevPod(clusterName, &vPod)
+			klog.Errorf("Found pPod %s/%s nodename is different from tenant pod nodename, delete the vPod.", targetNamespace, pPod.Name)
+			metrics.CheckerRemedyStats.WithLabelValues("numDeletedTenantPodsDueToNodeMissMatch").Inc()
+			continue
+		}
 		spec, err := c.multiClusterPodController.GetSpec(clusterName)
 		if err != nil {
 			klog.Errorf("fail to get cluster spec : %s", clusterName)

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/checker.go
@@ -281,7 +281,7 @@ func (c *controller) checkPodsOfTenantCluster(clusterName string) {
 			klog.Errorf("Found pPod %s/%s delegated UID is different from tenant object.", targetNamespace, pPod.Name)
 			continue
 		}
-		if pPod.Spec.NodeName != vPod.Spec.NodeName {
+		if pPod.Spec.NodeName != "" && vPod.Spec.NodeName != "" && pPod.Spec.NodeName != vPod.Spec.NodeName {
 			// If pPod can be deleted arbitrarily, e.g., evicted by node controller, this inconsistency may happen.
 			// For example, if pPod is deleted just before uws tries to bind the vPod and dws gets a request from checker or
 			// user update at the same time, a new pPod is going to be created potentially in a differnt node.

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/dws.go
@@ -79,7 +79,7 @@ func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, e
 			klog.Errorf("failed reconcile Pod %s/%s DELETE of cluster %s %v", request.Namespace, request.Name, request.ClusterName, err)
 			return reconciler.Result{Requeue: true}, err
 		}
-		if pPod.Spec.NodeName != "" && isPodScheduled(pPod) {
+		if pPod.Spec.NodeName != "" {
 			c.updateClusterVNodePodMap(request.ClusterName, pPod.Spec.NodeName, request.UID, reconciler.DeleteEvent)
 		}
 	} else if vExists && pExists {
@@ -91,7 +91,7 @@ func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, e
 			klog.Errorf("failed reconcile Pod %s/%s UPDATE of cluster %s %v", request.Namespace, request.Name, request.ClusterName, err)
 			return reconciler.Result{Requeue: true}, err
 		}
-		if vPod.Spec.NodeName != "" && isPodScheduled(vPod) {
+		if vPod.Spec.NodeName != "" {
 			c.updateClusterVNodePodMap(request.ClusterName, vPod.Spec.NodeName, request.UID, reconciler.UpdateEvent)
 		}
 	} else {
@@ -131,7 +131,7 @@ func (c *controller) reconcilePodCreate(clusterName, targetNamespace, requestUID
 		return nil
 	}
 
-	if vPod.Spec.NodeName != "" && !isPodScheduled(vPod) {
+	if vPod.Spec.NodeName != "" {
 		// For now, we skip vPod that has NodeName set to prevent tenant from deploying DaemonSet or DaemonSet alike CRDs.
 		tenantClient, err := c.multiClusterPodController.GetClusterClient(clusterName)
 		if err != nil {

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
@@ -236,7 +236,7 @@ func (c *controller) backPopulate(key string) error {
 			if err = tenantClient.CoreV1().Pods(vPod.Namespace).Delete(vPod.Name, deleteOptions); err != nil {
 				return err
 			}
-			if vPod.Spec.NodeName != "" && isPodScheduled(vPod) {
+			if vPod.Spec.NodeName != "" {
 				c.updateClusterVNodePodMap(clusterName, vPod.Spec.NodeName, string(vPod.UID), reconciler.DeleteEvent)
 			}
 		}


### PR DESCRIPTION
Supermaster Pod might be deleted at arbitrary time by admin or node controller if node is down. 
If we keep vPod alive and only recreate pPod,  the pPod may be created in a different node. 
Since we cannot rebind vPod to a new node, this will lead to inconsistency of nodename between tenant master and super master. 

In this change, if vPod has been bound to a node but the pPod for some reason is deleted, we 
deleted the vPod as well. Typically, the workload controller in tenant master will create a new Pod.
Due to rare race, it is still possible that the pPod nodename is different from vPod's nodename.
The checker will detect such inconsistency and delete the vPod. 