### PR TITLE
Implement HNS cascading delete

### DIFF
--- a/incubator/hnc/api/v1alpha1/hierarchy_types.go
+++ b/incubator/hnc/api/v1alpha1/hierarchy_types.go
@@ -27,21 +27,21 @@ const (
 
 // Constants for labels and annotations
 const (
-	MetaGroup          = "hnc.x-k8s.io"
-	LabelInheritedFrom = MetaGroup + "/inheritedFrom"
+	MetaGroup                  = "hnc.x-k8s.io"
+	LabelInheritedFrom         = MetaGroup + "/inheritedFrom"
+	FinalizerHasOwnedNamespace = MetaGroup + "/hasOwnedNamespace"
 )
 
 // Condition codes. *All* codes must also be documented in the comment to Condition.Code.
 // TODO change condition codes to CamelCase strings. See issue:
 //  https://github.com/kubernetes-sigs/multi-tenancy/issues/500
 const (
-	CritParentMissing    Code = "CRIT_PARENT_MISSING"
-	CritParentInvalid    Code = "CRIT_PARENT_INVALID"
-	CritAncestor         Code = "CRIT_ANCESTOR"
-	SubnamespaceConflict Code = "SUBNAMESPACE_CONFLICT"
-	HNSMissing           Code = "HNS_MISSING"
-	CannotUpdate         Code = "CANNOT_UPDATE_OBJECT"
-	CannotPropagate      Code = "CANNOT_PROPAGATE_OBJECT"
+	CritParentMissing Code = "CRIT_PARENT_MISSING"
+	CritParentInvalid Code = "CRIT_PARENT_INVALID"
+	CritAncestor      Code = "CRIT_ANCESTOR"
+	HNSMissing        Code = "HNS_MISSING"
+	CannotUpdate      Code = "CANNOT_UPDATE_OBJECT"
+	CannotPropagate   Code = "CANNOT_PROPAGATE_OBJECT"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/incubator/hnc/hack/test-issue-501.sh
+++ b/incubator/hnc/hack/test-issue-501.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+# Set up namespace structure
+echo "----------------------------------------------------"
+echo "${bold}Setting up a 3-level tree with 'parent' as the root${normal}"
+echo "Creating the root 'parent'"
+kubectl create ns parent
+sleep 1
+
+echo "${bold}----Creating the 1st branch of owned namespaces----${normal}"
+echo "Creating owned namespace 'ochild1' for 'parent'"
+kubectl hns create ochild1 -n parent
+sleep 1
+echo "Creating owned namespace 'ochild1ofochild1' for 'ochild1'"
+kubectl hns create ochild1ofochild1 -n ochild1
+echo "Creating owned namespace 'ochild2ofochild1' for 'ochild1'"
+kubectl hns create ochild2ofochild1 -n ochild1
+
+echo "${bold}----Creating the 2nd branch of owned namespaces----${normal}"
+echo "Creating owned namespace 'ochild2' for 'parent'"
+kubectl hns create ochild2 -n parent
+sleep 1
+echo "Creating owned namespace 'ochildofochild2' for 'ochild2'"
+kubectl hns create ochildofochild2 -n ochild2
+
+echo "${bold}----Creating the 3rd branch of a mix of unowned and owned namespaces----${normal}"
+echo "Creating a namespace 'nochild' (not-owned-child) and set its parent to 'parent'"
+kubectl create ns nochild
+sleep 1
+kubectl hns set nochild --parent parent
+echo "Creating owned namespace 'ochildofnochild' for 'nochild'"
+kubectl hns create ochildofnochild -n nochild
+sleep 1
+
+echo "${bold}Here's the outcome of the tree hierarhy:${normal}"
+kubectl hns tree parent
+
+echo "----------------------------------------------------"
+echo "${bold}Test-1:${normal} If the owned namespace doesn't allow cascadingDelete and the HNS is missing in the owner namespace, it should have 'HNS_MISSING' condition while its descendants shoudn't have any conditions."
+echo "${bold}Operation:${normal} delete 'ochild1' hns in 'parent' - kubectl delete hns ochild1 -n parent"
+kubectl delete hns ochild1 -n parent
+sleep 1
+echo "${bold}Expected:${normal} 'ochild1' namespace is not deleted and should have 'HNS_MISSING' condition; no other conditions."
+echo "${bold}Result:${normal}"
+kubectl hns tree parent
+
+echo "----------------------------------------------------"
+echo "${bold}Test-2:${normal} If the HNS is not missing, it should unset the 'HNS_MISSING' condition in the owned namespace."
+echo "${bold}Operation:${normal} recreate the 'ochild1' hns in 'parent' - kubectl hns create ochild1 -n parent"
+kubectl hns create ochild1 -n parent
+sleep 1
+echo "${bold}Expected:${normal} no conditions."
+echo "${bold}Result:${normal}"
+kubectl hns tree parent
+
+echo "----------------------------------------------------"
+echo "${bold}Test-3:${normal} If the owned namespace allows cascadingDelete and the HNS is deleted, it should cascading delete all directly owned namespaces."
+echo "${bold}Operation:${normal} 1) allow cascadingDelete in 'ochid1' - kubectl hns set ochild1 --allowCascadingDelete=true"
+kubectl hns set ochild1 --allowCascadingDelete=true
+echo "2) delete 'ochild1' hns in 'parent' - kubectl delete hns ochild1 -n parent"
+kubectl delete hns ochild1 -n parent
+echo "Waiting 3s for the namespaces to be deleted..."
+sleep 3
+echo "${bold}Expected:${normal} 'ochild1', 'ochild1ofochild1', 'ochild2ofochild1' should all be gone"
+echo "${bold}Result:${normal}"
+kubectl hns tree parent
+
+echo "----------------------------------------------------"
+echo "${bold}Test-4:${normal} If the owner namespace allows cascadingDelete and it's deleted, all its directly owned namespaces should be cascading deleted."
+echo "${bold}Operation:${normal} 1) allow cascadingDelete in 'parent' - kubectl hns set parent --allowCascadingDelete=true"
+kubectl hns set parent --allowCascadingDelete=true
+echo "2) delete 'parent' namespace - kubectl delete ns parent"
+kubectl delete ns parent
+echo "Waiting 3s for the namespaces to be deleted..."
+sleep 3
+echo "${bold}Expected:${normal} only 'nochild' and 'ochildofnochild' should be left and they should have CRIT_ conditions related to missing 'parent'"
+echo "${bold}Result:${normal}"
+kubectl hns tree parent
+kubectl hns tree ochild2
+kubectl hns tree nochild
+
+echo "----------------------------------------------------"
+echo "${bold}Cleaning up${normal}"
+kubectl hns set nochild --allowCascadingDelete=true
+kubectl delete ns nochild

--- a/incubator/hnc/pkg/reconcilers/hierarchical_namespace.go
+++ b/incubator/hnc/pkg/reconcilers/hierarchical_namespace.go
@@ -40,7 +40,6 @@ type HierarchicalNamespaceReconciler struct {
 	Log logr.Logger
 
 	forest *forest.Forest
-	hcr    *HierarchyConfigReconciler
 
 	// Affected is a channel of event.GenericEvent (see "Watching Channels" in
 	// https://book-v1.book.kubebuilder.io/beyond_basics/controller_watches.html) that is used to
@@ -59,22 +58,20 @@ func (r *HierarchicalNamespaceReconciler) Reconcile(req ctrl.Request) (ctrl.Resu
 	nm := req.Name
 	pnm := req.Namespace
 
-	// Get instance from apiserver. If the instance doesn't exist, we don't want to reconcile
-	// it since it may trigger the HC reconciler to recreate the namespace that was just deleted.
-	// TODO expand on this to check the owner's hc.spec.allowCascadingDelete. If it's set to
-	//  true, we still want to reconcile the hns instance. See issue:
-	//  https://github.com/kubernetes-sigs/multi-tenancy/issues/501
+	// Get instance from apiserver. If the instance doesn't exist, do nothing and
+	// early exist because HCR watches HNS instances and (if applicable) has
+	// already updated the owner HC when this HNS was purged.
 	inst, err := r.getInstance(ctx, pnm, nm)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			// If the instance doesn't exist, return nil to prevent a retry.
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
 	}
 
-	// Report "Forbidden" state and early exist if the namespace is not allowed to self-serve
-	// namespaces but has bypassed the webhook and successfully created the hns instance.
+	// Report "Forbidden" state and early exit if the namespace is not allowed to
+	// self-serve namespaces but has bypassed the webhook and successfully created
+	// the hns instance. Forbidden HNSes won't have finalizers.
 	// TODO refactor/split the EX map for 1) reconciler exclusion and 2) self-serve not allowed
 	//  purposes. See issue: https://github.com/kubernetes-sigs/multi-tenancy/issues/495
 	if EX[pnm] {
@@ -82,28 +79,92 @@ func (r *HierarchicalNamespaceReconciler) Reconcile(req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, r.writeInstance(ctx, log, inst)
 	}
 
-	// Get the self-serve namespace's hierarchyConfig and namespace instances.
-	nsInst, err := r.getNamespace(ctx, nm)
+	// Get the owned child namespace instance. If it doesn't exist, initialize one.
+	cnsInst, err := r.getNamespace(ctx, nm)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	switch {
-	case nsInst.Name == "":
-		log.Info("The owned subnamespace does not exist", "subnamespace", nm)
-		inst.Status.State = api.Missing
+	if deleting, err := r.onDeleting(ctx, log, inst, cnsInst); deleting {
+		return ctrl.Result{}, err
+	}
+
+	// Update the state. If the owned child namespace doesn't exist, create it.
+	// (This is how a self-service namespace is created through a CR)
+	r.updateState(log, inst, cnsInst)
+	if inst.Status.State == api.Missing {
 		if err := r.writeNamespace(ctx, log, nm, pnm); err != nil {
 			return ctrl.Result{}, err
 		}
-	case nsInst.Annotations[api.AnnotationOwner] != pnm:
-		log.Info("The owner annotation of the subnamespace doesn't match the owner", "annotation", nsInst.Annotations[api.AnnotationOwner])
-		inst.Status.State = api.Conflict
-	default:
-		log.Info("The subnamespace has the correct owner annotation", "annotation", nsInst.Annotations[api.AnnotationOwner])
-		inst.Status.State = api.Ok
 	}
 
+	// Add finalizers on all non-forbidden HNSes to ensure it's not deleted until
+	// after the owned child namespace is deleted.
+	inst.ObjectMeta.Finalizers = []string{api.MetaGroup}
 	return ctrl.Result{}, r.writeInstance(ctx, log, inst)
+}
+
+func (r *HierarchicalNamespaceReconciler) onDeleting(ctx context.Context, log logr.Logger, inst *api.HierarchicalNamespace, cnsInst *corev1.Namespace) (deleting bool, err error) {
+	// Early exit and continue reconciliation if the instance is not being deleted.
+	if inst.DeletionTimestamp.IsZero() {
+		return false, nil
+	}
+
+	cnm := inst.Name
+	log.Info("The HNS instance is being deleted.")
+	switch {
+	case len(inst.ObjectMeta.Finalizers) == 0:
+		// We've finished process this, nothing to do.
+		log.Info("Do nothing since the finalizers are already gone.")
+		return true, nil
+	case cnsInst.DeletionTimestamp.IsZero() && r.allowsCascadingDelete(cnm):
+		// The owned namespace is not being deleted but it allows cascadingDelete.
+		// Delete the owned namespace.
+		log.Info("The subnamespace is not being deleted but it allows cascading deletion.")
+		return true, r.deleteNamespace(ctx, log, cnsInst)
+	case r.removeFinalizers(log, inst, cnsInst):
+		log.Info("Remove the finalizers.")
+		return true, r.writeInstance(ctx, log, inst)
+	default:
+		// The owned namespace is being deleted. Do nothing in this Reconcile().
+		// Wait until it's purged to remove the finalizers in another Reconcile().
+		log.Info("Do nothing since the owned namespace is still being deleted (not purged yet).")
+		return true, nil
+	}
+}
+
+func (r *HierarchicalNamespaceReconciler) removeFinalizers(log logr.Logger, inst *api.HierarchicalNamespace, cnsInst *corev1.Namespace) bool {
+	pnm := inst.Namespace
+	cnm := inst.Name
+	switch {
+	case cnsInst.Name == "":
+		log.Info("The owned namespace is already purged.")
+	case cnsInst.GetAnnotations()[api.AnnotationOwner] != pnm:
+		log.Info("The subnamespace is not owned by this namespace.")
+	case cnsInst.DeletionTimestamp.IsZero() && !r.allowsCascadingDelete(cnm):
+		log.Info("The subnamespace is not being deleted and it doesn't allow cascading deletion.")
+	default:
+		return false
+	}
+
+	inst.ObjectMeta.Finalizers = nil
+	return true
+}
+
+func (r *HierarchicalNamespaceReconciler) updateState(log logr.Logger, inst *api.HierarchicalNamespace, cnsInst *corev1.Namespace) {
+	nm := inst.Name
+	pnm := inst.Namespace
+	switch {
+	case cnsInst.Name == "":
+		log.Info("The owned subnamespace does not exist", "subnamespace", nm)
+		inst.Status.State = api.Missing
+	case cnsInst.Annotations[api.AnnotationOwner] != pnm:
+		log.Info("The owner annotation of the subnamespace doesn't match the owner", "annotation", cnsInst.Annotations[api.AnnotationOwner])
+		inst.Status.State = api.Conflict
+	default:
+		log.Info("The subnamespace has the correct owner annotation", "annotation", cnsInst.Annotations[api.AnnotationOwner])
+		inst.Status.State = api.Ok
+	}
 }
 
 // It enqueues a hierarchicalNamespace instance for later reconciliation. This occurs in a goroutine
@@ -128,21 +189,6 @@ func (r *HierarchicalNamespaceReconciler) getInstance(ctx context.Context, pnm, 
 	return inst, nil
 }
 
-// getNamespace returns the namespace if it exists, or returns an invalid, blank, unnamed one if it
-// doesn't. This allows it to be trivially identified as a namespace that doesn't exist, and also
-// allows us to easily modify it if we want to create it.
-func (r *HierarchicalNamespaceReconciler) getNamespace(ctx context.Context, nm string) (*corev1.Namespace, error) {
-	ns := &corev1.Namespace{}
-	nnm := types.NamespacedName{Name: nm}
-	if err := r.Get(ctx, nnm, ns); err != nil {
-		if !errors.IsNotFound(err) {
-			return nil, err
-		}
-		return &corev1.Namespace{}, nil
-	}
-	return ns, nil
-}
-
 func (r *HierarchicalNamespaceReconciler) writeInstance(ctx context.Context, log logr.Logger, inst *api.HierarchicalNamespace) error {
 	if inst.CreationTimestamp.IsZero() {
 		log.Info("Creating instance on apiserver")
@@ -160,6 +206,21 @@ func (r *HierarchicalNamespaceReconciler) writeInstance(ctx context.Context, log
 	return nil
 }
 
+// getNamespace returns the namespace if it exists, or returns an invalid, blank, unnamed one if it
+// doesn't. This allows it to be trivially identified as a namespace that doesn't exist, and also
+// allows us to easily modify it if we want to create it.
+func (r *HierarchicalNamespaceReconciler) getNamespace(ctx context.Context, nm string) (*corev1.Namespace, error) {
+	ns := &corev1.Namespace{}
+	nnm := types.NamespacedName{Name: nm}
+	if err := r.Get(ctx, nnm, ns); err != nil {
+		if !errors.IsNotFound(err) {
+			return nil, err
+		}
+		return &corev1.Namespace{}, nil
+	}
+	return ns, nil
+}
+
 func (r *HierarchicalNamespaceReconciler) writeNamespace(ctx context.Context, log logr.Logger, nm, pnm string) error {
 	inst := &corev1.Namespace{}
 	inst.ObjectMeta.Name = nm
@@ -175,6 +236,23 @@ func (r *HierarchicalNamespaceReconciler) writeNamespace(ctx context.Context, lo
 		return err
 	}
 	return nil
+}
+
+func (r *HierarchicalNamespaceReconciler) deleteNamespace(ctx context.Context, log logr.Logger, inst *corev1.Namespace) error {
+	log.Info("Deleting namespace on apiserver")
+	if err := r.Delete(ctx, inst); err != nil {
+		log.Error(err, "while deleting on apiserver")
+		return err
+	}
+	return nil
+}
+
+func (r *HierarchicalNamespaceReconciler) allowsCascadingDelete(nm string) bool {
+	r.forest.Lock()
+	defer r.forest.Unlock()
+
+	ns := r.forest.Get(nm)
+	return ns.AllowsCascadingDelete()
 }
 
 func (r *HierarchicalNamespaceReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/incubator/hnc/pkg/reconcilers/hierarchical_namespace_test.go
+++ b/incubator/hnc/pkg/reconcilers/hierarchical_namespace_test.go
@@ -81,13 +81,13 @@ var _ = Describe("HierarchicalNamespace", func() {
 		// Create "bar" hns in "foo" namespace.
 		foo_hns_bar := newHierarchicalNamespace(barName, fooName)
 		updateHierarchicalNamespace(ctx, foo_hns_bar)
+		Eventually(func() string {
+			barHier := getHierarchy(ctx, barName)
+			return barHier.Spec.Parent
+		}).Should(Equal(fooName))
 
 		// Change the bar's parent. Additionally change another field to reflect the
 		// update of the HC instance (hc.Spec.AllowCascadingDelete).
-		Eventually(func() bool {
-			barHier := getHierarchy(ctx, barName)
-			return barHier.Spec.AllowCascadingDelete
-		}).Should(Equal(false))
 		barHier := getHierarchy(ctx, barName)
 		barHier.Spec.Parent = "other"
 		barHier.Spec.AllowCascadingDelete = true

--- a/incubator/hnc/pkg/reconcilers/hierarchy_config.go
+++ b/incubator/hnc/pkg/reconcilers/hierarchy_config.go
@@ -91,8 +91,22 @@ func (r *HierarchyConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 }
 
 func (r *HierarchyConfigReconciler) reconcile(ctx context.Context, log logr.Logger, nm string) error {
-	// Get the singleton and namespace.
-	inst, nsInst, err := r.GetInstances(ctx, log, nm)
+	nsInst, err := r.getNamespace(ctx, nm)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// The namespace doesn't exist or is purged. Update the forest and exit.
+			// (There must be no HC instance and we cannot create one.)
+			r.onMissingNamespace(log, nm)
+			return nil
+		}
+		return err
+	}
+	// Get singleton from apiserver. If it doesn't exist, initialize one.
+	inst, err := r.getSingleton(ctx, nm)
+	if err != nil {
+		return err
+	}
+	// Get a list of HNS instance namespaces from apiserver.
 	hnsnms, err := r.getHierarchicalNamespaceNames(ctx, nm)
 	if err != nil {
 		return err
@@ -101,23 +115,10 @@ func (r *HierarchyConfigReconciler) reconcile(ctx context.Context, log logr.Logg
 	origHC := inst.DeepCopy()
 	origNS := nsInst.DeepCopy()
 
-	// If either object exists but is being deleted, we won't update them when we're finished syncing
-	// (we should sync our internal data structure anyway just in case something's changed).  I'm not
-	// sure if this is the right thing to do but the kubebuilder boilerplate included this case
-	// explicitly.
-	update := true
-	if !inst.GetDeletionTimestamp().IsZero() || !nsInst.GetDeletionTimestamp().IsZero() {
-		log.Info("Singleton or namespace are being deleted; will not update")
-		update = false
-	}
+	r.updateFinalizers(ctx, log, inst, nsInst, hnsnms)
 
 	// Sync the Hierarchy singleton with the in-memory forest.
 	r.syncWithForest(log, nsInst, inst, hnsnms)
-
-	// Early exit if we don't need to write anything back.
-	if !update {
-		return nil
-	}
 
 	// Write back if anything's changed. Early-exit if we just write back exactly what we had.
 	if updated, err := r.writeInstances(ctx, log, origHC, inst, origNS, nsInst); !updated || err != nil {
@@ -136,6 +137,38 @@ func (r *HierarchyConfigReconciler) reconcile(ctx context.Context, log logr.Logg
 	return r.updateObjects(ctx, log, nm)
 }
 
+func (r *HierarchyConfigReconciler) onMissingNamespace(log logr.Logger, nm string) {
+	r.Forest.Lock()
+	defer r.Forest.Unlock()
+	ns := r.Forest.Get(nm)
+
+	if ns.Exists() {
+		r.enqueueAffected(log, "relative of deleted namespace", ns.RelativesNames()...)
+		ns.UnsetExists()
+		log.Info("Removed namespace")
+	}
+}
+
+func (r *HierarchyConfigReconciler) updateFinalizers(ctx context.Context, log logr.Logger, inst *api.HierarchyConfiguration, nsInst *corev1.Namespace, hnsnms []string) {
+	switch {
+	case len(hnsnms) == 0:
+		// There's no owned namespaces in this namespace. The HC instance can be
+		// safely deleted anytime.
+		log.Info("Remove finalizers since there's no HNS instance in the namespace.")
+		inst.ObjectMeta.Finalizers = nil
+	case !inst.DeletionTimestamp.IsZero() && nsInst.DeletionTimestamp.IsZero():
+		// If the HC instance is being deleted but not the namespace (which means
+		// it's not a cascading delete), remove the finalizers to let it go through.
+		// This is the only case the finalizers can be removed even when the
+		// namespace has owned namespaces. (A default HC will be recreated later.)
+		log.Info("Remove finalizers to allow a single deletion of the singleton (not involved in a cascading deletion).")
+		inst.ObjectMeta.Finalizers = nil
+	default:
+		log.Info("Add finalizers since there's HNS instance(s) in the namespace.")
+		inst.ObjectMeta.Finalizers = []string{api.FinalizerHasOwnedNamespace}
+	}
+}
+
 // syncWithForest synchronizes the in-memory forest with the (in-memory) Hierarchy instance. If any
 // *other* namespaces have changed, it enqueues them for later reconciliation. This method is
 // guarded by the forest mutex, which means that none of the other namespaces being reconciled will
@@ -147,11 +180,6 @@ func (r *HierarchyConfigReconciler) syncWithForest(log logr.Logger, nsInst *core
 	defer r.Forest.Unlock()
 	ns := r.Forest.Get(inst.ObjectMeta.Namespace)
 
-	// Handle missing namespaces.
-	if r.onMissingNamespace(log, ns, nsInst) {
-		return
-	}
-
 	// Clear locally-set conditions in the forest so we can set them to the latest.
 	hadCrit := ns.HasLocalCritCondition()
 	ns.ClearConditions(forest.Local, "")
@@ -162,29 +190,12 @@ func (r *HierarchyConfigReconciler) syncWithForest(log logr.Logger, nsInst *core
 	r.syncParent(log, inst, ns)
 	inst.Status.Children = ns.ChildNames()
 	r.syncHNSes(log, ns, hnsnms)
+	ns.UpdateAllowCascadingDelete(inst.Spec.AllowCascadingDelete)
 
 	r.syncLabel(log, nsInst, ns)
 
 	// Sync all conditions. This should be placed at the end after all conditions are updated.
 	r.syncConditions(log, inst, ns, hadCrit)
-}
-
-func (r *HierarchyConfigReconciler) onMissingNamespace(log logr.Logger, ns *forest.Namespace, nsInst *corev1.Namespace) bool {
-	if nsInst.Name != "" {
-		return false
-	}
-
-	// If the namespace is removed, no more action need on the reconciliation. The
-	// namespace is only unset existence below.
-	if !ns.Exists() {
-		return true
-	}
-
-	// Remove it from the forest and notify its relatives
-	r.enqueueAffected(log, "relative of deleted namespace", ns.RelativesNames()...)
-	ns.UnsetExists()
-	log.Info("Removed namespace")
-	return true
 }
 
 // syncOwner sets the parent to the owner and updates the HNS_MISSING condition
@@ -371,21 +382,6 @@ func (r *HierarchyConfigReconciler) enqueueAffected(log logr.Logger, reason stri
 	}()
 }
 
-func (r *HierarchyConfigReconciler) GetInstances(ctx context.Context, log logr.Logger, nm string) (inst *api.HierarchyConfiguration, ns *corev1.Namespace, err error) {
-	inst, err = r.getSingleton(ctx, nm)
-	if err != nil {
-		log.Error(err, "Couldn't read singleton")
-		return nil, nil, err
-	}
-	ns, err = r.getNamespace(ctx, nm)
-	if err != nil {
-		log.Error(err, "Couldn't read namespace")
-		return nil, nil, err
-	}
-
-	return inst, ns, nil
-}
-
 func (r *HierarchyConfigReconciler) writeInstances(ctx context.Context, log logr.Logger, oldHC, newHC *api.HierarchyConfiguration, oldNS, newNS *corev1.Namespace) (bool, error) {
 	ret := false
 	if updated, err := r.writeHierarchy(ctx, log, oldHC, newHC); err != nil {
@@ -488,10 +484,7 @@ func (r *HierarchyConfigReconciler) getNamespace(ctx context.Context, nm string)
 	ns := &corev1.Namespace{}
 	nnm := types.NamespacedName{Name: nm}
 	if err := r.Get(ctx, nnm, ns); err != nil {
-		if !errors.IsNotFound(err) {
-			return nil, err
-		}
-		return &corev1.Namespace{}, nil
+		return nil, err
 	}
 	return ns, nil
 }


### PR DESCRIPTION
Add a finalizer to all HNS instances and remove it only when the
subnamespace is deleted and purged for a cascading deletion OR if it's a
single deletion (HNS_MISSING condition will be set on the subnamespace
then).

Add a finalizer to HC instances only if the namespace has HNS instances.
It will be removed when the HNS instances are all deleted and purged for
a cascading deletion OR if it's a single deletion (a new default HC
instance will be created by the next HC reconciliation).

Add allowCascadingDelete field to forest. This is updated by the
hc.Spec.AllowCascadingDelete field.

Add allowCascadingDelete() func to forest. It indicates if the namespace
can be cascading deleted.

Update and move onMissingNamespace() to the top of HCR when a namespace
doesn't exist.

Add a testing script since the purge is not available in the integration
test.

Tested the testing script on GKE cluster by ". hack/test-issue-501.sh".

Fixes #501, #513 
Part of #457  