### PR TITLE
Set object conditions atomically (#326)

### DIFF
--- a/incubator/hnc/pkg/reconcilers/hierarchy_config.go
+++ b/incubator/hnc/pkg/reconcilers/hierarchy_config.go
@@ -409,13 +409,13 @@ func (r *HierarchyConfigReconciler) writeHierarchy(ctx context.Context, log logr
 
 	stats.WriteHierConfig()
 	if inst.CreationTimestamp.IsZero() {
-		log.Info("Creating singleton on apiserver")
+		log.Info("Creating singleton on apiserver", "conditions", len(inst.Status.Conditions))
 		if err := r.Create(ctx, inst); err != nil {
 			log.Error(err, "while creating on apiserver")
 			return false, err
 		}
 	} else {
-		log.Info("Updating singleton on apiserver")
+		log.Info("Updating singleton on apiserver", "conditions", len(inst.Status.Conditions))
 		if err := r.Update(ctx, inst); err != nil {
 			log.Error(err, "while updating apiserver")
 			return false, err


### PR DESCRIPTION
The object reconciler locks the forest twice: once when determining what
to do with an object (i.e. propagate or delete it), and once after the
propagation/deletion has been attempted so we can update the condition.
Prior to this change, we cleared all conditions associated with an
object during the first lock, and set them (if necessary) during the
second lock.

Unfortunately, in cases where objects failed to be propagated, this set
up neverending spin loop:

1. During the first lock, we'd clear the condition. Because the
conditions changed, we'd re-enqueue the HC reconciler.
2. If the HCR managed to run before the second lock was acquired (which
was usually the case), it would see that its conditions had changed and
update the HC.
3. During the second lock, we'd put the object condition back to what it
was before, also re-enqueng the HCR since it looks like another
condition change.
4. HCR would run again, update the HC, and re-enqueue all local objects
to be reconciled again, including this one (it also did this in step 2,
but that's not as relevant).

This led to three consequences:
* The HC was constantly changing, making it hard for clients like
`kubectl hns set` to modify it successfully.
* The conditions appeared to keep appearing and disappearing.
* Spinlocks are probably a bad idea as they DOS the apiserver.

This new change updates the object reconciler to _never_ modify the
conditions during the first lock, only the second. This ensures that we
only modify the conditions if we absolutely have to.

Tested: while this issue was previously known as a theoretical
possibility, it became an impedement to testing and fixing #328. I
developed both fixes together but am submitting them as separate PRs.
Without this fix, my test script for #328 (plus the fix) sometimes fails
because we can't update the hierarchy, sometimes fails because the
conditions aren't present or cleared correctly, and the logs always show
HNC spinning. With this change, the fix for #328 works every time and
the logs show that HNC is not spinning.