### PR TITLE
Always sync objects to forest, even in namespaces with critical conditions

### DIFF
--- a/incubator/hnc/pkg/reconcilers/hnc_config_test.go
+++ b/incubator/hnc/pkg/reconcilers/hnc_config_test.go
@@ -13,7 +13,6 @@ import (
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 const (
@@ -503,14 +502,4 @@ func getNumPropagatedObjects(ctx context.Context, apiVersion, kind string) func(
 		}
 		return -1, errors.New(fmt.Sprintf("apiversion %s, kind %s is not found in status", apiVersion, kind))
 	}
-}
-
-// deleteObject deletes an object of the given kind in a specific namespace. The kind and
-// its corresponding GVK should be included in the GVKs map.
-func deleteObject(ctx context.Context, kind string, nsName, name string) {
-	inst := &unstructured.Unstructured{}
-	inst.SetGroupVersionKind(GVKs[kind])
-	inst.SetNamespace(nsName)
-	inst.SetName(name)
-	ExpectWithOffset(1, k8sClient.Delete(ctx, inst)).Should(Succeed())
 }

--- a/incubator/hnc/pkg/reconcilers/object_test.go
+++ b/incubator/hnc/pkg/reconcilers/object_test.go
@@ -129,6 +129,34 @@ var _ = Describe("Secret", func() {
 		Eventually(isModified(ctx, bazName, "foo-role")).Should(BeTrue())
 	})
 
+	It("should have deletions propagated after crit conditions are removed", func() {
+		// Create tree: bar -> foo (root) and make sure foo-role is propagated
+		setParent(ctx, barName, fooName)
+		Eventually(hasObject(ctx, "Role", barName, "foo-role")).Should(BeTrue())
+
+		// Create a critical condition on foo (and also bar by extension)
+		brumpfName := createNSName("brumpf")
+		fooHier := newOrGetHierarchy(ctx, fooName)
+		fooHier.Spec.Parent = brumpfName
+		updateHierarchy(ctx, fooHier)
+		Eventually(hasCondition(ctx, fooName, api.CritParentMissing)).Should(BeTrue())
+		Eventually(hasCondition(ctx, barName, api.CritAncestor)).Should(BeTrue())
+
+		// Delete the object from `foo`, wait until we're sure that it's gone, and then wait a while
+		// longer and verify it *isn't* deleted from `bar`, because the critical condition has paused
+		// deletions.
+		deleteObject(ctx, "Role", fooName, "foo-role")
+		Eventually(hasObject(ctx, "Role", fooName, "foo-role")).Should(BeFalse())
+		time.Sleep(1 * time.Second) // todo: merge with similar constants elsewhere
+		Expect(hasObject(ctx, "Role", barName, "foo-role")()).Should(BeTrue())
+
+		// Resolve the critical condition and verify that the object is deleted
+		fooHier = newOrGetHierarchy(ctx, fooName)
+		fooHier.Spec.Parent = ""
+		updateHierarchy(ctx, fooHier)
+		Eventually(hasObject(ctx, "Role", barName, "foo-role")).Should(BeFalse())
+	})
+
 	It("shouldn't propagate/delete if the namespace has Crit condition", func() {
 		// Set tree as baz -> bar -> foo(root).
 		setParent(ctx, barName, fooName)

--- a/incubator/hnc/pkg/reconcilers/test_helpers_test.go
+++ b/incubator/hnc/pkg/reconcilers/test_helpers_test.go
@@ -158,6 +158,16 @@ func makeObject(ctx context.Context, kind string, nsName, name string) {
 	ExpectWithOffset(1, k8sClient.Create(ctx, inst)).Should(Succeed())
 }
 
+// deleteObject deletes an object of the given kind in a specific namespace. The kind and
+// its corresponding GVK should be included in the GVKs map.
+func deleteObject(ctx context.Context, kind string, nsName, name string) {
+	inst := &unstructured.Unstructured{}
+	inst.SetGroupVersionKind(GVKs[kind])
+	inst.SetNamespace(nsName)
+	inst.SetName(name)
+	ExpectWithOffset(1, k8sClient.Delete(ctx, inst)).Should(Succeed())
+}
+
 // objectInheritedFrom returns the name of the namespace where a specific object of a given kind
 // is propagated from or an empty string if the object is not a propagated object. The kind and
 // its corresponding GVK should be included in the GVKs map.


### PR DESCRIPTION
See #347. When an object is removed, we need to remove it from the
in-memory forest even when the object is in a namespace with a critical
condition, because when the condition is resolved, we'll use the forest
to re-sync all descendants of that namespace, and if the forest has
stale objects in it, the propagated copies won't be removed.

Added several other cleanups including:

* Made several names more unique so they can be more easily searched
(e.g. replaced `delete()` with `deleteObject()`)
* Factored out a new syncMissingObject() functionout of Reconcile()
* Some cosmetic renames plus a bunch of longer comments

TESTED: new integ test fails without the fix and works with it; also
tested manually on GKE.