### PR TITLE
[Incubator][VC]Add Pod patrol mock tests

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/conversion/equality.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/equality.go
@@ -276,16 +276,17 @@ func (e vcEquality) checkContainersImageEquality(pObj, vObj []v1.Container) []v1
 		return nil
 	}
 
-	for i, v := range pObj {
+	var updated []v1.Container
+	for _, v := range pObj {
 		if diff[v.Name] == v.Image {
-			continue
+			updated = append(updated, v)
+		} else {
+			c := v.DeepCopy()
+			c.Image = diff[v.Name]
+			updated = append(updated, *c)
 		}
-		c := v.DeepCopy()
-		c.Image = diff[v.Name]
-		pObj[i] = *c
 	}
-
-	return pObj
+	return updated
 }
 
 func (e vcEquality) checkInt64Equality(pObj, vObj *int64) (*int64, bool) {

--- a/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
+++ b/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
@@ -343,7 +343,7 @@ func (c *MultiClusterController) processNextWorkItem() bool {
 
 	if shutdown {
 		// Stop working
-		klog.Warning("Shutting down. Ignore work item and stop working.")
+		klog.V(4).Info("Shutting down. Ignore work item and stop working.")
 		return false
 	}
 
@@ -378,7 +378,6 @@ func (c *MultiClusterController) processNextWorkItem() bool {
 	if result, err := c.Reconciler.Reconcile(req); err != nil {
 		c.Queue.AddRateLimited(req)
 		klog.Error(err)
-		klog.Error("Could not reconcile Request. Stop working.")
 		return false
 	} else if result.RequeueAfter > 0 {
 		c.Queue.AddAfter(req, result.RequeueAfter)

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/checker_test.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/checker_test.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	stdlog "log"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	core "k8s.io/client-go/testing"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/util/test"
+)
+
+func TestPodPatrol(t *testing.T) {
+	testTenant := &v1alpha1.Virtualcluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "tenant-1",
+			UID:       "7374a172-c35d-45b1-9c8e-bf5c5b614937",
+		},
+		Spec: v1alpha1.VirtualclusterSpec{},
+		Status: v1alpha1.VirtualclusterStatus{
+			Phase: v1alpha1.ClusterRunning,
+		},
+	}
+	spec1 := &v1.PodSpec{
+		Containers: []v1.Container{
+			{
+				Image: "ngnix",
+				Name:  "c-1",
+			},
+		},
+		NodeName: "n1",
+	}
+	spec2 := &v1.PodSpec{
+		Containers: []v1.Container{
+			{
+				Image: "busybox",
+				Name:  "c-1",
+			},
+		},
+		NodeName: "n1",
+	}
+	statusPending := &v1.PodStatus{
+		Phase: "Pending",
+	}
+	statusReadyAndRunning := &v1.PodStatus{
+		Phase: "Running",
+		Conditions: []v1.PodCondition{
+			{
+				Type:   "PodScheduled",
+				Status: "True",
+			},
+		},
+	}
+
+	defaultClusterKey := conversion.ToClusterKey(testTenant)
+	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+
+	testcases := map[string]struct {
+		ExistingObjectInSuper  []runtime.Object
+		ExistingObjectInTenant []runtime.Object
+		ExpectedDeletedPPods   []string
+		ExpectedDeletedVPods   []string
+		ExpectedCreatedPPods   []string
+		ExpectedUpdatedPPods   []runtime.Object
+		ExpectedUpdatedVPods   []runtime.Object
+		WaitDWS                bool // Make sure to set this flag if the test involves DWS.
+		WaitUWS                bool // Make sure to set this flag if the test involves UWS.
+	}{
+		"pPod exists, vPod does not exists": {
+			ExistingObjectInSuper: []runtime.Object{
+				superAssignedPod("pod-1", superDefaultNSName, "12345", "n1", defaultClusterKey),
+			},
+			ExpectedDeletedPPods: []string{
+				superDefaultNSName + "/pod-1",
+			},
+		},
+		"pPod exists, vPod exists with different uid": {
+			ExistingObjectInSuper: []runtime.Object{
+				superAssignedPod("pod-2", superDefaultNSName, "12345", "n1", defaultClusterKey),
+			},
+			ExistingObjectInTenant: []runtime.Object{
+				tenantAssignedPod("pod-2", "default", "123456", "n1"),
+			},
+			ExpectedDeletedPPods: []string{
+				superDefaultNSName + "/pod-2",
+			},
+		},
+		"pPod exists, vPod exists with different spec": {
+			ExistingObjectInSuper: []runtime.Object{
+				applyStatusToPod(applySpecToPod(superAssignedPod("pod-3", superDefaultNSName, "12345", "n1", defaultClusterKey), spec2), statusReadyAndRunning),
+			},
+			ExistingObjectInTenant: []runtime.Object{
+				applyStatusToPod(applySpecToPod(tenantAssignedPod("pod-3", "default", "12345", "n1"), spec1), statusReadyAndRunning),
+			},
+			ExpectedUpdatedPPods: []runtime.Object{
+				applyStatusToPod(applySpecToPod(superAssignedPod("pod-3", superDefaultNSName, "12345", "n1", defaultClusterKey), spec1), statusReadyAndRunning),
+			},
+			WaitDWS: true,
+		},
+		"pPod exists, vPod exists with different status": {
+			ExistingObjectInSuper: []runtime.Object{
+				applyStatusToPod(superAssignedPod("pod-4", superDefaultNSName, "12345", "n1", defaultClusterKey), statusReadyAndRunning),
+			},
+			ExistingObjectInTenant: []runtime.Object{
+				applyStatusToPod(tenantAssignedPod("pod-4", "default", "12345", "n1"), statusPending),
+				tenantNode("n1"),
+			},
+			ExpectedUpdatedVPods: []runtime.Object{
+				applyStatusToPod(tenantAssignedPod("pod-4", "default", "12345", "n1"), statusReadyAndRunning),
+			},
+			WaitUWS: true,
+		},
+		"vPod not scheduled, pPod does not exists": {
+			ExistingObjectInSuper: []runtime.Object{
+				superSecret("default-token-12345", superDefaultNSName, "12345"),
+				superService("kubernetes", superDefaultNSName, "12345", ""),
+			},
+			ExistingObjectInTenant: []runtime.Object{
+				tenantPod("pod-5", "default", "12345"),
+				tenantServiceAccount("default", "default", "12345"),
+			},
+			ExpectedCreatedPPods: []string{
+				superDefaultNSName + "/pod-5",
+			},
+			WaitDWS: true,
+		},
+		"vPod scheduled with DeletionTimestamp, pPod does not exists": {
+			ExistingObjectInTenant: []runtime.Object{
+				applyStatusToPod(applyDeletionTimestampToPod(tenantAssignedPod("pod-6", "default", "12345", "n1"), time.Now()), statusReadyAndRunning),
+			},
+			ExpectedDeletedVPods: []string{
+				"default/pod-6",
+			},
+		},
+		"vPod scheduled without DeletionTimestamp, pPod does not exists": {
+			ExistingObjectInTenant: []runtime.Object{
+				applyStatusToPod(tenantAssignedPod("pod-7", "default", "12345", "n1"), statusReadyAndRunning),
+			},
+			ExpectedDeletedVPods: []string{
+				"default/pod-7",
+			},
+		},
+		"vPod nodename is not equal to pPod nodename": {
+			ExistingObjectInSuper: []runtime.Object{
+				applyStatusToPod(superAssignedPod("pod-8", superDefaultNSName, "12345", "n2", defaultClusterKey), statusReadyAndRunning),
+			},
+			ExistingObjectInTenant: []runtime.Object{
+				applyStatusToPod(tenantAssignedPod("pod-8", "default", "12345", "n1"), statusReadyAndRunning),
+			},
+			ExpectedDeletedVPods: []string{
+				"default/pod-8",
+			},
+		},
+	}
+
+	for k, tc := range testcases {
+		t.Run(k, func(t *testing.T) {
+			stdlog.Printf("%s: start to run.", k)
+			tenantActions, superActions, err := util.RunPatrol(NewPodController, testTenant, tc.ExistingObjectInSuper, tc.ExistingObjectInTenant, tc.WaitDWS, tc.WaitUWS)
+			if err != nil {
+				t.Errorf("%s: error running patrol: %v", k, err)
+				return
+			}
+
+			if tc.ExpectedDeletedPPods != nil {
+				if len(tc.ExpectedDeletedPPods) != len(superActions) {
+					t.Errorf("%s: Expected to delete PPod %#v. Actual actions were: %#v", k, tc.ExpectedDeletedPPods, superActions)
+					return
+				}
+				for i, expectedName := range tc.ExpectedDeletedPPods {
+					action := superActions[i]
+					if !action.Matches("delete", "pods") {
+						t.Errorf("%s: Unexpected action %s", k, action)
+						continue
+					}
+					fullName := action.(core.DeleteAction).GetNamespace() + "/" + action.(core.DeleteAction).GetName()
+					if fullName != expectedName {
+						t.Errorf("%s: Expect to delete pPod %s, got %s", k, expectedName, fullName)
+					}
+				}
+			}
+			if tc.ExpectedDeletedVPods != nil {
+				if len(tc.ExpectedDeletedVPods) != len(tenantActions) {
+					t.Errorf("%s: Expected to delete VPod %#v. Actual actions were: %#v", k, tc.ExpectedDeletedVPods, tenantActions)
+					return
+				}
+				for i, expectedName := range tc.ExpectedDeletedVPods {
+					action := tenantActions[i]
+					if !action.Matches("delete", "pods") {
+						t.Errorf("%s: Unexpected action %s", k, action)
+						continue
+					}
+					fullName := action.(core.DeleteAction).GetNamespace() + "/" + action.(core.DeleteAction).GetName()
+					if fullName != expectedName {
+						t.Errorf("%s: Expect to delete pPod %s, got %s", k, expectedName, fullName)
+					}
+				}
+			}
+			if tc.ExpectedCreatedPPods != nil {
+				if len(tc.ExpectedCreatedPPods) != len(superActions) {
+					t.Errorf("%s: Expected to create PPod %#v. Actual actions were: %#v", k, tc.ExpectedCreatedPPods, superActions)
+					return
+				}
+				for i, expectedName := range tc.ExpectedCreatedPPods {
+					action := superActions[i]
+					if !action.Matches("create", "pods") {
+						t.Errorf("%s: Unexpected action %s", k, action)
+						continue
+					}
+					createdPod := action.(core.CreateAction).GetObject().(*v1.Pod)
+					fullName := createdPod.Namespace + "/" + createdPod.Name
+					if fullName != expectedName {
+						t.Errorf("%s: Expect to create pPod %s, got %s", k, expectedName, fullName)
+					}
+				}
+			}
+			if tc.ExpectedUpdatedPPods != nil {
+				if len(tc.ExpectedUpdatedPPods) != len(superActions) {
+					t.Errorf("%s: Expected to update PPod %#v. Actual actions were: %#v", k, tc.ExpectedUpdatedPPods, superActions)
+					return
+				}
+				for i, obj := range tc.ExpectedUpdatedPPods {
+					action := superActions[i]
+					if !action.Matches("update", "pods") {
+						t.Errorf("%s: Unexpected action %s", k, action)
+					}
+					actionObj := action.(core.UpdateAction).GetObject()
+					if !equality.Semantic.DeepEqual(obj, actionObj) {
+						t.Errorf("%s: Expected updated pPod is %v, got %v", k, obj, actionObj)
+					}
+				}
+			}
+			if tc.ExpectedUpdatedVPods != nil {
+				if len(tc.ExpectedUpdatedVPods) != len(tenantActions) {
+					t.Errorf("%s: Expected to update VPod %#v. Actual actions were: %#v", k, tc.ExpectedUpdatedVPods, tenantActions)
+					return
+				}
+				for i, obj := range tc.ExpectedUpdatedVPods {
+					action := tenantActions[i]
+					if !action.Matches("update", "pods") {
+						t.Errorf("%s: Unexpected action %s", k, action)
+					}
+					actionObj := action.(core.UpdateAction).GetObject()
+					if !equality.Semantic.DeepEqual(obj, actionObj) {
+						t.Errorf("%s: Expected updated vPod is %v, got %v", k, obj, actionObj)
+					}
+				}
+			}
+		})
+	}
+}

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/dws.go
@@ -262,7 +262,6 @@ func (c *controller) reconcilePodUpdate(clusterName, targetNamespace, requestUID
 		}
 		return err
 	}
-
 	spec, err := c.multiClusterPodController.GetSpec(clusterName)
 	if err != nil {
 		return err

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/uws_test.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/uws_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/util/test"
 )
 
-func uwTenantPod(name, namespace, uid, nodename string) *v1.Pod {
+func tenantAssignedPod(name, namespace, uid, nodename string) *v1.Pod {
 	return &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -51,7 +51,7 @@ func uwTenantPod(name, namespace, uid, nodename string) *v1.Pod {
 	}
 }
 
-func uwSuperPod(name, namespace, uid, nodename, clusterKey string) *v1.Pod {
+func superAssignedPod(name, namespace, uid, nodename, clusterKey string) *v1.Pod {
 	return &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -118,24 +118,24 @@ func TestUWPodUpdate(t *testing.T) {
 	}{
 		"update vPod status": {
 			ExistingObjectInSuper: []runtime.Object{
-				applyStatusToPod(uwSuperPod("pod-1", superDefaultNSName, "12345", "n1", defaultClusterKey), statusRunning),
+				applyStatusToPod(superAssignedPod("pod-1", superDefaultNSName, "12345", "n1", defaultClusterKey), statusRunning),
 			},
 			ExistingObjectInTenant: []runtime.Object{
-				applyStatusToPod(uwTenantPod("pod-1", "default", "12345", "n1"), statusPending),
+				applyStatusToPod(tenantAssignedPod("pod-1", "default", "12345", "n1"), statusPending),
 				tenantNode("n1"),
 			},
 			EnquedKey: superDefaultNSName + "/pod-1",
 			ExpectedUpdatedPods: []runtime.Object{
-				applyStatusToPod(uwTenantPod("pod-1", "default", "12345", "n1"), statusRunning),
+				applyStatusToPod(tenantAssignedPod("pod-1", "default", "12345", "n1"), statusRunning),
 			},
 			ExpectedError: "",
 		},
 		"vPod existing with different uid one": {
 			ExistingObjectInSuper: []runtime.Object{
-				uwSuperPod("pod-1", superDefaultNSName, "123456", "n1", defaultClusterKey),
+				superAssignedPod("pod-1", superDefaultNSName, "123456", "n1", defaultClusterKey),
 			},
 			ExistingObjectInTenant: []runtime.Object{
-				uwTenantPod("pod-1", "default", "12345", "n1"),
+				tenantAssignedPod("pod-1", "default", "12345", "n1"),
 			},
 			EnquedKey:           superDefaultNSName + "/pod-1",
 			ExpectedUpdatedPods: []runtime.Object{},

--- a/incubator/virtualcluster/pkg/syncer/util/test/runPatrol.go
+++ b/incubator/virtualcluster/pkg/syncer/util/test/runPatrol.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	core "k8s.io/client-go/testing"
+	fakeClient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/cluster"
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
+	mc "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
+	pa "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/patrol"
+	uw "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/uwcontroller"
+)
+
+type fakePatrolReconciler struct {
+	resourceSyncer manager.ResourceSyncer
+	errCh          chan error
+}
+
+func (r *fakePatrolReconciler) PatrollerDo() {
+	var err error
+	if r.resourceSyncer != nil {
+		r.resourceSyncer.PatrollerDo()
+		err = nil
+	} else {
+		err = fmt.Errorf("fake patrol reconciler is not initialized")
+	}
+	r.errCh <- err
+}
+
+func (r *fakePatrolReconciler) SetResourceSyncer(c manager.ResourceSyncer) {
+	r.resourceSyncer = c
+}
+
+func RunPatrol(
+	newControllerFunc controllerNew,
+	testTenant *v1alpha1.Virtualcluster,
+	existingObjectInSuper []runtime.Object,
+	existingObjectInTenant []runtime.Object,
+	waitDWS bool,
+	waitUWS bool,
+) ([]core.Action, []core.Action, error) {
+	// setup fake tenant cluster
+	tenantClientset := fake.NewSimpleClientset()
+	tenantClient := fakeClient.NewFakeClient()
+	if existingObjectInTenant != nil {
+		tenantClientset = fake.NewSimpleClientset(existingObjectInTenant...)
+		// For controller runtime client, if the informer cache is empty, the request goes to client obj tracker.
+		// Hence we don't have to populate the infomer cache.
+		tenantClient = fakeClient.NewFakeClient(existingObjectInTenant...)
+	}
+	tenantCluster, err := cluster.NewFakeTenantCluster(testTenant, tenantClientset, tenantClient)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating tenantCluster: %v", err)
+	}
+
+	// setup fake super cluster
+	superClient := fake.NewSimpleClientset()
+	if existingObjectInSuper != nil {
+		superClient = fake.NewSimpleClientset(existingObjectInSuper...)
+	}
+	superInformer := informers.NewSharedInformerFactory(superClient, 0)
+	// setup fake controller
+	syncDWS := make(chan error)
+	defer close(syncDWS)
+	syncUWS := make(chan error)
+	defer close(syncUWS)
+	syncPatrol := make(chan error)
+	defer close(syncPatrol)
+
+	fakePatrolRc := &fakePatrolReconciler{errCh: syncPatrol}
+	fakeDWRc := &fakeReconciler{errCh: syncDWS}
+	fakeUWRc := &fakeUWReconciler{errCh: syncUWS}
+
+	rsOptions := &manager.ResourceSyncerOptions{
+		MCOptions:     &mc.Options{Reconciler: fakeDWRc},
+		UWOptions:     &uw.Options{Reconciler: fakeUWRc},
+		PatrolOptions: &pa.Options{Reconciler: fakePatrolRc},
+		IsFake:        true,
+	}
+
+	resourceSyncer, _, _, err := newControllerFunc(
+		&config.SyncerConfiguration{
+			DisableServiceAccountToken: true,
+		},
+		superClient.CoreV1(),
+		superInformer.Core().V1(),
+		rsOptions,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating controller: %v", err)
+	}
+	fakePatrolRc.SetResourceSyncer(resourceSyncer)
+	fakeDWRc.SetResourceSyncer(resourceSyncer)
+	fakeUWRc.SetResourceSyncer(resourceSyncer)
+
+	// register tenant cluster to controller.
+	resourceSyncer.AddCluster(tenantCluster)
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	// add object to super informer.
+	for _, each := range existingObjectInSuper {
+		informer := getObjectInformer(superInformer.Core().V1(), each)
+		informer.GetStore().Add(each)
+	}
+	go resourceSyncer.StartDWS(stopCh)
+	go resourceSyncer.StartUWS(stopCh)
+	go resourceSyncer.StartPatrol(stopCh)
+
+	// wait to be called
+	select {
+	case _ = <-syncPatrol:
+	case <-time.After(10 * time.Second):
+		return nil, nil, fmt.Errorf("timeout waiting for syncPatrol")
+	}
+	if waitDWS {
+		select {
+		case _ = <-syncDWS:
+		case <-time.After(10 * time.Second):
+			return nil, nil, fmt.Errorf("timeout waiting for syncDWS")
+		}
+	}
+	if waitUWS {
+		select {
+		case _ = <-syncUWS:
+		case <-time.After(10 * time.Second):
+			return nil, nil, fmt.Errorf("timeout waiting for syncUWS")
+		}
+	}
+
+	return tenantClientset.Actions(), superClient.Actions(), nil
+}


### PR DESCRIPTION
This change add mock test for Pod periodic checker. With these tests, the checker.go code coverage reaches 63.8%.

This change also fixes a bug found during the mock test. The `checkContainersImageEquality` method sure not directly modify the input pObj since the change will be saved in the informer cache.
