### PR TITLE
Updates the Readme

### DIFF
--- a/benchmarks/documentation/run.md
+++ b/benchmarks/documentation/run.md
@@ -32,17 +32,8 @@ tenantA:
 go test ./e2e/tests
 ```
 
+### To see a more verbose output from the test
 
-### Compile the test binary and run the test
-
-This command compiles the test and output to `tests.test` in current directory.
 ```shell
-go test -c ./e2e/tests
+go test -v ./e2e/tests
 ```
-
-Run the test:
-```shell
-./tests.test 
-```
-<br/><br/>
-*Read Next >> [Contributing](contributing.md)*

--- a/benchmarks/documentation/run.md
+++ b/benchmarks/documentation/run.md
@@ -37,3 +37,5 @@ go test ./e2e/tests
 ```shell
 go test -v ./e2e/tests
 ```
+<br/><br/>
+*Read Next >> [Contributing](contributing.md)*


### PR DESCRIPTION
This updates the Readme on how to run the test. It removes commands on how to compile the binary has that throws an error. See [comment](https://github.com/kubernetes-sigs/multi-tenancy/pull/545#issuecomment-605385781)