### PR TITLE
Capitalize help usage and make more clear

### DIFF
--- a/incubator/hnc/pkg/kubectl/create.go
+++ b/incubator/hnc/pkg/kubectl/create.go
@@ -23,7 +23,7 @@ import (
 )
 
 var createCmd = &cobra.Command{
-	Use:   "create -n parent child",
+	Use:   "create -n PARENT CHILD",
 	Short: "Creates a subnamespace under the given parent.",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/incubator/hnc/pkg/kubectl/describe.go
+++ b/incubator/hnc/pkg/kubectl/describe.go
@@ -24,7 +24,7 @@ import (
 )
 
 var describeCmd = &cobra.Command{
-	Use:   "describe",
+	Use:   "describe NAMESPACE",
 	Short: "Displays information about the hierarchy configuration",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/incubator/hnc/pkg/kubectl/set.go
+++ b/incubator/hnc/pkg/kubectl/set.go
@@ -33,7 +33,7 @@ type hcUpdates struct {
 }
 
 var setCmd = &cobra.Command{
-	Use:   "set <namespace>",
+	Use:   "set NAMESPACE",
 	Short: "Sets hierarchical properties of the given namespace",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/incubator/hnc/pkg/kubectl/tree.go
+++ b/incubator/hnc/pkg/kubectl/tree.go
@@ -34,7 +34,7 @@ var (
 )
 
 var treeCmd = &cobra.Command{
-	Use:   "tree",
+	Use:   "tree TREE",
 	Short: "Display one or more hierarchy trees",
 	Run: func(cmd *cobra.Command, args []string) {
 		flags := cmd.Flags()


### PR DESCRIPTION
The captilization helps align it better to kubectl help usage
documentation