### PR TITLE
Flush obsolete conditions when tree changes (#328)

### DIFF
--- a/incubator/hnc/hack/test-issue-328.sh
+++ b/incubator/hnc/hack/test-issue-328.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# See https://github.com/kubernetes-sigs/multi-tenancy/issues/328
+
+echo "----------------------------------------------------"
+echo "Trying to clean up from last run (this may fail, and that's fine)"
+kubectl delete ns parent-328 child-328
+
+# Set up namespace structure
+echo "----------------------------------------------------"
+echo "Setting up hierarchy with rolebinding that HNC doesn't have permission to copy"
+kubectl create ns parent-328
+kubectl create ns child-328
+sleep 1
+kubectl hns set child-328 --parent parent-328
+# cluster-admin is the highest-powered ClusterRole and HNC is missing some of
+# its permissions, so it cannot propagate it.
+kubectl create rolebinding cluster-admin-rb \
+  -n parent-328 \
+  --clusterrole='cluster-admin' \
+  --serviceaccount='parent-328:default'
+echo "Waiting 2s..."
+sleep 2
+
+echo "----------------------------------------------------"
+echo "Tree should show CannotPropagateObject in 'parent-328' and CannotUpdateObject in 'child-328'"
+kubectl hns tree parent-328
+
+# Remove the child and verify that the condition is gone
+echo "----------------------------------------------------"
+echo "Removing the child and verifying that the condition is gone"
+kubectl hns set child-328 --root
+echo "Waiting 2s..."
+sleep 2
+
+echo "----------------------------------------------------"
+echo "There should no longer be any conditions in 'parent-328'"
+kubectl hns describe parent-328
+
+echo "----------------------------------------------------"
+echo "There should no longer be any conditions in 'child-328'"
+kubectl hns describe child-328
+
+echo "----------------------------------------------------"
+echo "Cleaning up"
+kubectl delete ns parent-328 child-328

--- a/incubator/hnc/pkg/forest/forest.go
+++ b/incubator/hnc/pkg/forest/forest.go
@@ -499,6 +499,27 @@ func (ns *Namespace) ClearLocalCondition(code api.Code) bool {
 	return ns.ClearCondition(api.AffectedObject{}, code)
 }
 
+// ClearConditionsByNamespace accepts a set of namespace names, and clears any condition that
+// matches those names. It's only used to flush obsolete object conditions.
+//
+// This is a bit ugly but I'm not sure what the better answer is.
+func (ns *Namespace) ClearConditionsByNamespace(log logr.Logger, nses map[string]bool) bool {
+	if len(nses) == 0 {
+		return false
+	}
+	found := false
+	for obj := range ns.conditions {
+		if nses[obj.Namespace] {
+			found = true
+			for code := range ns.conditions[obj] {
+				log.Info("Cleared conditions by namespace", "on", ns.name, "obj", obj.String(), "code", code)
+			}
+			delete(ns.conditions, obj)
+		}
+	}
+	return found
+}
+
 // ClearConditionsByCode clears all conditions of a given code from this namespace across all
 // objects. It should only be called by the code that also *sets* the condition.
 //


### PR DESCRIPTION
This changes ensures that any conditions on ancestor namespaces caused
by objects in their descendants are removed if a child namespace is
removed from its hierarchy. Without this change, no reconciler will ever
attempt to remove the CANNOT_PROPAGATE_OBJECT condition from an
ancestor, and it will incorrectly sit on the (old) ancestor namespace
until HNC is restarted.

I initially tried to fix this by having the object reconciler determine
from scratch whether it was needed, by searching the forest for all
possible copies of the source object and looking for conditions. But I
found that approach to be overly confusing and it still needed to be
triggered in a variety of ways.

I don't really love the fact that most of the code here is in
hierarchy_config.go; it would be more natural to put it in object.go.
But I'm not sure exactly how I'd trigger it. For now, I'd rather simply
submit this fix, and then make incremental improvements later if anyone
gets any bright ideas.

Tested: hack/test-issue-328.sh. I wasn't able to induce this kind of
situation in the integ tests, because HNC has full permissions in those
tests, unlike on a real cluster where it runs with its own more
restrictive service account. The new script fails without this fix and
passes with it; it works even better when #326 is fixed as well, but I'm
submitting that in a separate PR.

Fixes #328