### PR TITLE
Address #333. Fail a release on duplicate image and tag

### DIFF
--- a/incubator/hnc/Makefile
+++ b/incubator/hnc/Makefile
@@ -17,6 +17,13 @@ ifeq ($(CONFIG),kind)
 HNC_IMG ?= controller:kind-local
 else
 HNC_IMG ?= "gcr.io/${PROJECT_ID}/hnc/controller:${HNC_IMG_TAG}"
+# We don't want to overwrite an existing docker image and tag so we query the repository
+# to see if the image already exists. This can be overridden by setting FORCE_RELEASE=true
+ifeq ($(FORCE_RELEASE), true)
+	IMG_READ_ERROR=1
+else
+	IMG_READ_ERROR=$(shell gcloud container images describe $(HNC_IMG) > /dev/null 2>&1; echo $$?)
+endif
 endif
 
 HNC_RELEASED_IMG ?= "gcr.io/k8s-staging-multitenancy/hnc/controller:${HNC_IMG_TAG}"
@@ -198,6 +205,9 @@ ifndef HNC_PAT
 endif
 ifndef HNC_RELEASE_ID
 	$(error HNC_RELEASE_ID is undefined; ${ERR_MSG})
+endif
+ifeq ($(IMG_READ_ERROR), 0)
+	$(error The image ${HNC_IMG} already exists. Force and overwrite this image by using FORCE_RELEASE=true)
 endif
 	@echo "*********************************************"
 	@echo "*********************************************"

--- a/incubator/hnc/README.md
+++ b/incubator/hnc/README.md
@@ -196,7 +196,7 @@ Within the `reconcilers` directory, there are three reconcilers:
 
 1. Ensure you have a Personal Access Token from Github with permissions to write
    to the repo, and
-   [permisison]((https://github.com/kubernetes/k8s.io/blob/master/groups/groups.yaml#L566))
+   [permission](https://github.com/kubernetes/k8s.io/blob/master/groups/groups.yaml#L566)
    to access `k8s-staging-multitenancy`'s GCR.
 
 2. Set the following environment variables:


### PR DESCRIPTION
Do not allow overwriting of an image and tag if it already exists in the
repository. This prevents us from being able to overwrite released
images. Pass in FORCE_RELEASE=true to override this behavior.