### PR TITLE
Make allowCascadingDelete optional

### DIFF
--- a/incubator/hnc/api/v1alpha1/hierarchy_types.go
+++ b/incubator/hnc/api/v1alpha1/hierarchy_types.go
@@ -68,7 +68,7 @@ type HierarchyConfigurationSpec struct {
 
 	// AllowCascadingDelete indicates if the self-serve subnamespaces of this namespace are allowed
 	// to cascading delete.
-	AllowCascadingDelete bool `json:"allowCascadingDelete"`
+	AllowCascadingDelete bool `json:"allowCascadingDelete,omitempty"`
 }
 
 // HierarchyStatus defines the observed state of Hierarchy

--- a/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hierarchyconfigurations.yaml
+++ b/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hierarchyconfigurations.yaml
@@ -41,8 +41,6 @@ spec:
             parent:
               description: Parent indicates the parent of this namespace, if any.
               type: string
-          required:
-          - allowCascadingDelete
           type: object
         status:
           description: HierarchyStatus defines the observed state of Hierarchy


### PR DESCRIPTION
The default value is "false," so it's fine to leave it optional. This
also unbreaks the current HNS plugin.

TESTED: on a GKE cluster, couldn't call `k hns set --parent` without
this change, and call call it after this change.