### PR TITLE
[Incubator][VC]Fix a few checker bugs.

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/checker.go
@@ -134,9 +134,7 @@ func (c *controller) checkPersistentVolumeOfTenantCluster(clusterName string) {
 				klog.Errorf("Removed pv %s in cluster %s is bound to a pvc", vPV.Name, clusterName)
 			}
 
-		}
-
-		if vPV.Annotations[constants.LabelUID] != string(pPV.UID) {
+		} else if vPV.Annotations[constants.LabelUID] != string(pPV.UID) {
 			klog.Errorf("Found vPV %s in cluster %s delegated UID is different from super master object.", vPV.Name, clusterName)
 			shouldDelete = true
 		}


### PR DESCRIPTION
This change fixes a few checker bugs:
1) pPV can be nil, which can cause a crash. 
2) If Pod spec missmatches, the remediation should be requeuing in dws.
3) If service spec missmatches, the remediation should be requeuing in dws.