### PR TITLE
Clean up created objects in tests

### DIFF
--- a/incubator/hnc/pkg/reconcilers/hnc_config_test.go
+++ b/incubator/hnc/pkg/reconcilers/hnc_config_test.go
@@ -48,6 +48,9 @@ var _ = Describe("HNCConfiguration", func() {
 	)
 
 	BeforeEach(func() {
+		// We want to ensure we're working with a clean slate, in case a previous tests objects still exist
+		cleanupObjects(ctx)
+
 		fooName = createNS(ctx, "foo")
 		barName = createNS(ctx, "bar")
 	})
@@ -57,6 +60,7 @@ var _ = Describe("HNCConfiguration", func() {
 		Eventually(func() error {
 			return resetHNCConfigToDefault(ctx)
 		}).Should(Succeed())
+		cleanupObjects(ctx)
 	})
 
 	It("should set mode of Roles and RoleBindings as propagate by default", func() {

--- a/incubator/hnc/pkg/reconcilers/object_test.go
+++ b/incubator/hnc/pkg/reconcilers/object_test.go
@@ -27,6 +27,9 @@ var _ = Describe("Secret", func() {
 		barName = createNS(ctx, "bar")
 		bazName = createNS(ctx, "baz")
 
+		// We want to ensure we're working with a clean slate, in case a previous tests objects still exist
+		cleanupObjects(ctx)
+
 		// Give them each a role.
 		makeObject(ctx, "Role", fooName, "foo-role")
 		makeObject(ctx, "Role", barName, "bar-role")
@@ -38,6 +41,7 @@ var _ = Describe("Secret", func() {
 		Eventually(func() error {
 			return resetHNCConfigToDefault(ctx)
 		}).Should(Succeed())
+		cleanupObjects(ctx)
 	})
 
 	It("should be copied to descendents", func() {


### PR DESCRIPTION
This addresses issue #586. This is to ensure that objects created in one
test case will not affect objects in another test case.

TESTED: Ran the tests through 10 times via go test ./pkg/reconcilers/...