### PR TITLE
HNC: Change condition codes to CamelCase strings.

### DIFF
--- a/incubator/hnc/api/v1alpha1/hierarchy_types.go
+++ b/incubator/hnc/api/v1alpha1/hierarchy_types.go
@@ -37,15 +37,13 @@ const (
 )
 
 // Condition codes. *All* codes must also be documented in the comment to Condition.Code.
-// TODO change condition codes to CamelCase strings. See issue:
-//  https://github.com/kubernetes-sigs/multi-tenancy/issues/500
 const (
-	CritParentMissing Code = "CRIT_PARENT_MISSING"
-	CritParentInvalid Code = "CRIT_PARENT_INVALID"
-	CritAncestor      Code = "CRIT_ANCESTOR"
-	HNSMissing        Code = "HNS_MISSING"
-	CannotUpdate      Code = "CANNOT_UPDATE_OBJECT"
-	CannotPropagate   Code = "CANNOT_PROPAGATE_OBJECT"
+	CritParentMissing Code = "CritParentMissing"
+	CritParentInvalid Code = "CritParentInvalid"
+	CritAncestor      Code = "CritAncestor"
+	HNSMissing        Code = "HNSMissing"
+	CannotUpdate      Code = "CannotUpdateObject"
+	CannotPropagate   Code = "CannotPropagateObject"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/incubator/hnc/api/v1alpha1/hnc_config.go
+++ b/incubator/hnc/api/v1alpha1/hnc_config.go
@@ -45,9 +45,9 @@ const (
 // HNCConfigurationCondition codes. *All* codes must also be documented in the
 // comment to HNCConfigurationCondition.Code.
 const (
-	CritSingletonNameInvalid         HNCConfigurationCode = "critSingletonNameInvalid"
-	ObjectReconcilerCreationFailed   HNCConfigurationCode = "objectReconcilerCreationFailed"
-	MultipleConfigurationsForOneType HNCConfigurationCode = "multipleConfigurationsForOneType"
+	CritSingletonNameInvalid         HNCConfigurationCode = "CritSingletonNameInvalid"
+	ObjectReconcilerCreationFailed   HNCConfigurationCode = "ObjectReconcilerCreationFailed"
+	MultipleConfigurationsForOneType HNCConfigurationCode = "MultipleConfigurationsForOneType"
 )
 
 // TypeSynchronizationSpec defines the desired synchronization state of a specific kind.


### PR DESCRIPTION
fixes #500 

Tested: I added lines like:
```go
fmt.Println(string(api.CritParentMissing))
```
in cmd/manager/main.go to check if the condition code is printed in initial-capitalized CameCase string.