### PR TITLE
[Incubator][VC]Add uid check for pv update and periodic check

### DIFF
--- a/incubator/virtualcluster/config/setup/all_in_one.yaml
+++ b/incubator/virtualcluster/config/setup/all_in_one.yaml
@@ -240,6 +240,7 @@ rules:
     - delete
 - apiGroups:
     - ""
+    - storage.k8s.io
   resources:
     - events
     - nodes

--- a/incubator/virtualcluster/config/setup/all_in_one_aliyun.yaml
+++ b/incubator/virtualcluster/config/setup/all_in_one_aliyun.yaml
@@ -241,6 +241,7 @@ rules:
     - delete
 - apiGroups:
     - ""
+    - storage.k8s.io
   resources:
     - events
     - nodes

--- a/incubator/virtualcluster/pkg/syncer/conversion/helper.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/helper.go
@@ -187,8 +187,8 @@ func BuildVirtualStorageClass(cluster string, pStorageClass *storagev1.StorageCl
 }
 
 func BuildVirtualPersistentVolume(cluster string, pPV *v1.PersistentVolume, vPVC *v1.PersistentVolumeClaim) *v1.PersistentVolume {
-	vPV := pPV.DeepCopy()
-	ResetMetadata(vPV)
+	vPVobj, _ := BuildMetadata(cluster, "", pPV)
+	vPV := vPVobj.(*v1.PersistentVolume)
 	// The pv needs to bind with the vPVC
 	vPV.Spec.ClaimRef.Namespace = vPVC.Namespace
 	vPV.Spec.ClaimRef.UID = vPVC.UID

--- a/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/uws.go
@@ -147,6 +147,10 @@ func (c *controller) backPopulate(key string) error {
 	}
 
 	vPV := vPVObj.(*v1.PersistentVolume)
+	if vPV.Annotations[constants.LabelUID] != string(pPV.UID) {
+		return fmt.Errorf("vPV %s in cluster %s delegated UID is different from pPV.", vPV.Name, clusterName)
+	}
+
 	// We only update PV.Spec, PV.Status is managed by tenant/super pv binder controller independently.
 	updatedPVSpec := conversion.Equality(nil).CheckPVSpecEquality(&pPV.Spec, &vPV.Spec)
 	if updatedPVSpec != nil {


### PR DESCRIPTION
This change ensures that PV spec is updated to the correct PV in tenant by checking the uid.
Also checker will delete a vPV if its uid is not equal to the pPV uid even if their names are the same.

This change also fixes the rbac rules for storageclass resource. 
