### PR TITLE
[Incubator][VC]Add Pod UWS mock tests

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/manager/manager.go
+++ b/incubator/virtualcluster/pkg/syncer/manager/manager.go
@@ -20,13 +20,21 @@ import (
 	"sync"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/listener"
+	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
+	uw "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/uwcontroller"
 )
 
 // ControllerManager manages number of resource syncers. It starts their caches, waits for those to sync,
 // then starts the controllers.
 type ControllerManager struct {
 	resourceSyncers map[ResourceSyncer]struct{}
+}
+
+type ResourceSyncerOptions struct {
+	MCOptions *mc.Options
+	UWOptions *uw.Options
+	IsFake    bool
 }
 
 func New() *ControllerManager {

--- a/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
+++ b/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
@@ -70,9 +70,6 @@ type Options struct {
 
 	// Queue can be used to override the default queue.
 	Queue workqueue.RateLimitingInterface
-
-	// A Fake controller is created for testing purpose.
-	IsFake bool
 }
 
 // Cache is the interface used by Controller to start and wait for caches to sync.

--- a/incubator/virtualcluster/pkg/syncer/reconciler/reconciler.go
+++ b/incubator/virtualcluster/pkg/syncer/reconciler/reconciler.go
@@ -49,9 +49,3 @@ type DWReconciler interface {
 type UWReconciler interface {
 	BackPopulate(string) error
 }
-
-type UwsRequest struct {
-	Key string
-	// Optional, in many cases, the cluster name is unknown when uws request is created
-	ClusterName string
-}

--- a/incubator/virtualcluster/pkg/syncer/resources/event/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/event/controller.go
@@ -121,7 +121,7 @@ func (c *controller) enqueueEvent(obj interface{}) {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %v: %v", obj, err))
 		return
 	}
-	c.upwardEventController.AddToQueue(reconciler.UwsRequest{Key: key})
+	c.upwardEventController.AddToQueue(key)
 }
 
 func (c *controller) StartDWS(stopCh <-chan struct{}) error {

--- a/incubator/virtualcluster/pkg/syncer/resources/node/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/node/uws.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/metrics"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
 )
 
 // StartUWS starts the upward syncer
@@ -42,7 +41,7 @@ func (c *controller) StartUWS(stopCh <-chan struct{}) error {
 
 func (c *controller) enqueueNode(obj interface{}) {
 	node := obj.(*v1.Node)
-	c.upwardNodeController.AddToQueue(reconciler.UwsRequest{Key: node.Name})
+	c.upwardNodeController.AddToQueue(node.Name)
 }
 
 func (c *controller) BackPopulate(nodeName string) error {

--- a/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/checker.go
@@ -33,7 +33,6 @@ import (
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/metrics"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
 )
 
 var numClaimMissMatchedPVs uint64
@@ -95,7 +94,7 @@ func (c *controller) checkPVs() {
 		if err != nil {
 			if errors.IsNotFound(err) {
 				metrics.CheckerRemedyStats.WithLabelValues("numRequeuedSuperMasterPVs").Inc()
-				c.upwardPersistentVolumeController.AddToQueue(reconciler.UwsRequest{Key: pPV.Name})
+				c.upwardPersistentVolumeController.AddToQueue(pPV.Name)
 			}
 			klog.Errorf("fail to get pv %s from cluster %s: %v", pPV.Name, clusterName, err)
 		} else {

--- a/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/controller.go
@@ -129,7 +129,7 @@ func (c *controller) enqueuePersistentVolume(obj interface{}) {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %v: %v", obj, err))
 		return
 	}
-	c.upwardPersistentVolumeController.AddToQueue(reconciler.UwsRequest{Key: key})
+	c.upwardPersistentVolumeController.AddToQueue(key)
 }
 
 func (c *controller) StartDWS(stopCh <-chan struct{}) error {

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
@@ -101,7 +101,7 @@ func (c *controller) BackPopulate(key string) error {
 			return err
 		}
 
-		if _, err := c.multiClusterPodController.GetByObjectType(clusterName, vNamespace, n.GetName(), &v1.Node{}); err != nil {
+		if _, err := c.multiClusterPodController.GetByObjectType(clusterName, "", n.GetName(), &v1.Node{}); err != nil {
 			// check if target node has already registered on the vc
 			// before creating
 			if !errors.IsNotFound(err) {
@@ -133,8 +133,8 @@ func (c *controller) BackPopulate(key string) error {
 		}
 	} else {
 		// Check if the vNode exists in Tenant master.
-		if _, err := tenantClient.CoreV1().Nodes().Get(vPod.Spec.NodeName, metav1.GetOptions{}); err != nil {
-			if !errors.IsNotFound(err) {
+		if _, err := c.multiClusterPodController.GetByObjectType(clusterName, "", vPod.Spec.NodeName, &v1.Node{}); err != nil {
+			if errors.IsNotFound(err) {
 				// We have consistency issue here, do not fix for now. TODO: add to metrics
 			}
 			return fmt.Errorf("failed to check vNode %s of vPod %s in cluster %s: %v ", vPod.Spec.NodeName, vPod.Name, clusterName, err)

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/uws_test.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/uws_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	core "k8s.io/client-go/testing"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/util/test"
+)
+
+func uwTenantPod(name, namespace, uid, nodename string) *v1.Pod {
+	return &v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			UID:       types.UID(uid),
+		},
+		Spec: v1.PodSpec{
+			NodeName: nodename,
+		},
+	}
+}
+
+func uwSuperPod(name, namespace, uid, nodename, clusterKey string) *v1.Pod {
+	return &v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				constants.LabelUID:       uid,
+				constants.LabelCluster:   clusterKey,
+				constants.LabelNamespace: "default",
+			},
+		},
+		Spec: v1.PodSpec{
+			NodeName: nodename,
+		},
+	}
+}
+
+func tenantNode(name string) *v1.Node {
+	return &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+func applyStatusToPod(pod *v1.Pod, status *v1.PodStatus) *v1.Pod {
+	pod.Status = *status.DeepCopy()
+	return pod
+}
+
+func TestUWPodUpdate(t *testing.T) {
+	testTenant := &v1alpha1.Virtualcluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "tenant-1",
+			UID:       "7374a172-c35d-45b1-9c8e-bf5c5b614937",
+		},
+		Spec: v1alpha1.VirtualclusterSpec{},
+		Status: v1alpha1.VirtualclusterStatus{
+			Phase: v1alpha1.ClusterRunning,
+		},
+	}
+
+	statusPending := &v1.PodStatus{
+		Phase: "Pending",
+	}
+
+	statusRunning := &v1.PodStatus{
+		Phase: "Running",
+	}
+
+	defaultClusterKey := conversion.ToClusterKey(testTenant)
+	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+
+	testcases := map[string]struct {
+		ExistingObjectInSuper  []runtime.Object
+		ExistingObjectInTenant []runtime.Object
+		EnquedKey              string
+		ExpectedUpdatedPods    []runtime.Object
+		ExpectedError          string
+	}{
+		"update vPod status": {
+			ExistingObjectInSuper: []runtime.Object{
+				applyStatusToPod(uwSuperPod("pod-1", superDefaultNSName, "12345", "n1", defaultClusterKey), statusRunning),
+			},
+			ExistingObjectInTenant: []runtime.Object{
+				applyStatusToPod(uwTenantPod("pod-1", "default", "12345", "n1"), statusPending),
+				tenantNode("n1"),
+			},
+			EnquedKey: superDefaultNSName + "/pod-1",
+			ExpectedUpdatedPods: []runtime.Object{
+				applyStatusToPod(uwTenantPod("pod-1", "default", "12345", "n1"), statusRunning),
+			},
+			ExpectedError: "",
+		},
+		"vPod existing with different uid one": {
+			ExistingObjectInSuper: []runtime.Object{
+				uwSuperPod("pod-1", superDefaultNSName, "123456", "n1", defaultClusterKey),
+			},
+			ExistingObjectInTenant: []runtime.Object{
+				uwTenantPod("pod-1", "default", "12345", "n1"),
+			},
+			EnquedKey:           superDefaultNSName + "/pod-1",
+			ExpectedUpdatedPods: []runtime.Object{},
+			ExpectedError:       "delegated UID is different",
+		},
+	}
+
+	for k, tc := range testcases {
+		t.Run(k, func(t *testing.T) {
+			actions, reconcileErr, err := util.RunUpwardSync(NewPodController, testTenant, tc.ExistingObjectInSuper, tc.ExistingObjectInTenant, tc.EnquedKey)
+			if err != nil {
+				t.Errorf("%s: error running upward sync: %v", k, err)
+				return
+			}
+
+			if reconcileErr != nil {
+				if tc.ExpectedError == "" {
+					t.Errorf("expected no error, but got \"%v\"", reconcileErr)
+				} else if !strings.Contains(reconcileErr.Error(), tc.ExpectedError) {
+					t.Errorf("expected error msg \"%s\", but got \"%v\"", tc.ExpectedError, reconcileErr)
+				}
+			} else {
+				if tc.ExpectedError != "" {
+					t.Errorf("expected error msg \"%s\", but got empty", tc.ExpectedError)
+				}
+			}
+
+			if len(tc.ExpectedUpdatedPods) != len(actions) {
+				t.Errorf("%s: Expected to update Pod to %#v. Actual actions were: %#v", k, tc.ExpectedUpdatedPods, actions)
+				return
+			}
+			for i, obj := range tc.ExpectedUpdatedPods {
+				action := actions[i]
+				if !action.Matches("update", "pods") {
+					t.Errorf("%s: Unexpected action %s", k, action)
+					continue
+				}
+				actionObj := action.(core.UpdateAction).GetObject()
+				if !equality.Semantic.DeepEqual(obj, actionObj) {
+					exp, _ := json.Marshal(obj)
+					got, _ := json.Marshal(actionObj)
+					t.Errorf("%s: Expected updated pod is %v, got %v", k, string(exp), string(got))
+				}
+			}
+		})
+	}
+}

--- a/incubator/virtualcluster/pkg/syncer/resources/storageclass/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/storageclass/checker.go
@@ -33,7 +33,6 @@ import (
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/metrics"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
 )
 
 var numMissMatchedStorageClasses uint64
@@ -83,7 +82,7 @@ func (c *controller) checkStorageClass() {
 			if err != nil {
 				if errors.IsNotFound(err) {
 					metrics.CheckerRemedyStats.WithLabelValues("numRequeuedSuperMasterStorageClasses").Inc()
-					c.upwardStorageClassController.AddToQueue(reconciler.UwsRequest{Key: clusterName + "/" + pStorageClass.Name})
+					c.upwardStorageClassController.AddToQueue(clusterName + "/" + pStorageClass.Name)
 				}
 				klog.Errorf("fail to get storageclass from cluster %s: %v", clusterName, err)
 			}
@@ -131,7 +130,7 @@ func (c *controller) checkStorageClassOfTenantCluster(clusterName string) {
 			atomic.AddUint64(&numMissMatchedStorageClasses, 1)
 			klog.Warningf("spec of storageClass %v diff in super&tenant master", vStorageClass.Name)
 			if publicStorageClass(pStorageClass) {
-				c.upwardStorageClassController.AddToQueue(reconciler.UwsRequest{Key: clusterName + "/" + pStorageClass.Name})
+				c.upwardStorageClassController.AddToQueue(clusterName + "/" + pStorageClass.Name)
 			}
 		}
 	}

--- a/incubator/virtualcluster/pkg/syncer/resources/storageclass/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/storageclass/controller.go
@@ -137,7 +137,7 @@ func (c *controller) enqueueStorageClass(obj interface{}) {
 	}
 
 	for _, clusterName := range clusterNames {
-		c.upwardStorageClassController.AddToQueue(reconciler.UwsRequest{Key: clusterName + "/" + key})
+		c.upwardStorageClassController.AddToQueue(clusterName + "/" + key)
 	}
 }
 


### PR DESCRIPTION
This change builds the framework for running uws mock tests. 
- uitl/test/runUWS.go is created. The RunUpwardSync method is provided to orchestrate the mock test workflow.
- Introduce ResourceSyncerOptions struct to combine the controller options of mccontroller and uwcontroller. `IsFake` field is moved from mccontroller.Options to manager.ResourceSyncerOptions.
- Remove reconciler.UwsRequest. All uws controllers push object key string in their workerqueues. 
- Add pod/uws_test.go to use the new uws test framework. A few example tests are included.