### PR TITLE
Add better HNC Config observability and fix flaky test

### DIFF
--- a/incubator/hnc/api/v1alpha1/hnc_config.go
+++ b/incubator/hnc/api/v1alpha1/hnc_config.go
@@ -68,6 +68,10 @@ type TypeSynchronizationStatus struct {
 	APIVersion string `json:"apiVersion,omitempty"`
 	// Kind to be configured.
 	Kind string `json:"kind,omitempty"`
+	// Mode describes the synchronization mode of the kind. Typically, it will be the same as the mode
+	// in the spec, except when the reconciler has fallen behind or when the mode is omitted from the
+	// spec and the default is chosen.
+	Mode SynchronizationMode `json:"mode,omitempty"`
 
 	// Tracks the number of objects that are being propagated to descendant namespaces. The propagated
 	// objects are created by HNC.

--- a/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
+++ b/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
@@ -108,6 +108,12 @@ spec:
                   kind:
                     description: Kind to be configured.
                     type: string
+                  mode:
+                    description: Mode describes the synchronization mode of the kind.
+                      Typically, it will be the same as the mode in the spec, except
+                      when the reconciler has fallen behind or when the mode is omitted
+                      from the spec and the default is chosen.
+                    type: string
                   numPropagatedObjects:
                     description: Tracks the number of objects that are being propagated
                       to descendant namespaces. The propagated objects are created

--- a/incubator/hnc/pkg/reconcilers/object.go
+++ b/incubator/hnc/pkg/reconcilers/object.go
@@ -144,7 +144,7 @@ func (r *ObjectReconciler) SetMode(ctx context.Context, mode api.Synchronization
 	if newMode == oldMode {
 		return nil
 	}
-	r.Log.Info("Changing mode of the object reconciler", "old", oldMode, "new", newMode)
+	log.Info("Changing mode of the object reconciler", "old", oldMode, "new", newMode)
 	r.Mode = newMode
 	// If the new mode is not "ignore", we need to update objects in the cluster
 	// (e.g., propagate or remove existing objects).


### PR DESCRIPTION
One of the HNC config observability tests was failing because we didn't
wait for the HNC config reconciler to pick up a change before verifying
that it was working:

* We changed a sync mode from "propagate" to "ignore"
* We created a new object
* We verified that this object wasn't created

Occasionally (about 1/4 of the time), the object reconciler would run before
the HNC config reconciler had a chance to change it to "ignore." The fix
is to add a "Mode" to the HNC Config status, so we can tell when the
reconciler has actually picked it up. This is also useful for when the
spec doesn't include an explicit mode.

This change also includes a few other minor improvements:

* If there's an extra HNC Config object, and we can't write it back due
to an apiserver error, retry the failure (previously we wouldn't retry).
* Fully deterministically sort the types in the Status (had only been
sorting by apiVersion)
* Added comments throughout
* Make the Gomega pattern matching more explicit for easier-to-read
tests and better error messages (e.g. when the sync mode is wrong, the
bad value will now be printed out)
* Other minor test improvements

Tested: ran `make test` 10x