### PR TITLE
[Incubator][VC]Introduce Patroller to abstract periodic checker

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/patrol/patroller.go
+++ b/incubator/virtualcluster/pkg/syncer/patrol/patroller.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patrol
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
+)
+
+type Patroller struct {
+	name string
+
+	Options
+}
+
+// Options are the arguments for creating a new UpwardController.
+type Options struct {
+	Reconciler reconciler.PatrolReconciler
+	Period     time.Duration
+}
+
+func NewPatroller(name string, options Options) (*Patroller, error) {
+	if options.Reconciler == nil {
+		return nil, fmt.Errorf("must specify patrol reconciler")
+	}
+
+	if len(name) == 0 {
+		return nil, fmt.Errorf("must specify Name for patrol reconciler")
+	}
+	p := &Patroller{
+		name:    name,
+		Options: options,
+	}
+	if p.Period == 0 {
+		p.Period = 60 * time.Second
+	}
+	return p, nil
+}
+
+func (p *Patroller) Start(stop <-chan struct{}) {
+	klog.Infof("start periodic checker %s", p.name)
+	wait.Until(p.Reconciler.PatrollerDo, p.Period, stop)
+}

--- a/incubator/virtualcluster/pkg/syncer/reconciler/reconciler.go
+++ b/incubator/virtualcluster/pkg/syncer/reconciler/reconciler.go
@@ -49,3 +49,8 @@ type DWReconciler interface {
 type UWReconciler interface {
 	BackPopulate(string) error
 }
+
+// PatrolReconciler is the interface used by a peroidic checker to ensure the object consistency between tenant and super master.
+type PatrolReconciler interface {
+	PatrollerDo()
+}

--- a/incubator/virtualcluster/pkg/syncer/resources/configmap/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/configmap/checker.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
@@ -37,25 +36,19 @@ import (
 
 var numMissMatchedConfigMaps uint64
 
-// StartPeriodChecker starts the period checker for data consistency check. Checker is
-// blocking so should be called via a goroutine.
-func (c *controller) StartPeriodChecker(stopCh <-chan struct{}) error {
+func (c *controller) StartPatrol(stopCh <-chan struct{}) error {
 	defer utilruntime.HandleCrash()
 
 	if !cache.WaitForCacheSync(stopCh, c.configMapSynced) {
 		return fmt.Errorf("failed to wait for caches to sync before starting ConfigMap checker")
 	}
-
-	// Start a loop to periodically check if configmaps keep consistency between super
-	// master and tenant masters.
-	wait.Until(c.checkConfigMaps, c.periodCheckerPeriod, stopCh)
-
+	c.configMapPatroller.Start(stopCh)
 	return nil
 }
 
-// checkConfigMaps checks to see if configmaps in super master informer cache and tenant master
+// PatrollerDo checks to see if configmaps in super master informer cache and tenant master
 // keep consistency.
-func (c *controller) checkConfigMaps() {
+func (c *controller) PatrollerDo() {
 	clusterNames := c.multiClusterConfigMapController.GetClusterNames()
 	if len(clusterNames) == 0 {
 		klog.Infof("tenant masters has no clusters, give up period checker")

--- a/incubator/virtualcluster/pkg/syncer/resources/endpoints/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/endpoints/controller.go
@@ -17,8 +17,6 @@ limitations under the License.
 package endpoints
 
 import (
-	"time"
-
 	v1 "k8s.io/api/core/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -29,6 +27,7 @@ import (
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
+	pa "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/patrol"
 )
 
 type controller struct {
@@ -39,8 +38,8 @@ type controller struct {
 	endpointsSynced cache.InformerSynced
 	// Connect to all tenant master endpoints informers
 	multiClusterEndpointsController *mc.MultiClusterController
-	// Checker timer
-	periodCheckerPeriod time.Duration
+	// Periodic checker
+	endPointsPatroller *pa.Patroller
 }
 
 func Register(
@@ -50,8 +49,7 @@ func Register(
 	controllerManager *manager.ControllerManager,
 ) {
 	c := &controller{
-		endpointClient:      endpointsClient,
-		periodCheckerPeriod: 60 * time.Second,
+		endpointClient: endpointsClient,
 	}
 
 	options := mc.Options{Reconciler: c}
@@ -63,6 +61,14 @@ func Register(
 	c.multiClusterEndpointsController = multiClusterEndpointsController
 	c.endpointsLister = endpointsInformer.Lister()
 	c.endpointsSynced = endpointsInformer.Informer().HasSynced
+
+	patrolOptions := &pa.Options{Reconciler: c}
+	endPointsPatroller, err := pa.NewPatroller("endPoints-patroller", *patrolOptions)
+	if err != nil {
+		klog.Errorf("failed to create endpoints patroller %v", err)
+		return
+	}
+	c.endPointsPatroller = endPointsPatroller
 
 	controllerManager.AddResourceSyncer(c)
 }

--- a/incubator/virtualcluster/pkg/syncer/resources/event/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/event/controller.go
@@ -128,8 +128,11 @@ func (c *controller) StartDWS(stopCh <-chan struct{}) error {
 	return nil
 }
 
-func (c *controller) StartPeriodChecker(stopCh <-chan struct{}) error {
+func (c *controller) StartPatrol(stopCh <-chan struct{}) error {
 	return nil
+}
+
+func (c *controller) PatrollerDo() {
 }
 
 func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {

--- a/incubator/virtualcluster/pkg/syncer/resources/node/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/node/controller.go
@@ -102,8 +102,11 @@ func Register(
 	controllerManager.AddResourceSyncer(c)
 }
 
-func (c *controller) StartPeriodChecker(stopCh <-chan struct{}) error {
+func (c *controller) StartPatrol(stopCh <-chan struct{}) error {
 	return nil
+}
+
+func (c *controller) PatrollerDo() {
 }
 
 func (c *controller) AddCluster(cluster mc.ClusterInterface) {

--- a/incubator/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/checker.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
@@ -37,18 +36,17 @@ import (
 
 var numMissMatchedPVCs uint64
 
-func (c *controller) StartPeriodChecker(stopCh <-chan struct{}) error {
+func (c *controller) StartPatrol(stopCh <-chan struct{}) error {
 	if !cache.WaitForCacheSync(stopCh, c.pvcSynced) {
 		return fmt.Errorf("failed to wait for caches to sync before starting Service checker")
 	}
-
-	wait.Until(c.checkPVCs, c.periodCheckerPeriod, stopCh)
+	c.persistentVolumeClaimPatroller.Start(stopCh)
 	return nil
 }
 
-// checkPVCs check if persistent volume claims keep consistency between super
+// PatrollerDo check if persistent volume claims keep consistency between super
 // master and tenant masters.
-func (c *controller) checkPVCs() {
+func (c *controller) PatrollerDo() {
 	clusterNames := c.multiClusterPersistentVolumeClaimController.GetClusterNames()
 	if len(clusterNames) == 0 {
 		klog.Infof("tenant masters has no clusters, give up period checker")

--- a/incubator/virtualcluster/pkg/syncer/resources/secret/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/secret/checker.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
@@ -38,16 +37,16 @@ import (
 var numMissMatchedOpaqueSecrets uint64
 var numMissMatchedSASecrets uint64
 
-func (c *controller) StartPeriodChecker(stopCh <-chan struct{}) error {
+func (c *controller) StartPatrol(stopCh <-chan struct{}) error {
 	if !cache.WaitForCacheSync(stopCh, c.secretSynced) {
 		return fmt.Errorf("failed to wait for caches to sync before starting secret checker")
 	}
-
-	wait.Until(c.checkSecrets, c.periodCheckerPeriod, stopCh)
+	c.secretPatroller.Start(stopCh)
 	return nil
 }
 
-func (c *controller) checkSecrets() {
+// PatrollerDo check if normal secrets and service account secrets keep consistency between super master and tenant masters.
+func (c *controller) PatrollerDo() {
 	clusterNames := c.multiClusterSecretController.GetClusterNames()
 	if len(clusterNames) == 0 {
 		klog.Infof("tenant masters has no clusters, give up secret period checker")

--- a/incubator/virtualcluster/pkg/syncer/resources/service/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/service/checker.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 
@@ -38,18 +37,17 @@ import (
 
 var numMissMatchedServices uint64
 
-func (c *controller) StartPeriodChecker(stopCh <-chan struct{}) error {
+func (c *controller) StartPatrol(stopCh <-chan struct{}) error {
 	if !cache.WaitForCacheSync(stopCh, c.serviceSynced) {
 		return fmt.Errorf("failed to wait for caches to sync before starting Service checker")
 	}
-
-	wait.Until(c.checkServices, c.periodCheckerPeriod, stopCh)
+	c.servicePatroller.Start(stopCh)
 	return nil
 }
 
-// checkServices check if services keep consistency between super
+// PatrollerDo check if services keep consistency between super
 // master and tenant masters.
-func (c *controller) checkServices() {
+func (c *controller) PatrollerDo() {
 	clusterNames := c.multiClusterServiceController.GetClusterNames()
 	if len(clusterNames) == 0 {
 		klog.Infof("tenant masters has no clusters, give up period checker")

--- a/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/controller.go
@@ -17,8 +17,6 @@ limitations under the License.
 package serviceaccount
 
 import (
-	"time"
-
 	"k8s.io/api/core/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -30,6 +28,7 @@ import (
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
+	pa "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/patrol"
 )
 
 type controller struct {
@@ -40,8 +39,8 @@ type controller struct {
 	saSynced cache.InformerSynced
 	// Connect to all tenant master sa informers
 	multiClusterServiceAccountController *mc.MultiClusterController
-	// Checker timer
-	periodCheckerPeriod time.Duration
+	// Periodic checker
+	serviceAccountPatroller *pa.Patroller
 }
 
 func Register(
@@ -51,8 +50,7 @@ func Register(
 	controllerManager *manager.ControllerManager,
 ) {
 	c := &controller{
-		saClient:            client,
-		periodCheckerPeriod: 60 * time.Second,
+		saClient: client,
 	}
 
 	// Create the multi cluster secret controller
@@ -65,6 +63,14 @@ func Register(
 	c.multiClusterServiceAccountController = multiClusterServiceAccountController
 	c.saLister = saInformer.Lister()
 	c.saSynced = saInformer.Informer().HasSynced
+
+	patrolOptions := &pa.Options{Reconciler: c}
+	serviceAccountPatroller, err := pa.NewPatroller("serviceAccount-patroller", *patrolOptions)
+	if err != nil {
+		klog.Errorf("failed to create serviceAccount patroller %v", err)
+		return
+	}
+	c.serviceAccountPatroller = serviceAccountPatroller
 
 	controllerManager.AddResourceSyncer(c)
 }


### PR DESCRIPTION
This change introduces Patroller struct to abstract the current periodic checker mechanism used by all resource syncers. This is the prerequisite for implementing checker mock tests. 

A new method PatrollerDo is added to manager.Controller interface and the StartPeriodChecker method is renamed to StartPatrol.

