### PR TITLE
Rename kubectl-hierarchical_namespaces to kubectl-hns

### DIFF
--- a/incubator/hnc/Makefile
+++ b/incubator/hnc/Makefile
@@ -35,7 +35,7 @@ CRD_OPTIONS ?= "crd:trivialVersions=true"
 GOBIN ?= $(shell go env GOPATH)/bin
 
 # Get check sum value of krew archive
-KREW_CKSM=$(shell sha256sum bin/kubectl-hierarchical_namespaces.tar.gz | cut -d " " -f 1)
+KREW_CKSM=$(shell sha256sum bin/kubectl-hns.tar.gz | cut -d " " -f 1)
 
 all: test docker-build
 
@@ -48,20 +48,18 @@ test: build
 # Builds all binaries (manager and kubectl) and manifests
 build: generate fmt vet manifests
 	go build -o bin/manager ./cmd/manager/main.go
-	go build -o bin/kubectl/kubectl-hierarchical_namespaces ./cmd/kubectl/main.go
+	go build -o bin/kubectl/kubectl-hns ./cmd/kubectl/main.go
 
 # Clean all binaries (manager and kubectl)
 clean: krew-uninstall
 	-rm -rf bin/*
 	-rm -rf manifests/*
-	-rm -f ${GOPATH}/bin/kubectl-hierarchical_namespaces
+	-rm -f ${GOPATH}/bin/kubectl-hns
 	-rm -f ${GOPATH}/bin/kubectl-hns
 
 # Install kubectl plugin
 kubectl: build
-	cp bin/kubectl/kubectl-hierarchical_namespaces ${GOPATH}/bin/kubectl-hierarchical_namespaces
-	ln -fs ${GOPATH}/bin/kubectl-hierarchical_namespaces ${GOPATH}/bin/kubectl-hns
-	@echo "Installed kubectl-hierarchical_namespaces and kubectl-hns to GOPATH/bin"
+	cp bin/kubectl/kubectl-hns ${GOPATH}/bin/kubectl-hns
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: build
@@ -77,11 +75,11 @@ krew-build: krew-tar
 
 # Install kubectl plugin locally using krew.
 krew-install: krew-build
-	kubectl krew install --manifest=manifests/krew-hierarchical-namespaces.yaml --archive=bin/kubectl-hierarchical_namespaces.tar.gz
+	kubectl krew install --manifest=manifests/krew-hierarchical-namespaces.yaml --archive=bin/kubectl-hns.tar.gz
 
 # Make krew archive and put into /hack
 krew-tar: build
-	tar -zcvf bin/kubectl-hierarchical_namespaces.tar.gz bin/kubectl
+	tar -zcvf bin/kubectl-hns.tar.gz bin/kubectl
 
 # Uninstall krew
 krew-uninstall:

--- a/incubator/hnc/README.md
+++ b/incubator/hnc/README.md
@@ -46,10 +46,15 @@ kubectl apply -f https://github.com/kubernetes-sigs/multi-tenancy/releases/downl
 
 # Download kubectl plugin (Linux only) - will move to Krew soon
 PLUGIN_DIR=<directory where you keep your plugins - just has to be on your PATH>
+
+# Instructions for hnc-v0.2.0 and before
 curl -L https://github.com/kubernetes-sigs/multi-tenancy/releases/download/hnc-${HNC_VERSION}/kubectl-hierarchical_namespaces -o ${PLUGIN_DIR}/kubectl-hierarchical_namespaces
-chmod +x ${PLUGIN_DIR}/kubectl-hierarchical_namespaces
-# If desired to make 'kubectl hns' work:
+chmod +x ${PLUGIN_DIR}/kubectl-hierarchical_namespaces	
 ln -s ${PLUGIN_DIR}/kubectl-hierarchical_namespaces ${PLUGIN_DIR}/kubectl-hns
+
+# Instructions for hnc-v0.3.0 and later
+curl -L https://github.com/kubernetes-sigs/multi-tenancy/releases/download/hnc-${HNC_VERSION}/kubectl-hns -o ${PLUGIN_DIR}/kubectl-hns
+chmod +x ${PLUGIN_DIR}/kubectl-hns
 ```
 
 ### Getting started and learning more
@@ -79,6 +84,7 @@ is no need to uninstall HNC before upgrading it.
 
 ```bash
 rm ${PLUGIN_DIR}/kubectl-hns
+# hnc-v0.2.0 and before only, noop for hnc-v0.3.0 and after
 rm ${PLUGIN_DIR}/kubectl-hierarchical_namespaces
 kubectl delete -f https://github.com/kubernetes-sigs/multi-tenancy/releases/download/hnc-${HNC_VERSION}/hnc-manager.yaml
 # Don't need to delete the cert manager if you plan to reinstall it later.
@@ -137,9 +143,10 @@ To deploy to a cluster:
       so and then try again. The certificate manager takes a few moments for its
       webhook to become available. This should only happen the first time you
       deploy this way, or if we change the recommended version of cert-manager.
-    - This will also install the `kubectl-hierarchical_namespaces` plugin into
-      `$GOPATH/bin` (as well as its alias, `kubectl-hns`), so make sure that's
+    - For v0.2.0 and before, this will also install the `kubectl-hierarchical_namespaces` 
+      plugin into `$GOPATH/bin` (as well as its alias, `kubectl-hns`), so make sure that's
       in your path if you want to use commands like `kubectl hns tree`.
+    - For v0.3.0 and after, this will install the `kubectl-hns` plugin into `$GOPATH/bin`
     - The manifests that get deployed will be output to
       `/manifests/hnc-controller.yaml` if you want to check them out.
   - To view logs, say `make deploy-watch`

--- a/incubator/hnc/cloudbuild.yaml
+++ b/incubator/hnc/cloudbuild.yaml
@@ -30,7 +30,7 @@ steps:
     kustomize build . -o ./hnc-manager.yaml
 
     # Build plugin
-    go build -o kubectl-hierarchical_namespaces ../cmd/kubectl/main.go
+    go build -o kubectl-hns ../cmd/kubectl/main.go
 # Upload manifest
 - name: gcr.io/cloud-builders/curl
   args:
@@ -51,10 +51,10 @@ steps:
   - '-H'
   - 'Content-Type: application/x-application'
   - '--data-binary'
-  - '@multi-tenancy/incubator/hnc/out/kubectl-hierarchical_namespaces'
+  - '@multi-tenancy/incubator/hnc/out/kubectl-hns'
   - '-u'
   - '$_HNC_USER:$_HNC_PERSONAL_ACCESS_TOKEN'
-  - 'https://uploads.github.com/repos/kubernetes-sigs/multi-tenancy/releases/$_HNC_RELEASE_ID/assets?name=kubectl-hierarchical_namespaces'
+  - 'https://uploads.github.com/repos/kubernetes-sigs/multi-tenancy/releases/$_HNC_RELEASE_ID/assets?name=kubectl-hns'
 # Build Docker image
 - name: gcr.io/cloud-builders/docker
   args: ['build', '-t', 'gcr.io/$PROJECT_ID/hnc/controller:$_HNC_IMG_TAG', 'multi-tenancy/incubator/hnc']

--- a/incubator/hnc/hack/krew-hierarchical-namespaces.yaml
+++ b/incubator/hnc/hack/krew-hierarchical-namespaces.yaml
@@ -18,6 +18,6 @@ spec:
           arch: amd64
       sha256: --- will be populated by make krew-build ---
       files:
-        - from: "bin/kubectl/kubectl-hierarchical_namespaces"
+        - from: "bin/kubectl/kubectl-hns"
           to: "."
-      bin: "./kubectl-hierarchical_namespaces"
+      bin: "./kubectl-hns"


### PR DESCRIPTION
Issue #594.

TESTED: ran `make release` all the way to the point to publish to
k8s-staging-multitenancy, but I didn't have permissions to push there