### PR TITLE
Enable Tenant and Tenantnamespace reconcilers to check

### DIFF
--- a/tenant/pkg/controller/tenant/tenant_controller_suite.go
+++ b/tenant/pkg/controller/tenant/tenant_controller_suite.go
@@ -17,38 +17,13 @@ limitations under the License.
 package tenant
 
 import (
-	stdlog "log"
-	"os"
-	"path/filepath"
 	"sync"
-	"testing"
 
-	"github.com/kubernetes-sigs/multi-tenancy/tenant/pkg/apis"
 	"github.com/onsi/gomega"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-var cfg *rest.Config
-
-func TestMain(m *testing.M) {
-	t := &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds")},
-	}
-	apis.AddToScheme(scheme.Scheme)
-
-	var err error
-	if cfg, err = t.Start(); err != nil {
-		stdlog.Fatal(err)
-	}
-
-	code := m.Run()
-	t.Stop()
-	os.Exit(code)
-}
 
 // SetupTestReconcile returns a reconcile.Reconcile implementation that delegates to inner and
 // writes the request to requests after Reconcile is finished.
@@ -72,4 +47,12 @@ func StartTestManager(mgr manager.Manager, g *gomega.GomegaWithT) (chan struct{}
 		g.Expect(mgr.Start(stop)).NotTo(gomega.HaveOccurred())
 	}()
 	return stop, wg
+}
+
+func SetupNewReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return newReconciler(mgr)
+}
+
+func AddManager(mgr manager.Manager, r reconcile.Reconciler) error {
+	return add(mgr, r)
 }

--- a/tenant/pkg/controller/tenantnamespace/tenantnamespace_controller_suite_test.go
+++ b/tenant/pkg/controller/tenantnamespace/tenantnamespace_controller_suite_test.go
@@ -20,6 +20,7 @@ import (
 	stdlog "log"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -37,11 +38,12 @@ var cfg *rest.Config
 func TestMain(m *testing.M) {
 	t := &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds")},
+		UseExistingCluster:true,
 	}
 	apis.AddToScheme(scheme.Scheme)
 
 	var err error
-	if cfg, err = t.Start(); err != nil {
+	if cfg, err = t.Start(); err != nil && !(strings.Contains(err.Error(), "customresourcedefinitions.apiextensions.k8s.io") && strings.Contains(err.Error(), "already exists") && (strings.Contains(err.Error(), "tenants.tenancy.x-k8s.io") || strings.Contains(err.Error(), "tenantnamespaces.tenancy.x-k8s.io"))) {
 		stdlog.Fatal(err)
 	}
 

--- a/tenant/pkg/controller/tenantnamespace/tenantnamespace_controller_test.go
+++ b/tenant/pkg/controller/tenantnamespace/tenantnamespace_controller_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package tenantnamespace
 
 import (
+	"fmt"
+	v1 "k8s.io/api/rbac/v1"
+	"k8s.io/client-go/tools/clientcmd"
 	"testing"
 	"time"
 
-	tenancyv1alpha1 "github.com/kubernetes-sigs/multi-tenancy/tenant/pkg/apis/tenancy/v1alpha1"
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
 	corev1 "k8s.io/api/core/v1"
@@ -30,29 +32,31 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	tenancyv1alpha1 "github.com/kubernetes-sigs/multi-tenancy/tenant/pkg/apis/tenancy/v1alpha1"
+	tenant2 "github.com/kubernetes-sigs/multi-tenancy/tenant/pkg/controller/tenant"
 )
 
 var c client.Client
 
 const timeout = time.Second * 5
 
-func testCreateTenantNamespaceNoPrefix(c client.Client, g *gomega.GomegaWithT, t *testing.T, requests chan reconcile.Request) {
-	var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: "ta-admin"}}
+func testCreateTenantNamespaceNoPrefix(c client.Client, g *gomega.GomegaWithT, t *testing.T, requests chan reconcile.Request, uniqueNo string) {
 	tenant := &tenancyv1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tenant-a",
+			Name: getUniqueName("tenant-a", uniqueNo),
 		},
 		Spec: tenancyv1alpha1.TenantSpec{
-			TenantAdminNamespaceName: "ta-admin",
+			TenantAdminNamespaceName: getUniqueName("ta-admin", uniqueNo),
 		},
 	}
 	instance := &tenancyv1alpha1.TenantNamespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo",
-			Namespace: "ta-admin",
+			Name:      getUniqueName("foo", uniqueNo),
+			Namespace: tenant.Spec.TenantAdminNamespaceName,
 		},
 		Spec: tenancyv1alpha1.TenantNamespaceSpec{
-			Name: "t1",
+			Name: getUniqueName("tns", uniqueNo),
 		},
 	}
 	// Create tenant object
@@ -65,7 +69,7 @@ func testCreateTenantNamespaceNoPrefix(c client.Client, g *gomega.GomegaWithT, t
 	// Tenant reconcile is not active hence we need to manually create tenant admin namespace
 	adminNs := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "ta-admin",
+			Name: tenant.Spec.TenantAdminNamespaceName,
 		},
 	}
 	err = c.Create(context.TODO(), adminNs)
@@ -82,9 +86,10 @@ func testCreateTenantNamespaceNoPrefix(c client.Client, g *gomega.GomegaWithT, t
 	}
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	defer c.Delete(context.TODO(), instance)
+	var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: instance.ObjectMeta.Name, Namespace: instance.ObjectMeta.Namespace}}
 	g.Eventually(requests, timeout).Should(gomega.Receive(gomega.Equal(expectedRequest)))
 
-	nskey := types.NamespacedName{Name: "t1"}
+	nskey := types.NamespacedName{Name: instance.Spec.Name}
 	tenantNs := &corev1.Namespace{}
 	g.Eventually(func() error { return c.Get(context.TODO(), nskey, tenantNs) }, timeout).
 		Should(gomega.Succeed())
@@ -98,24 +103,23 @@ func testCreateTenantNamespaceNoPrefix(c client.Client, g *gomega.GomegaWithT, t
 	//	Should(gomega.Succeed())
 }
 
-func testCreateTenantNamespaceWithPrefix(c client.Client, g *gomega.GomegaWithT, t *testing.T, requests chan reconcile.Request) {
-	var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo-1", Namespace: "ta-admin"}}
+func testCreateTenantNamespaceWithPrefix(c client.Client, g *gomega.GomegaWithT, t *testing.T, requests chan reconcile.Request, uniqueNo string) {
 	tenant := &tenancyv1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tenant-a",
+			Name: getUniqueName("tenant-a", uniqueNo),
 		},
 		Spec: tenancyv1alpha1.TenantSpec{
-			TenantAdminNamespaceName: "ta-admin",
+			TenantAdminNamespaceName: getUniqueName("ta-admin", uniqueNo),
 			RequireNamespacePrefix:   true,
 		},
 	}
 	instance := &tenancyv1alpha1.TenantNamespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo-1",
-			Namespace: "ta-admin",
+			Name:      getUniqueName("foo", uniqueNo),
+			Namespace: tenant.Spec.TenantAdminNamespaceName,
 		},
 		Spec: tenancyv1alpha1.TenantNamespaceSpec{
-			Name: "t1",
+			Name: getUniqueName("tns", uniqueNo),
 		},
 	}
 	// Create tenant object
@@ -128,7 +132,7 @@ func testCreateTenantNamespaceWithPrefix(c client.Client, g *gomega.GomegaWithT,
 	// Tenant reconcile is not active hence we need to manually create tenant admin namespace
 	adminNs := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "ta-admin",
+			Name: tenant.Spec.TenantAdminNamespaceName,
 		},
 	}
 	err = c.Create(context.TODO(), adminNs)
@@ -145,29 +149,29 @@ func testCreateTenantNamespaceWithPrefix(c client.Client, g *gomega.GomegaWithT,
 	}
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	defer c.Delete(context.TODO(), instance)
+	var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: instance.ObjectMeta.Name, Namespace: instance.ObjectMeta.Namespace}}
 	g.Eventually(requests, timeout).Should(gomega.Receive(gomega.Equal(expectedRequest)))
 
-	nskey := types.NamespacedName{Name: "ta-admin-t1"}
+	nskey := types.NamespacedName{Name: fmt.Sprintf("%+v-%+v", tenant.Spec.TenantAdminNamespaceName, instance.Spec.Name)}
 	tenantNs := &corev1.Namespace{}
 	g.Eventually(func() error { return c.Get(context.TODO(), nskey, tenantNs) }, timeout).
 		Should(gomega.Succeed())
 }
 
-func testCreateTenantNamespaceWithPrefixNoSpec(c client.Client, g *gomega.GomegaWithT, t *testing.T, requests chan reconcile.Request) {
-	var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo-2", Namespace: "ta-admin"}}
+func testCreateTenantNamespaceWithPrefixNoSpec(c client.Client, g *gomega.GomegaWithT, t *testing.T, requests chan reconcile.Request, uniqueNo string) {
 	tenant := &tenancyv1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tenant-a",
+			Name: getUniqueName("tenant-a", uniqueNo),
 		},
 		Spec: tenancyv1alpha1.TenantSpec{
-			TenantAdminNamespaceName: "ta-admin",
+			TenantAdminNamespaceName: getUniqueName("ta-admin", uniqueNo),
 			RequireNamespacePrefix:   true,
 		},
 	}
 	instance := &tenancyv1alpha1.TenantNamespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo-2",
-			Namespace: "ta-admin",
+			Name:      getUniqueName("foo", uniqueNo),
+			Namespace: tenant.Spec.TenantAdminNamespaceName,
 		},
 	}
 	// Create tenant object
@@ -180,7 +184,7 @@ func testCreateTenantNamespaceWithPrefixNoSpec(c client.Client, g *gomega.Gomega
 	// Tenant reconcile is not active hence we need to manually create tenant admin namespace
 	adminNs := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "ta-admin",
+			Name: tenant.Spec.TenantAdminNamespaceName,
 		},
 	}
 	err = c.Create(context.TODO(), adminNs)
@@ -197,31 +201,31 @@ func testCreateTenantNamespaceWithPrefixNoSpec(c client.Client, g *gomega.Gomega
 	}
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	defer c.Delete(context.TODO(), instance)
+	var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: instance.ObjectMeta.Name, Namespace: instance.ObjectMeta.Namespace}}
 	g.Eventually(requests, timeout).Should(gomega.Receive(gomega.Equal(expectedRequest)))
 
-	nskey := types.NamespacedName{Name: "ta-admin-foo-2"}
+	nskey := types.NamespacedName{Name: fmt.Sprintf("%+v-%+v", tenant.Spec.TenantAdminNamespaceName, instance.ObjectMeta.Name)}
 	tenantNs := &corev1.Namespace{}
 	g.Eventually(func() error { return c.Get(context.TODO(), nskey, tenantNs) }, timeout).
 		Should(gomega.Succeed())
 }
 
-func testImportExistingNamespace(c client.Client, g *gomega.GomegaWithT, t *testing.T, requests chan reconcile.Request) {
-	var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo-3", Namespace: "ta-admin"}}
+func testImportExistingNamespace(c client.Client, g *gomega.GomegaWithT, t *testing.T, requests chan reconcile.Request, uniqueNo string) {
 	tenant := &tenancyv1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "tenant-a",
+			Name: getUniqueName("tenant-a", uniqueNo),
 		},
 		Spec: tenancyv1alpha1.TenantSpec{
-			TenantAdminNamespaceName: "ta-admin",
+			TenantAdminNamespaceName: getUniqueName("ta-admin", uniqueNo),
 		},
 	}
 	instance := &tenancyv1alpha1.TenantNamespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo-3",
-			Namespace: "ta-admin",
+			Name:      getUniqueName("foo", uniqueNo),
+			Namespace: tenant.Spec.TenantAdminNamespaceName,
 		},
 		Spec: tenancyv1alpha1.TenantNamespaceSpec{
-			Name: "t2",
+			Name: getUniqueName("tns", uniqueNo),
 		},
 	}
 	// Create tenant object
@@ -234,7 +238,7 @@ func testImportExistingNamespace(c client.Client, g *gomega.GomegaWithT, t *test
 	// Tenant reconcile is not active hence we need to manually create tenant admin namespace
 	adminNs := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "ta-admin",
+			Name: tenant.Spec.TenantAdminNamespaceName,
 		},
 	}
 	err = c.Create(context.TODO(), adminNs)
@@ -246,7 +250,7 @@ func testImportExistingNamespace(c client.Client, g *gomega.GomegaWithT, t *test
 	// Create t2, make it available before creating tenant namespace object
 	t2Ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "t2",
+			Name: instance.Spec.Name,
 		},
 	}
 	err = c.Create(context.TODO(), t2Ns)
@@ -262,8 +266,9 @@ func testImportExistingNamespace(c client.Client, g *gomega.GomegaWithT, t *test
 		return
 	}
 	g.Expect(err).NotTo(gomega.HaveOccurred())
-	defer c.Delete(context.TODO(), instance)
+	var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: instance.ObjectMeta.Name, Namespace: instance.ObjectMeta.Namespace}}
 	g.Eventually(requests, timeout).Should(gomega.Receive(gomega.Equal(expectedRequest)))
+	defer c.Delete(context.TODO(), instance)
 	// Refresh instance
 	err = c.Get(context.TODO(), expectedRequest.NamespacedName, instance)
 	if apierrors.IsInvalid(err) {
@@ -271,7 +276,7 @@ func testImportExistingNamespace(c client.Client, g *gomega.GomegaWithT, t *test
 		return
 	}
 	// Refresh t2
-	nskey := types.NamespacedName{Name: "t2"}
+	nskey := types.NamespacedName{Name: instance.Spec.Name}
 	err = c.Get(context.TODO(), nskey, t2Ns)
 	if apierrors.IsInvalid(err) {
 		t.Logf("failed to get namespace object, got an invalid object error: %v", err)
@@ -286,6 +291,244 @@ func testImportExistingNamespace(c client.Client, g *gomega.GomegaWithT, t *test
 	g.Expect(len(t2Ns.OwnerReferences) == 1 && expectedOwnerRef == t2Ns.OwnerReferences[0]).To(gomega.BeTrue())
 }
 
+func testRoleAndBindingsWithValidAdmin(t *testing.T, g *gomega.GomegaWithT, c client.Client, requestsTenant, requestsTenantNS chan reconcile.Request, uniqueNo string) {
+	//create tenant-admin
+	sa := corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ServiceAccount",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getUniqueName("tenant-admin-sa", uniqueNo),
+			Namespace: "default",
+		},
+	}
+	err := c.Create(context.TODO(), &sa)
+	if err != nil {
+		t.Logf("Failed to create tenant admin: %+v with error: %+v", sa.ObjectMeta.Name, err)
+		return
+	}
+	//	defer c.Delete(context.TODO(), &sa)
+
+	//create tenant object
+	tenant := &tenancyv1alpha1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: getUniqueName("tenant-a", uniqueNo),
+		},
+		Spec: tenancyv1alpha1.TenantSpec{
+			TenantAdminNamespaceName: getUniqueName("tenant-admin-ns", uniqueNo),
+			TenantAdmins: []v1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      sa.ObjectMeta.Name,
+					Namespace: sa.ObjectMeta.Namespace,
+				},
+			},
+		},
+	}
+	err = c.Create(context.TODO(), tenant)
+	if apierrors.IsInvalid(err) {
+		t.Logf("failed to create tenant object, got an invalid object error: %v", err)
+		return
+	}
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	var expectedRequestTenant = reconcile.Request{NamespacedName: types.NamespacedName{Name: tenant.ObjectMeta.Name}}
+	g.Eventually(requestsTenant, timeout).Should(gomega.Receive(gomega.Equal(expectedRequestTenant)))
+	//	defer c.Delete(context.TODO(), tenant)
+
+	//check admin namespace of tenant is created or not
+	tenantadminkey := types.NamespacedName{Name: tenant.Spec.TenantAdminNamespaceName}
+	tenantAdminNs := &corev1.Namespace{}
+	g.Eventually(func() error { return c.Get(context.TODO(), tenantadminkey, tenantAdminNs) }, timeout).
+		Should(gomega.Succeed())
+
+	saSecretName, err := findSecretNameOfSA(c, sa.ObjectMeta.Name)
+	if err != nil {
+		t.Logf("Failed to get secret name of a service account: error: %+v", err)
+		return
+	}
+
+	//Get secret
+	saSecretKey := types.NamespacedName{Name: saSecretName, Namespace: sa.ObjectMeta.Namespace}
+	tenantAdminSecret := corev1.Secret{}
+	err = c.Get(context.TODO(), saSecretKey, &tenantAdminSecret)
+	if err != nil {
+		t.Logf("Failed to get tenant admin secret, error %+v", err)
+		return
+	}
+
+	//Generate user config string
+	userCfgStr, err := GenerateCfgStr("kind-kind", cfg.Host, tenantAdminSecret.Data["ca.crt"], tenantAdminSecret.Data["token"], sa.ObjectMeta.Name)
+	userCfg, err := clientcmd.RESTConfigFromKubeConfig([]byte(userCfgStr))
+	if err != nil {
+		t.Logf("failed to create user config, got an invalid object error: %v", err)
+		return
+	}
+
+	//User manager and client
+	userMgr, err := manager.New(userCfg, manager.Options{})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	userCl := userMgr.GetClient()
+
+	stopUserMgr, userMgrStopped := StartTestManager(userMgr, g)
+
+	defer func() {
+		close(stopUserMgr)
+		userMgrStopped.Wait()
+	}()
+
+	//create tenantnamespace object using user client
+	tenantnamespaceObj := &tenancyv1alpha1.TenantNamespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getUniqueName("foo-tenantns", uniqueNo),
+			Namespace: tenant.Spec.TenantAdminNamespaceName,
+		},
+		Spec: tenancyv1alpha1.TenantNamespaceSpec{
+			Name: getUniqueName("tenantnamespace-t", uniqueNo),
+		},
+	}
+	err = userCl.Create(context.TODO(), tenantnamespaceObj)
+	if err != nil {
+		t.Logf("failed to create tenantnamespace object, got an invalid object error: %v", err)
+		return
+	}
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	var expectedRequestTenantNamespace = reconcile.Request{NamespacedName: types.NamespacedName{Name: tenantnamespaceObj.ObjectMeta.Name, Namespace: tenantnamespaceObj.ObjectMeta.Namespace}}
+	g.Eventually(requestsTenantNS, timeout).Should(gomega.Receive(gomega.Equal(expectedRequestTenantNamespace)))
+
+	//check if tenantnamespace is created or not
+	nskey := types.NamespacedName{Name: tenantnamespaceObj.Spec.Name}
+	tenantNs := &corev1.Namespace{}
+	g.Eventually(func() error { return c.Get(context.TODO(), nskey, tenantNs) }, timeout).
+		Should(gomega.Succeed())
+
+	//deleting all resources
+	c.Delete(context.TODO(), &sa)
+	c.Delete(context.TODO(), tenant)
+	c.Delete(context.TODO(), tenantAdminNs)
+	userCl.Delete(context.TODO(), tenantnamespaceObj)
+	userCl.Delete(context.TODO(), tenantNs)
+
+}
+
+func testRoleAndBindingsWithNonValidAdmin(t *testing.T, g *gomega.GomegaWithT, c client.Client, requestsTenant, requestsTenantNS chan reconcile.Request, uniqueNo string) {
+	//create normal user
+	usr := corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ServiceAccount",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getUniqueName("fake-sa", uniqueNo),
+			Namespace: "default",
+		},
+	}
+	err := c.Create(context.TODO(), &usr)
+	if err != nil {
+		t.Logf("Failed to create fake user: %+v with error: %+v", usr.ObjectMeta.Name, err)
+		return
+	}
+
+	//create tenant-admin
+	sa := corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ServiceAccount",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getUniqueName("tenant-admin-sa", uniqueNo),
+			Namespace: "default",
+		},
+	}
+	err = c.Create(context.TODO(), &sa)
+	if err != nil {
+		t.Logf("Failed to create tenant admin: %+v with error: %+v", sa.ObjectMeta.Name, err)
+		return
+	}
+
+	//create tenant object
+	tenant := &tenancyv1alpha1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: getUniqueName("tenant-a", uniqueNo),
+		},
+		Spec: tenancyv1alpha1.TenantSpec{
+			TenantAdminNamespaceName: getUniqueName("tenant-admin-ns", uniqueNo),
+			TenantAdmins: []v1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      sa.ObjectMeta.Name,
+					Namespace: sa.ObjectMeta.Namespace,
+				},
+			},
+		},
+	}
+	err = c.Create(context.TODO(), tenant)
+	if apierrors.IsInvalid(err) {
+		t.Logf("failed to create tenant object, got an invalid object error: %v", err)
+		return
+	}
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	var expectedRequestTenant = reconcile.Request{NamespacedName: types.NamespacedName{Name: tenant.ObjectMeta.Name}}
+	g.Eventually(requestsTenant, timeout).Should(gomega.Receive(gomega.Equal(expectedRequestTenant)))
+
+	//check admin namespace of tenant is created or not
+	tenantadminkey := types.NamespacedName{Name: tenant.Spec.TenantAdminNamespaceName}
+	tenantAdminNs := &corev1.Namespace{}
+	g.Eventually(func() error { return c.Get(context.TODO(), tenantadminkey, tenantAdminNs) }, timeout).
+		Should(gomega.Succeed())
+
+	// get secretname of fake user
+	saSecretName, err := findSecretNameOfSA(c, usr.ObjectMeta.Name)
+	if err != nil {
+		t.Logf("Failed to get secret name of a service account: error: %+v", err)
+		return
+	}
+
+	//Get secret
+	saSecretKey := types.NamespacedName{Name: saSecretName, Namespace: usr.ObjectMeta.Namespace}
+	fakeUserSecret := corev1.Secret{}
+	err = c.Get(context.TODO(), saSecretKey, &fakeUserSecret)
+	if err != nil {
+		t.Logf("Failed to get tenant admin secret, error %+v", err)
+		return
+	}
+
+	//Generate user config string
+	userCfgStr, err := GenerateCfgStr("kind-kind", cfg.Host, fakeUserSecret.Data["ca.crt"], fakeUserSecret.Data["token"], usr.ObjectMeta.Name)
+	userCfg, err := clientcmd.RESTConfigFromKubeConfig([]byte(userCfgStr))
+	if err != nil {
+		t.Logf("failed to create user config, got an invalid object error: %v", err)
+		return
+	}
+
+	//User manager and client
+	userMgr, err := manager.New(userCfg, manager.Options{})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	userCl := userMgr.GetClient()
+
+	stopUserMgr, userMgrStopped := StartTestManager(userMgr, g)
+
+	defer func() {
+		close(stopUserMgr)
+		userMgrStopped.Wait()
+	}()
+
+	//create tenantnamespace object using user client
+	tenantnamespaceObj := &tenancyv1alpha1.TenantNamespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getUniqueName("foo-tenantns", uniqueNo),
+			Namespace: tenant.Spec.TenantAdminNamespaceName,
+		},
+		Spec: tenancyv1alpha1.TenantNamespaceSpec{
+			Name: getUniqueName("tenantnamespace", uniqueNo),
+		},
+	}
+
+	g.Eventually(func() error { return userCl.Create(context.TODO(), tenantnamespaceObj) }).ShouldNot(gomega.Succeed())
+
+	c.Delete(context.TODO(), &sa)
+	c.Delete(context.TODO(), &usr)
+	c.Delete(context.TODO(), tenant)
+	c.Delete(context.TODO(), tenantAdminNs)
+}
+
 func TestReconcile(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	// Setup the Manager and Controller.  Wrap the Controller Reconcile function so it writes each request to a
@@ -294,18 +537,25 @@ func TestReconcile(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
 
-	recFn, requests := SetupTestReconcile(newReconciler(mgr))
-	g.Expect(add(mgr, recFn)).NotTo(gomega.HaveOccurred())
+	//start tenant controller
+	recFnTenant, requestsTenant := tenant2.SetupTestReconcile(tenant2.SetupNewReconciler(mgr))
+	g.Expect(tenant2.AddManager(mgr, recFnTenant)).NotTo(gomega.HaveOccurred())
 
+	//start tenantnamespace controller
+	recFnTenantNS, requestsTenantNS := SetupTestReconcile(newReconciler(mgr))
+	g.Expect(add(mgr, recFnTenantNS)).NotTo(gomega.HaveOccurred())
+
+	//start and defer manager
 	stopMgr, mgrStopped := StartTestManager(mgr, g)
-
 	defer func() {
 		close(stopMgr)
 		mgrStopped.Wait()
 	}()
 
-	testCreateTenantNamespaceNoPrefix(c, g, t, requests)
-	testCreateTenantNamespaceWithPrefix(c, g, t, requests)
-	testCreateTenantNamespaceWithPrefixNoSpec(c, g, t, requests)
-	testImportExistingNamespace(c, g, t, requests)
+	testCreateTenantNamespaceNoPrefix(c, g, t, requestsTenantNS,"1")
+	testCreateTenantNamespaceWithPrefix(c, g, t, requestsTenantNS,"2")
+	testCreateTenantNamespaceWithPrefixNoSpec(c, g, t, requestsTenantNS,"3")
+	testImportExistingNamespace(c, g, t, requestsTenantNS,"4")
+	testRoleAndBindingsWithValidAdmin(t, g, c, requestsTenant, requestsTenantNS,"5")
+	testRoleAndBindingsWithNonValidAdmin(t, g, c, requestsTenant, requestsTenantNS,"6")
 }

--- a/tenant/pkg/controller/tenantnamespace/tenantnamespace_helper.go
+++ b/tenant/pkg/controller/tenantnamespace/tenantnamespace_helper.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tenantnamespace
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"html/template"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	cfgTemplate = `
+kind: Config
+apiVersion: v1
+users:
+- name: {{ .username }}
+  user:
+    token: {{ .token }}
+clusters:
+- name: {{ .cluster }}
+  cluster:
+    certificate-authority-data: {{ .ca }}
+    server: {{ .master }}
+contexts:
+- context:
+    cluster: {{ .cluster }}
+    user: {{ .username }}
+  name: default
+current-context: default
+preferences: {}
+`
+)
+
+func GenerateCfgStr(clusterName string, ip string, ca, token []byte, username string) (string, error) {
+	de := base64.StdEncoding.EncodeToString(token)
+	r, _ := base64.StdEncoding.DecodeString(de)
+	ctx := map[string]string{
+		"ca":       base64.StdEncoding.EncodeToString(ca),
+		"token":    string(r),
+		"username": username,
+		"master":   ip,
+		"cluster":  clusterName,
+	}
+
+	return getTemplateContent(cfgTemplate, ctx)
+}
+
+// getTemplateContent fills out the kubeconfig templates based on the context
+func getTemplateContent(kubeConfigTmpl string, context interface{}) (string, error) {
+	t, tmplPrsErr := template.New("test").Parse(kubeConfigTmpl)
+	if tmplPrsErr != nil {
+		return "", tmplPrsErr
+	}
+	writer := bytes.NewBuffer([]byte{})
+	if err := t.Execute(writer, context); nil != err {
+		return "", err
+	}
+
+	return writer.String(), nil
+}
+
+//findSecretNameOfSA: get secret name of tenant admin service account
+func findSecretNameOfSA(c client.Client, saName string) (string, error) {
+	var saSecretName string
+	secretList := corev1.SecretList{}
+	if err := c.List(context.TODO(), &client.ListOptions{}, &secretList); err != nil {
+		return "", err
+	}
+	for _, eachSecret := range secretList.Items {
+		//checks secret type and annotations
+		if v, ok := eachSecret.Annotations[corev1.ServiceAccountNameKey]; ok && strings.EqualFold(v, saName) && (eachSecret.Type == corev1.SecretTypeServiceAccountToken) {
+			saSecretName = eachSecret.Name
+			break
+		}
+	}
+
+	return saSecretName, nil
+}
+
+func getUniqueName(str, a string) string {
+	return fmt.Sprintf("%+v-%+v", str, a)
+}


### PR DESCRIPTION
Changes
1. Roles and Rolebindings are assigned by controllers to the tenant admin
2. Only tenant admin is allowed to create tenantnamespace whereas other SA not.

Currently to test above changes, used exisiting cluster

Tested: manually caused some conditions and verified that they were
reported correctly.