### PR TITLE
[Incubator][VC]Restructure syncer namespace mock test

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/manager/manager.go
+++ b/incubator/virtualcluster/pkg/syncer/manager/manager.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/listener"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
 )
 
 // ControllerManager manages number of controllers. It starts their caches, waits for those to sync,
@@ -40,6 +41,7 @@ type Controller interface {
 	StartUWS(stopCh <-chan struct{}) error
 	StartDWS(stopCh <-chan struct{}) error
 	StartPeriodChecker(stopCh <-chan struct{}) error
+	Reconcile(request reconciler.Request) (reconciler.Result, error)
 }
 
 // AddController adds a controller to the ControllerManager.

--- a/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
+++ b/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -74,6 +74,9 @@ type Options struct {
 
 	// Queue can be used to override the default queue.
 	Queue workqueue.RateLimitingInterface
+
+	// A Fake controller is created for testing purpose.
+	IsFake bool
 }
 
 // Cache is the interface used by Controller to start and wait for caches to sync.

--- a/incubator/virtualcluster/pkg/syncer/resources/namespace/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/namespace/dws.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -39,10 +39,6 @@ func (c *controller) StartDWS(stopCh <-chan struct{}) error {
 
 // The reconcile logic for tenant master namespace informer
 func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
-	return c.reconcileHandler(request)
-}
-
-func (c *controller) reconcile(request reconciler.Request) (reconciler.Result, error) {
 	klog.V(4).Infof("reconcile namespace %s for cluster %s", request.Name, request.ClusterName)
 	targetNamespace := conversion.ToSuperMasterNamespace(request.ClusterName, request.Name)
 	pNamespace, err := c.nsLister.Get(targetNamespace)

--- a/incubator/virtualcluster/pkg/syncer/resources/namespace/dws_test.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/namespace/dws_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,28 +17,20 @@ limitations under the License.
 package namespace
 
 import (
-	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
-	fakeClient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/cluster"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/util/test"
 )
-
-var alwaysReady = func() bool { return true }
 
 func tenantNamespace(name, uid string) *v1.Namespace {
 	return &v1.Namespace{
@@ -109,7 +101,7 @@ func TestDWNamespaceCreation(t *testing.T) {
 
 	for k, tc := range testcases {
 		t.Run(k, func(t *testing.T) {
-			actions, reconcileErr, err := runDownwardSync(testTenant, tc.ExistingObjectInSuper, tc.ExistingObjectInTenant, tc.ExistingObjectInTenant)
+			actions, reconcileErr, err := util.RunDownwardSync(NewNamespaceController, testTenant, tc.ExistingObjectInSuper, tc.ExistingObjectInTenant, tc.ExistingObjectInTenant)
 			if err != nil {
 				t.Errorf("%s: error running downward sync: %v", k, err)
 				return
@@ -194,7 +186,7 @@ func TestDWNamespaceDeletion(t *testing.T) {
 
 	for k, tc := range testcases {
 		t.Run(k, func(t *testing.T) {
-			actions, reconcileErr, err := runDownwardSync(testTenant, tc.ExistingObjectInSuper, nil, tc.EnqueueObject)
+			actions, reconcileErr, err := util.RunDownwardSync(NewNamespaceController, testTenant, tc.ExistingObjectInSuper, nil, tc.EnqueueObject)
 			if err != nil {
 				t.Errorf("%s: error running downward sync: %v", k, err)
 				return
@@ -228,74 +220,4 @@ func TestDWNamespaceDeletion(t *testing.T) {
 			}
 		})
 	}
-}
-
-func runDownwardSync(
-	testTenant *v1alpha1.Virtualcluster,
-	existingObjectInSuper []runtime.Object,
-	existingObjectInTenant *v1.Namespace,
-	enqueueObject *v1.Namespace,
-) (actions []core.Action, reconcileError error, err error) {
-	// setup fake tenant cluster
-	tenantClientset := fake.NewSimpleClientset()
-	tenantClient := fakeClient.NewFakeClient()
-	if existingObjectInTenant != nil {
-		tenantClientset = fake.NewSimpleClientset(existingObjectInTenant)
-		tenantClient = fakeClient.NewFakeClient(existingObjectInTenant)
-	}
-	tenantCluster, err := cluster.NewFakeTenantCluster(testTenant, tenantClientset, tenantClient)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error creating tenantCluster: %v", err)
-	}
-
-	// setup fake super cluster
-	superClient := fake.NewSimpleClientset()
-	if existingObjectInSuper != nil {
-		superClient = fake.NewSimpleClientset(existingObjectInSuper...)
-	}
-	superInformer := informers.NewSharedInformerFactory(superClient, 0)
-	nsInformer := superInformer.Core().V1().Namespaces()
-
-	controller, err := NewNamespaceController(
-		superClient.CoreV1(),
-		nsInformer,
-	)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error creating namespace controller: %v", err)
-	}
-	controller.nsSynced = alwaysReady
-
-	syncCalls := make(chan struct{})
-	controller.reconcileHandler = func(request reconciler.Request) (result reconciler.Result, err error) {
-		res, err := controller.reconcile(request)
-		reconcileError = err
-		syncCalls <- struct{}{}
-		return res, err
-	}
-
-	// register tenant cluster to controller.
-	controller.AddCluster(tenantCluster)
-
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	go controller.StartDWS(stopCh)
-
-	// add object to informer.
-	for _, ns := range existingObjectInSuper {
-		nsInformer.Informer().GetStore().Add(ns)
-	}
-
-	// start testing
-	if err := controller.multiClusterNamespaceController.RequeueObject(conversion.ToClusterKey(testTenant), enqueueObject); err != nil {
-		return nil, nil, fmt.Errorf("error enqueue object %v: %v", enqueueObject, err)
-	}
-
-	// wait to be called
-	select {
-	case <-syncCalls:
-	case <-time.After(10 * time.Second):
-		return nil, nil, fmt.Errorf("timeout wating for sync")
-	}
-
-	return superClient.Actions(), reconcileError, nil
 }

--- a/incubator/virtualcluster/pkg/syncer/resources/register.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import (
 )
 
 func Register(config *config.SyncerConfiguration, client clientset.Interface, informerFactory informers.SharedInformerFactory, controllerManager *manager.ControllerManager) {
-	namespace.Register(config, client.CoreV1(), informerFactory.Core().V1().Namespaces(), controllerManager)
+	namespace.Register(config, client.CoreV1(), informerFactory.Core().V1(), controllerManager)
 	pod.Register(config, client.CoreV1(), informerFactory.Core().V1(), controllerManager)
 	configmap.Register(config, client.CoreV1(), informerFactory.Core().V1().ConfigMaps(), controllerManager)
 	secret.Register(config, client.CoreV1(), informerFactory.Core().V1().Secrets(), controllerManager)

--- a/incubator/virtualcluster/pkg/syncer/util/test/runDWS.go
+++ b/incubator/virtualcluster/pkg/syncer/util/test/runDWS.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	core "k8s.io/client-go/testing"
+	cache "k8s.io/client-go/tools/cache"
+	fakeClient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/cluster"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
+	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
+)
+
+type fakeReconciler struct {
+	controller manager.Controller
+	errCh      chan error
+}
+
+func (r *fakeReconciler) Reconcile(request reconciler.Request) (reconciler.Result, error) {
+	var res reconciler.Result
+	var err error
+	if r.controller != nil {
+		res, err = r.controller.Reconcile(request)
+	} else {
+		res, err = reconciler.Result{}, fmt.Errorf("fake reconciler's controller is not initialized")
+	}
+	r.errCh <- err
+	return res, err
+}
+
+func (r *fakeReconciler) SetController(c manager.Controller) {
+	r.controller = c
+}
+
+type controllerNew func(corev1.CoreV1Interface, coreinformers.Interface, *mc.Options) (manager.Controller, *mc.MultiClusterController, error)
+
+func RunDownwardSync(
+	newControllerFunc controllerNew,
+	testTenant *v1alpha1.Virtualcluster,
+	existingObjectInSuper []runtime.Object,
+	existingObjectInTenant runtime.Object,
+	enqueueObject runtime.Object,
+) (actions []core.Action, reconcileError error, err error) {
+	// setup fake tenant cluster
+	tenantClientset := fake.NewSimpleClientset()
+	tenantClient := fakeClient.NewFakeClient()
+	if existingObjectInTenant != nil {
+		tenantClientset = fake.NewSimpleClientset(existingObjectInTenant)
+		tenantClient = fakeClient.NewFakeClient(existingObjectInTenant)
+	}
+	tenantCluster, err := cluster.NewFakeTenantCluster(testTenant, tenantClientset, tenantClient)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating tenantCluster: %v", err)
+	}
+
+	// setup fake super cluster
+	superClient := fake.NewSimpleClientset()
+	if existingObjectInSuper != nil {
+		superClient = fake.NewSimpleClientset(existingObjectInSuper...)
+	}
+	superInformer := informers.NewSharedInformerFactory(superClient, 0)
+
+	// setup fake controller
+	syncErr := make(chan error)
+	defer close(syncErr)
+	fakeRc := &fakeReconciler{errCh: syncErr}
+	options := &mc.Options{Reconciler: fakeRc, IsFake: true}
+
+	controller, mccontroller, err := newControllerFunc(
+		superClient.CoreV1(),
+		superInformer.Core().V1(),
+		options,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating dws controller: %v", err)
+	}
+	fakeRc.SetController(controller)
+
+	// register tenant cluster to controller.
+	controller.AddCluster(tenantCluster)
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go controller.StartDWS(stopCh)
+
+	// add object to informer.
+	for _, each := range existingObjectInSuper {
+		informer := getObjectInformer(superInformer.Core().V1(), each)
+		informer.GetStore().Add(each)
+	}
+
+	// start testing
+	if err := mccontroller.RequeueObject(conversion.ToClusterKey(testTenant), enqueueObject); err != nil {
+		return nil, nil, fmt.Errorf("error enqueue object %v: %v", enqueueObject, err)
+	}
+
+	// wait to be called
+	select {
+	case reconcileError = <-syncErr:
+	case <-time.After(10 * time.Second):
+		return nil, nil, fmt.Errorf("timeout wating for sync")
+	}
+
+	return superClient.Actions(), reconcileError, nil
+}
+
+func getObjectInformer(informer coreinformers.Interface, obj runtime.Object) cache.SharedIndexInformer {
+	switch obj.(type) {
+	case *v1.Namespace:
+		return informer.Namespaces().Informer()
+	default:
+		return nil
+
+	}
+}


### PR DESCRIPTION
This change restructures the mock test so that the RunDownwardSync method can be reused by
the mock tests of other resources.

To achieve this, this change makes a few abstractions in the controller creation codepath. 
Basically, the manager.Controller interface is used in the util.RunDownwardSync method instead of a specific controller implementation, making the mock test infra code reusable for all synced resources.