### PR TITLE
Replace ns.Owner with ns.IsOwned in the forest

### DIFF
--- a/incubator/hnc/pkg/forest/forest.go
+++ b/incubator/hnc/pkg/forest/forest.go
@@ -168,11 +168,9 @@ type Namespace struct {
 	// on this namespace.
 	conditions conditions
 
-	// Todo remove Owner field or replace it with isOwned bool field. See issue:
-	//  https://github.com/kubernetes-sigs/multi-tenancy/issues/552
-	// Owner indicates that this namespace is being or was created solely to live as a
+	// IsOwned indicates that this namespace is being or was created solely to live as a
 	// subnamespace of the specified parent.
-	Owner string
+	IsOwned bool
 
 	// HNSes store a list of HNS instances in the namespace.
 	HNSes []string


### PR DESCRIPTION
Since we only use subnamespace owner annotation as source of truth and
always set parent to the owner in HCR, ns.Owner string field is not
necessary and a ns.IsOwned bool field is enough.

Tested with 'make test' and manually tested the webhook of changing an
owned namespace's parent on GKE cluster.

Part of #457 
Fixes #552 