### PR TITLE
[Incubator][VC] Ensure ClusterVNodePodMap is consistent in Pod checker.

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/resources/pod/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/checker.go
@@ -257,6 +257,11 @@ func (c *controller) checkPodsOfTenantCluster(clusterName string) {
 			// We should skip pods with NodeName set in the spec
 			continue
 		}
+		// Ensure the ClusterVNodePodMap is consistent
+		if vPod.Spec.NodeName != "" && !c.checkClusterVNodePodMap(clusterName, vPod.Spec.NodeName, string(vPod.UID)) {
+			klog.Errorf("Found vPod %s/%s in cluster %s is missing in ClusterVNodePodMap, added back!", vPod.Namespace, vPod.Name, clusterName)
+			c.updateClusterVNodePodMap(clusterName, vPod.Spec.NodeName, string(vPod.UID), reconciler.UpdateEvent)
+		}
 		targetNamespace := conversion.ToSuperMasterNamespace(clusterName, vPod.Namespace)
 		pPod, err := c.podLister.Pods(targetNamespace).Get(vPod.Name)
 		if errors.IsNotFound(err) {

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/controller.go
@@ -215,6 +215,19 @@ func (c *controller) removeQuiescingNodeFromClusterVNodeGCMap(cluster string, no
 	return true
 }
 
+func (c *controller) checkClusterVNodePodMap(clusterName, nodeName, uid string) bool {
+	c.Lock()
+	defer c.Unlock()
+	if _, exist := c.clusterVNodePodMap[clusterName]; !exist {
+		return false
+	} else if _, exist := c.clusterVNodePodMap[clusterName][nodeName]; !exist {
+		return false
+	} else if _, exist := c.clusterVNodePodMap[clusterName][nodeName][uid]; !exist {
+		return false
+	}
+	return true
+}
+
 func (c *controller) updateClusterVNodePodMap(clusterName, nodeName, requestUID string, event reconciler.EventType) {
 	c.Lock()
 	defer c.Unlock()


### PR DESCRIPTION
This change ensures ClusterVNodePodMap is consistent when scanning all tenant Pods in periodic check. 

With this change, it is almost impossible for vNode gc routine to wrongly remove a vNode if it 
has been bound with a vPod since the DefaultvNodeGCGracePeriod is 120 seconds (larger than the default  periodic check interval of 60 seconds). 