### PR TITLE
Add a kubectl command to set the HNC configuration of a specific type

### DIFF
--- a/incubator/hnc/pkg/kubectl/config.go
+++ b/incubator/hnc/pkg/kubectl/config.go
@@ -31,4 +31,5 @@ func newConfigCmd() *cobra.Command {
 func init() {
 	configCmd.AddCommand(newConfigDescribeCmd())
 	configCmd.AddCommand(newConfigDeleteCmd())
+	configCmd.AddCommand(newSetTypeCmd())
 }

--- a/incubator/hnc/pkg/kubectl/configset.go
+++ b/incubator/hnc/pkg/kubectl/configset.go
@@ -1,0 +1,69 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+)
+
+var setTypeCmd = &cobra.Command{
+	Use: fmt.Sprintf("set-type --apiVersion X --kind Y <%s|%s|%s>",
+		api.Propagate, api.Remove, api.Ignore),
+	Short: "Sets the HNC configuration of a specific resources type",
+	Example: fmt.Sprintf("  # Set configuration of a core type\n" +
+		"  kubectl hns config set-type --apiVersion v1 --kind Secret ignore\n\n" +
+		"  # Set configuration of a custom type\n" +
+		"  kubectl hns config set-type --apiversion stable.example.com/v1 --kind CronTab propagate"),
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		mode := api.SynchronizationMode(args[0])
+		flags := cmd.Flags()
+		apiVersion, _ := flags.GetString("apiVersion")
+		kind, _ := flags.GetString("kind")
+		config := client.getHNCConfig()
+
+		exist := false
+		for i := 0; i < len(config.Spec.Types); i++ {
+			t := &config.Spec.Types[i]
+			if t.APIVersion == apiVersion && t.Kind == kind {
+				t.Mode = mode
+				exist = true
+				break
+			}
+		}
+
+		if !exist {
+			config.Spec.Types = append(config.Spec.Types,
+				api.TypeSynchronizationSpec{
+					APIVersion: apiVersion,
+					Kind:       kind,
+					Mode:       mode,
+				})
+		}
+
+		client.updateHNCConfig(config)
+	},
+}
+
+func newSetTypeCmd() *cobra.Command {
+	setTypeCmd.Flags().String("apiVersion", "", "API version of the kind")
+	setTypeCmd.Flags().String("kind", "", "Kind to be configured")
+	return setTypeCmd
+}

--- a/incubator/hnc/pkg/validators/hierarchy.go
+++ b/incubator/hnc/pkg/validators/hierarchy.go
@@ -381,13 +381,26 @@ func deny(reason metav1.StatusReason, msg string) admission.Response {
 			},
 		}}
 	} else {
-		// metav1.StatusReasonInvalid shows the custom message in the Details field instead of
-		// Message field of metav1.Status.
+		// We need to set the custom message in both Details and Message fields.
+		//
+		// When manipulating the HNC configuration object via kubectl directly, kubectl
+		// ignores the Message field and displays the Details field if an error is
+		// StatusReasonInvalid (see implementation here: https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/util/helpers.go#L145-L160).
+		//
+		// When manipulating the HNC configuration object via the hns kubectl plugin,
+		// if an error is StatusReasonInvalid, only the Message field will be displayed. This is because
+		// the Error method (https://github.com/kubernetes/client-go/blob/cb664d40f84c27bee45c193e4acb0fcd549b0305/rest/request.go#L1273)
+		// calls FromObject (https://github.com/kubernetes/apimachinery/blob/7e441e0f246a2db6cf1855e4110892d1623a80cf/pkg/api/errors/errors.go#L100),
+		// which generates a StatusError (https://github.com/kubernetes/apimachinery/blob/7e441e0f246a2db6cf1855e4110892d1623a80cf/pkg/api/errors/errors.go#L35) object.
+		// *StatusError implements the Error interface using only the Message
+		// field (https://github.com/kubernetes/apimachinery/blob/7e441e0f246a2db6cf1855e4110892d1623a80cf/pkg/api/errors/errors.go#L49)).
+		// Therefore, when displaying the error, only the Message field will be available.
 		return admission.Response{AdmissionResponse: admissionv1beta1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
-				Code:   codeFromReason(reason),
-				Reason: reason,
+				Code:    codeFromReason(reason),
+				Reason:  reason,
+				Message: msg,
 				Details: &metav1.StatusDetails{
 					Causes: []metav1.StatusCause{
 						{


### PR DESCRIPTION
This PR adds a kubectl command to set the HNC configuration of a specific type. Specifically it implements the following features:
- If the type exists in the spec, it will update the configuration of the type. 
- If the type does not exist in the spec, it will add the configuration in the spec.

Example usage: `kubectl hns config --apiVersion v1 --kind Secret ignore`

Issue: #454

