### PR TITLE
Update validators to respect excluded namespaces

### DIFF
--- a/incubator/hnc/Makefile
+++ b/incubator/hnc/Makefile
@@ -55,7 +55,6 @@ clean: krew-uninstall
 	-rm -rf bin/*
 	-rm -rf manifests/*
 	-rm -f ${GOPATH}/bin/kubectl-hns
-	-rm -f ${GOPATH}/bin/kubectl-hns
 
 # Install kubectl plugin
 kubectl: build

--- a/incubator/hnc/pkg/config/default_config.go
+++ b/incubator/hnc/pkg/config/default_config.go
@@ -4,6 +4,17 @@ import (
 	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
 )
 
+// The EX map is used by reconcilers and validators to exclude
+// namespaces that shouldn't be reconciled or validated. We explicitly
+// exclude some default namespaces with constantly changing objects.
+// TODO make the exclusion configurable - https://github.com/kubernetes-sigs/multi-tenancy/issues/374
+var EX = map[string]bool{
+	"kube-system":  true,
+	"kube-public":  true,
+	"hnc-system":   true,
+	"cert-manager": true,
+}
+
 // GetDefaultRoleSpec and GetDefaultRoleBindingSpec create the default
 // configuration for Roles and RoleBindings respectively.
 // By default, HNC configuration should always propagate Roles and RoleBindings.

--- a/incubator/hnc/pkg/reconcilers/hierarchical_namespace.go
+++ b/incubator/hnc/pkg/reconcilers/hierarchical_namespace.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/go-logr/logr"
 	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/config"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/forest"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/metadata"
 	corev1 "k8s.io/api/core/v1"
@@ -74,7 +75,7 @@ func (r *HierarchicalNamespaceReconciler) Reconcile(req ctrl.Request) (ctrl.Resu
 	// the hns instance. Forbidden HNSes won't have finalizers.
 	// TODO refactor/split the EX map for 1) reconciler exclusion and 2) self-serve not allowed
 	//  purposes. See issue: https://github.com/kubernetes-sigs/multi-tenancy/issues/495
-	if EX[pnm] {
+	if config.EX[pnm] {
 		inst.Status.State = api.Forbidden
 		return ctrl.Result{}, r.writeInstance(ctx, log, inst)
 	}

--- a/incubator/hnc/pkg/reconcilers/hierarchy_config.go
+++ b/incubator/hnc/pkg/reconcilers/hierarchy_config.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/config"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/forest"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/metadata"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/stats"
@@ -74,7 +75,7 @@ type HierarchyConfigReconciler struct {
 
 // Reconcile sets up some basic variables and then calls the business logic.
 func (r *HierarchyConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-	if EX[req.Namespace] {
+	if config.EX[req.Namespace] {
 		return ctrl.Result{}, nil
 	}
 

--- a/incubator/hnc/pkg/reconcilers/object.go
+++ b/incubator/hnc/pkg/reconcilers/object.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/go-logr/logr"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/config"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/metadata"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/object"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/stats"
@@ -182,7 +183,7 @@ func (r *ObjectReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
 	log := r.Log.WithValues("trigger", req.NamespacedName)
 
-	if EX[req.Namespace] {
+	if config.EX[req.Namespace] {
 		return resp, nil
 	}
 

--- a/incubator/hnc/pkg/reconcilers/setup.go
+++ b/incubator/hnc/pkg/reconcilers/setup.go
@@ -9,16 +9,6 @@ import (
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/forest"
 )
 
-// The EX map is used by reconcilers to exclude namespaces to reconcile. We explicitly
-// exclude some default namespaces with constantly changing objects.
-// TODO make the exclusion configurable - https://github.com/kubernetes-sigs/multi-tenancy/issues/374
-var EX = map[string]bool{
-	"kube-system":  true,
-	"kube-public":  true,
-	"hnc-system":   true,
-	"cert-manager": true,
-}
-
 // Create creates all reconcilers.
 //
 // This function is called both from main.go as well as from the integ tests.

--- a/incubator/hnc/pkg/validators/hierarchical_namespace.go
+++ b/incubator/hnc/pkg/validators/hierarchical_namespace.go
@@ -10,8 +10,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	api "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/api/v1alpha1"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/config"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/forest"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/reconcilers"
 )
 
 // HierarchicalNamespaceServingPath is where the validator will run. Must be kept in sync with the
@@ -69,7 +69,7 @@ func (v *HierarchicalNamespace) handle(req *hnsRequest) admission.Response {
 	cns := v.Forest.Get(cnm)
 
 	if req.op == v1beta1.Create {
-		if reconcilers.EX[pnm] {
+		if config.EX[pnm] {
 			msg := fmt.Sprintf("The namespace %s is not allowed to create subnamespaces. Please create subnamespaces in a different namespace.", pnm)
 			return deny(metav1.StatusReasonForbidden, msg)
 		}

--- a/incubator/hnc/pkg/validators/hierarchy_test.go
+++ b/incubator/hnc/pkg/validators/hierarchy_test.go
@@ -33,6 +33,10 @@ func TestStructure(t *testing.T) {
 		{name: "missing parent", nnm: "foo", pnm: "brumpf", fail: true},
 		{name: "self-cycle", nnm: "foo", pnm: "foo", fail: true},
 		{name: "other cycle", nnm: "foo", pnm: "bar", fail: true},
+		{name: "exclude kube-system", nnm: "foo", pnm: "kube-system", fail: true},
+		{name: "exclude kube-public", nnm: "foo", pnm: "kube-public", fail: true},
+		{name: "exclude hnc-system", nnm: "foo", pnm: "hnc-system", fail: true},
+		{name: "exclude cert-manager", nnm: "foo", pnm: "cert-manager", fail: true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/incubator/hnc/pkg/validators/object_test.go
+++ b/incubator/hnc/pkg/validators/object_test.go
@@ -19,12 +19,13 @@ func TestInheritedFromLabel(t *testing.T) {
 	l := zap.Logger(false)
 
 	tests := []struct {
-		name     string
-		oldLabel string
-		oldValue string
-		newLabel string
-		newValue string
-		fail     bool
+		name      string
+		oldLabel  string
+		oldValue  string
+		newLabel  string
+		newValue  string
+		namespace string
+		fail      bool
 	}{{
 		name:     "Regular labels can be changed",
 		oldLabel: "oldLabel", oldValue: "foo",
@@ -46,7 +47,13 @@ func TestInheritedFromLabel(t *testing.T) {
 		name:     "Label is added",
 		newLabel: api.LabelInheritedFrom, newValue: "foo",
 		fail: true,
-	}}
+	}, {
+		name:     "Objects in excluded namespace is ignored",
+		oldLabel: api.LabelInheritedFrom, oldValue: "foo",
+		newLabel: api.LabelInheritedFrom, newValue: "bar",
+		namespace: "hnc-system",
+	},
+	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -55,6 +62,7 @@ func TestInheritedFromLabel(t *testing.T) {
 			oldInst := &unstructured.Unstructured{}
 			metadata.SetLabel(oldInst, tc.oldLabel, tc.oldValue)
 			inst := &unstructured.Unstructured{}
+			inst.SetNamespace(tc.namespace)
 			metadata.SetLabel(inst, tc.newLabel, tc.newValue)
 
 			// Test


### PR DESCRIPTION
Fixes #607. Parent namespaces in the excluded namespaces should be
denied. Objects in parent namespaces should be ignored.