### PR TITLE
[Incubator][VC] Using the signature of the tenant apiserver certificate to identify the request sender

### DIFF
--- a/incubator/virtualcluster/config/setup/all_in_one.yaml
+++ b/incubator/virtualcluster/config/setup/all_in_one.yaml
@@ -338,6 +338,14 @@ rules:
   - get
   - list
   - create
+- apiGroups:
+  - tenancy.x-k8s.io
+  resources:
+  - virtualclusters
+  - virtualclusters/status
+  verbs:
+  - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/incubator/virtualcluster/pkg/controller/constants/constants.go
+++ b/incubator/virtualcluster/pkg/controller/constants/constants.go
@@ -1,0 +1,5 @@
+package constants
+
+const (
+	AnnoX509SignatureBase64 = "tenancy.x-k8s.io/apiserver.sig"
+)

--- a/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner.go
+++ b/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner.go
@@ -17,11 +17,14 @@ limitations under the License.
 package virtualcluster
 
 import (
+	"crypto/x509"
+
 	tenancyv1alpha1 "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
 )
 
 type MasterProvisioner interface {
 	CreateVirtualCluster(vc *tenancyv1alpha1.Virtualcluster) error
 	DeleteVirtualCluster(vc *tenancyv1alpha1.Virtualcluster) error
+	GetClusterCertificate(vc *tenancyv1alpha1.Virtualcluster) (*x509.Certificate, error)
 	GetMasterProvisioner() string
 }

--- a/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_aliyun.go
+++ b/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_aliyun.go
@@ -18,6 +18,7 @@ package virtualcluster
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -562,6 +563,12 @@ PollASK:
 	}
 	log.Info("the node selector service account is deleted", "vc", vc.GetName())
 	return nil
+}
+
+// TODO GetClusterCertificate gets the tenant apiserver's certificate by sending a basic GET request and extract
+// the certificate from the TLSConnection
+func (mpa *MasterProvisionerAliyun) GetClusterCertificate(vc *tenancyv1alpha1.Virtualcluster) (*x509.Certificate, error) {
+	return nil, nil
 }
 
 // DeleteVirtualCluster deletes the ASK cluster corresponding to the given Virtualcluster


### PR DESCRIPTION
Using the signature of the tenant apiserver certificate to identify the sender of a request received by vn-agent

1. add the annotation of the certificate's signature to VC CR after it
is created.
2. when receiving a request, vn-agent extracts the signature from the
client certificate and find the VC that has the same signature.
4. implement the `GetClusterCertificate` function for
`master_provisioner_native`
3. add RBAC rights to vn-agent-role for accessing virtualcluster CR