### PR TITLE
[Incubator][VC] Refactor manager.Controller interface

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/manager/manager.go
+++ b/incubator/virtualcluster/pkg/syncer/manager/manager.go
@@ -23,31 +23,30 @@ import (
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
 )
 
-// ControllerManager manages number of controllers. It starts their caches, waits for those to sync,
+// ControllerManager manages number of resource syncers. It starts their caches, waits for those to sync,
 // then starts the controllers.
-// A ControllerManager is required to start controllers.
 type ControllerManager struct {
-	controllers map[Controller]struct{}
+	resourceSyncers map[ResourceSyncer]struct{}
 }
 
-// New creates a Manager.
 func New() *ControllerManager {
-	return &ControllerManager{controllers: make(map[Controller]struct{})}
+	return &ControllerManager{resourceSyncers: make(map[ResourceSyncer]struct{})}
 }
 
-// Controller is the interface used by ControllerManager to start the controllers and get their caches (beforehand).
-type Controller interface {
+// ResourceSyncer is the interface used by ControllerManager to manage multiple resource syncers.
+type ResourceSyncer interface {
 	listener.ClusterChangeListener
 	StartUWS(stopCh <-chan struct{}) error
 	StartDWS(stopCh <-chan struct{}) error
 	StartPeriodChecker(stopCh <-chan struct{}) error
 	Reconcile(request reconciler.Request) (reconciler.Result, error)
+	BackPopulate(string) error
 }
 
-// AddController adds a controller to the ControllerManager.
-func (m *ControllerManager) AddController(c Controller) {
-	m.controllers[c] = struct{}{}
-	listener.AddListener(c)
+// AddController adds a resource syncer to the ControllerManager.
+func (m *ControllerManager) AddResourceSyncer(s ResourceSyncer) {
+	m.resourceSyncers[s] = struct{}{}
+	listener.AddListener(s)
 }
 
 // Start gets all the unique caches of the controllers it manages, starts them,
@@ -57,29 +56,29 @@ func (m *ControllerManager) Start(stop <-chan struct{}) error {
 	errCh := make(chan error)
 
 	wg := &sync.WaitGroup{}
-	wg.Add(len(m.controllers) * 3)
+	wg.Add(len(m.resourceSyncers) * 3)
 
-	for co := range m.controllers {
-		go func(co Controller) {
+	for s := range m.resourceSyncers {
+		go func(s ResourceSyncer) {
 			defer wg.Done()
-			if err := co.StartDWS(stop); err != nil {
+			if err := s.StartDWS(stop); err != nil {
 				errCh <- err
 			}
-		}(co)
+		}(s)
 		// start UWS syncer
-		go func(co Controller) {
+		go func(s ResourceSyncer) {
 			defer wg.Done()
-			if err := co.StartUWS(stop); err != nil {
+			if err := s.StartUWS(stop); err != nil {
 				errCh <- err
 			}
-		}(co)
+		}(s)
 		// start period checker
-		go func(co Controller) {
+		go func(s ResourceSyncer) {
 			defer wg.Done()
-			if err := co.StartPeriodChecker(stop); err != nil {
+			if err := s.StartPeriodChecker(stop); err != nil {
 				errCh <- err
 			}
-		}(co)
+		}(s)
 	}
 
 	doneCh := make(chan struct{})

--- a/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
+++ b/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
@@ -64,13 +64,9 @@ type Options struct {
 	JitterPeriod time.Duration
 
 	// MaxConcurrentReconciles is the number of concurrent control loops.
-	// Use this if your Reconciler is slow, but thread safe.
 	MaxConcurrentReconciles int
 
-	// Reconciler is a function that can be called at any time with the Name / Namespace of an object and
-	// ensures that the state of the system matches the state specified in the object.
-	// Defaults to the DefaultReconcileFunc.
-	Reconciler reconciler.Reconciler
+	Reconciler reconciler.DWReconciler
 
 	// Queue can be used to override the default queue.
 	Queue workqueue.RateLimitingInterface

--- a/incubator/virtualcluster/pkg/syncer/reconciler/reconciler.go
+++ b/incubator/virtualcluster/pkg/syncer/reconciler/reconciler.go
@@ -30,7 +30,7 @@ const (
 	DeleteEvent EventType = "Delete"
 )
 
-// Request contains the information needed by a multicluster Reconciler to Reconcile:
+// Request contains the information needed by a DWReconciler to reconcile.
 // It ONLY contains the meta that can uniquely identify an object without any state information which can lead to parallel reconcile.
 type Request struct {
 	ClusterName string
@@ -40,8 +40,8 @@ type Request struct {
 
 type Result reconcile.Result
 
-// Reconciler is the interface used by a Controller to reconcile.
-type Reconciler interface {
+// DWReconciler is the interface used by a Controller to do downward reconcile (tenant->super).
+type DWReconciler interface {
 	Reconcile(Request) (Result, error)
 }
 

--- a/incubator/virtualcluster/pkg/syncer/resources/configmap/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/configmap/controller.go
@@ -66,10 +66,14 @@ func Register(
 	c.configMapLister = configMapInformer.Lister()
 	c.configMapSynced = configMapInformer.Informer().HasSynced
 
-	controllerManager.AddController(c)
+	controllerManager.AddResourceSyncer(c)
 }
 
 func (c *controller) StartUWS(stopCh <-chan struct{}) error {
+	return nil
+}
+
+func (c *controller) BackPopulate(string) error {
 	return nil
 }
 

--- a/incubator/virtualcluster/pkg/syncer/resources/endpoints/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/endpoints/controller.go
@@ -64,10 +64,14 @@ func Register(
 	c.endpointsLister = endpointsInformer.Lister()
 	c.endpointsSynced = endpointsInformer.Informer().HasSynced
 
-	controllerManager.AddController(c)
+	controllerManager.AddResourceSyncer(c)
 }
 
 func (c *controller) StartUWS(stopCh <-chan struct{}) error {
+	return nil
+}
+
+func (c *controller) BackPopulate(string) error {
 	return nil
 }
 

--- a/incubator/virtualcluster/pkg/syncer/resources/event/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/event/controller.go
@@ -102,7 +102,7 @@ func Register(
 			},
 		})
 
-	controllerManager.AddController(c)
+	controllerManager.AddResourceSyncer(c)
 }
 
 func assignPodEvent(e *v1.Event) bool {

--- a/incubator/virtualcluster/pkg/syncer/resources/event/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/event/uws.go
@@ -75,7 +75,7 @@ func (c *controller) processNextWorkItem() bool {
 	}
 
 	klog.V(4).Infof("back populate event %+v", req.Key)
-	err := c.backPopulate(req.Key)
+	err := c.BackPopulate(req.Key)
 	if err == nil {
 		c.queue.Forget(obj)
 		return true
@@ -91,7 +91,7 @@ func (c *controller) processNextWorkItem() bool {
 	return true
 }
 
-func (c *controller) backPopulate(key string) error {
+func (c *controller) BackPopulate(key string) error {
 	pNamespace, pName, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("invalid resource key %v: %v", key, err))

--- a/incubator/virtualcluster/pkg/syncer/resources/namespace/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/namespace/controller.go
@@ -56,10 +56,10 @@ func Register(
 		return
 	}
 
-	controllerManager.AddController(c)
+	controllerManager.AddResourceSyncer(c)
 }
 
-func NewNamespaceController(config *config.SyncerConfiguration, namespaceClient v1core.CoreV1Interface, informer coreinformers.Interface, options *mc.Options) (manager.Controller, *mc.MultiClusterController, error) {
+func NewNamespaceController(config *config.SyncerConfiguration, namespaceClient v1core.CoreV1Interface, informer coreinformers.Interface, options *mc.Options) (manager.ResourceSyncer, *mc.MultiClusterController, error) {
 	c := &controller{
 		namespaceClient:     namespaceClient,
 		periodCheckerPeriod: 60 * time.Second,
@@ -84,6 +84,10 @@ func NewNamespaceController(config *config.SyncerConfiguration, namespaceClient 
 }
 
 func (c *controller) StartUWS(stopCh <-chan struct{}) error {
+	return nil
+}
+
+func (c *controller) BackPopulate(string) error {
 	return nil
 }
 

--- a/incubator/virtualcluster/pkg/syncer/resources/node/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/node/controller.go
@@ -92,7 +92,7 @@ func Register(
 		},
 	)
 
-	controllerManager.AddController(c)
+	controllerManager.AddResourceSyncer(c)
 }
 
 func (c *controller) StartPeriodChecker(stopCh <-chan struct{}) error {

--- a/incubator/virtualcluster/pkg/syncer/resources/node/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/node/uws.go
@@ -73,7 +73,7 @@ func (c *controller) processNextWorkItem() bool {
 	}
 	defer c.queue.Done(key)
 
-	err := c.backPopulate(key.(string))
+	err := c.BackPopulate(key.(string))
 	if err == nil {
 		c.queue.Forget(key)
 		return true
@@ -84,7 +84,7 @@ func (c *controller) processNextWorkItem() bool {
 	return true
 }
 
-func (c *controller) backPopulate(nodeName string) error {
+func (c *controller) BackPopulate(nodeName string) error {
 	node, err := c.nodeLister.Get(nodeName)
 	if err != nil {
 		if errors.IsNotFound(err) {

--- a/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/controller.go
@@ -112,7 +112,7 @@ func Register(
 				DeleteFunc: c.enqueuePersistentVolume,
 			},
 		})
-	controllerManager.AddController(c)
+	controllerManager.AddResourceSyncer(c)
 }
 
 func boundPersistentVolume(e *v1.PersistentVolume) bool {

--- a/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/uws.go
@@ -76,7 +76,7 @@ func (c *controller) processNextWorkItem() bool {
 	}
 
 	klog.Infof("back populate persistentvolume %+v", req.Key)
-	err := c.backPopulate(req.Key)
+	err := c.BackPopulate(req.Key)
 	if err == nil {
 		c.queue.Forget(obj)
 		return true
@@ -92,7 +92,7 @@ func (c *controller) processNextWorkItem() bool {
 	return true
 }
 
-func (c *controller) backPopulate(key string) error {
+func (c *controller) BackPopulate(key string) error {
 	pPV, err := c.pvLister.Get(key)
 	if err != nil {
 		if errors.IsNotFound(err) {

--- a/incubator/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/controller.go
@@ -66,10 +66,14 @@ func Register(
 	c.pvcLister = pvcInformer.Lister()
 	c.pvcSynced = pvcInformer.Informer().HasSynced
 
-	controllerManager.AddController(c)
+	controllerManager.AddResourceSyncer(c)
 }
 
 func (c *controller) StartUWS(stopCh <-chan struct{}) error {
+	return nil
+}
+
+func (c *controller) BackPopulate(string) error {
 	return nil
 }
 

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/controller.go
@@ -88,10 +88,10 @@ func Register(
 		klog.Errorf("failed to create multi cluster Pod controller %v", err)
 		return
 	}
-	controllerManager.AddController(c)
+	controllerManager.AddResourceSyncer(c)
 }
 
-func NewPodController(config *config.SyncerConfiguration, client v1core.CoreV1Interface, informer coreinformers.Interface, options *mc.Options) (manager.Controller, *mc.MultiClusterController, error) {
+func NewPodController(config *config.SyncerConfiguration, client v1core.CoreV1Interface, informer coreinformers.Interface, options *mc.Options) (manager.ResourceSyncer, *mc.MultiClusterController, error) {
 	c := &controller{
 		config:              config,
 		client:              client,

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
@@ -79,7 +79,7 @@ func (c *controller) processNextWorkItem() bool {
 	}
 
 	klog.V(4).Infof("back populate pod %+v", req.Key)
-	err := c.backPopulate(req.Key)
+	err := c.BackPopulate(req.Key)
 	if err == nil {
 		c.queue.Forget(obj)
 		return true
@@ -95,7 +95,7 @@ func (c *controller) processNextWorkItem() bool {
 	return true
 }
 
-func (c *controller) backPopulate(key string) error {
+func (c *controller) BackPopulate(key string) error {
 	pNamespace, pName, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("invalid resource key %v: %v", key, err))

--- a/incubator/virtualcluster/pkg/syncer/resources/secret/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/secret/controller.go
@@ -70,10 +70,14 @@ func Register(
 	c.secretLister = secretInformer.Lister()
 	c.secretSynced = secretInformer.Informer().HasSynced
 
-	controllerManager.AddController(c)
+	controllerManager.AddResourceSyncer(c)
 }
 
 func (c *controller) StartUWS(stopCh <-chan struct{}) error {
+	return nil
+}
+
+func (c *controller) BackPopulate(string) error {
 	return nil
 }
 

--- a/incubator/virtualcluster/pkg/syncer/resources/service/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/service/controller.go
@@ -63,10 +63,10 @@ func Register(
 		klog.Errorf("failed to create multi cluster service controller %v", err)
 		return
 	}
-	controllerManager.AddController(c)
+	controllerManager.AddResourceSyncer(c)
 }
 
-func NewServiceController(config *config.SyncerConfiguration, serviceClient v1core.CoreV1Interface, informer coreinformers.Interface, options *mc.Options) (manager.Controller, *mc.MultiClusterController, error) {
+func NewServiceController(config *config.SyncerConfiguration, serviceClient v1core.CoreV1Interface, informer coreinformers.Interface, options *mc.Options) (manager.ResourceSyncer, *mc.MultiClusterController, error) {
 	c := &controller{
 		serviceClient:       serviceClient,
 		periodCheckerPeriod: 60 * time.Second,

--- a/incubator/virtualcluster/pkg/syncer/resources/service/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/service/uws.go
@@ -77,7 +77,7 @@ func (c *controller) processNextWorkItem() bool {
 	}
 
 	klog.Infof("back populate service %+v", req.Key)
-	err := c.backPopulate(req.Key)
+	err := c.BackPopulate(req.Key)
 	if err == nil {
 		c.queue.Forget(obj)
 		return true
@@ -93,7 +93,7 @@ func (c *controller) processNextWorkItem() bool {
 	return true
 }
 
-func (c *controller) backPopulate(key string) error {
+func (c *controller) BackPopulate(key string) error {
 	pNamespace, pName, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("invalid resource key %v: %v", key, err))

--- a/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/controller.go
@@ -66,10 +66,14 @@ func Register(
 	c.saLister = saInformer.Lister()
 	c.saSynced = saInformer.Informer().HasSynced
 
-	controllerManager.AddController(c)
+	controllerManager.AddResourceSyncer(c)
 }
 
 func (c *controller) StartUWS(stopCh <-chan struct{}) error {
+	return nil
+}
+
+func (c *controller) BackPopulate(string) error {
 	return nil
 }
 

--- a/incubator/virtualcluster/pkg/syncer/resources/storageclass/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/storageclass/controller.go
@@ -109,7 +109,7 @@ func Register(
 			},
 		})
 
-	controllerManager.AddController(c)
+	controllerManager.AddResourceSyncer(c)
 }
 
 func publicStorageClass(e *v1.StorageClass) bool {
@@ -131,7 +131,7 @@ func (c *controller) enqueueStorageClass(obj interface{}) {
 	}
 
 	for _, clusterName := range clusterNames {
-		c.queue.Add(reconciler.UwsRequest{Key: key, ClusterName: clusterName})
+		c.queue.Add(reconciler.UwsRequest{Key: clusterName + "/" + key})
 	}
 }
 


### PR DESCRIPTION
This change refactors the manager.Controller interface by doing this followings:

- Rename the interface from Controller to ResourceSyncer since there are too many "Controller" terms in VC project and they often look confusing.
- Add BackPopulate method to the interface, which is needed for UWS mock test (in the future)
- Change the input of the BackPopulate method of storageclass controller to a string in order to meet the interface requirement.

In next change, I will extract the UW controller code to a common structure. This will help for both
removing duplicated code and supporting UWS mock tests. 
