### PR TITLE
Flush obsolete conditions on descendants

### DIFF
--- a/incubator/hnc/pkg/reconcilers/object.go
+++ b/incubator/hnc/pkg/reconcilers/object.go
@@ -538,6 +538,8 @@ func (r *ObjectReconciler) setConditions(log logr.Logger, srcInst, inst *unstruc
 	r.Forest.Lock()
 	defer r.Forest.Unlock()
 	ao := api.NewAffectedObject(inst.GetObjectKind().GroupVersionKind(), inst.GetNamespace(), inst.GetName())
+	// This affected object is initialized with the source object if it exits.
+	sao := api.NewAffectedObject(inst.GetObjectKind().GroupVersionKind(), inst.GetLabels()[api.LabelInheritedFrom], inst.GetName())
 	ns := r.Forest.Get(inst.GetNamespace())
 
 	switch {
@@ -548,11 +550,13 @@ func (r *ObjectReconciler) setConditions(log logr.Logger, srcInst, inst *unstruc
 		}
 
 	case err != nil:
-		// There was an error updating this object; set a local condition.
+		// There was an error updating this object; set a condition pointing to the source object. Note we
+		// never take actions on a source object, so only propagated objects could possibly get an error.
 		msg := fmt.Sprintf("Could not %s: %s", act, err.Error())
-		if ns.SetCondition(ao, api.CannotUpdate, msg) {
+		if ns.SetCondition(sao, api.CannotUpdate, msg) {
 			r.enqueueNamespace(log, ns.Name(), "Set CannotUpdate due to error")
 		}
+
 		// Also set a condition on the source if one exists.
 		if srcInst != nil {
 			srcNS := r.Forest.Get(srcInst.GetNamespace())
@@ -572,6 +576,11 @@ func (r *ObjectReconciler) setConditions(log logr.Logger, srcInst, inst *unstruc
 		// No error conditions exist for this object; clear all conditions in the namespace and all its
 		// ancestors (technically, srcNS is the only feasible ancestor, but because we don't hold the
 		// lock, it's safer to just do everything).
+		if hasPropagatedLabel(inst) {
+			if ns.ClearCondition(sao, "") {
+				r.enqueueNamespace(log, ns.Name(), "Removed condition")
+			}
+		}
 		for ns != nil {
 			if ns.ClearCondition(ao, "") {
 				r.enqueueNamespace(log, ns.Name(), "Removed condition")


### PR DESCRIPTION
As described in issue 605, obsolete CannotUpdate condition was not
cleared on the descendants namespaces of a namespace who just changes
its parent. This commit changes the key of a CannotUpdate condition from
the local object to the source object if it exists. Therefore, we can
flush obsolete conditions on descendants by clearing the conditions by
ancestor namespaces, the same way as how we flush obsolete conditions on
ancestors.

Tested with "make test" and running the test script
"hack/test-issue-605.sh' seeing the CannotUpdate condition was gone
immediately in all 10 attempts. See [results](https://gist.github.com/yiqigao217/a99afd57f5a5e3084d90b56fad31c99d) and [logs](https://gist.github.com/yiqigao217/424eafae7ac4900753b432e7768543e0).

Fixes #605 