### PR TITLE
[Incubator][VC]Add vNode GC mock tests

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/resources/pod/checker_test.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/checker_test.go
@@ -322,8 +322,6 @@ func TestVNodeGC(t *testing.T) {
 		ExistingObjectInTenant []runtime.Object
 		ExpectedDeletedVNodes  []string
 		StateModifyFunc        func(manager.ResourceSyncer)
-		WaitDWS                bool // Make sure to set this flag if the test involves DWS.
-		WaitUWS                bool // Make sure to set this flag if the test involves UWS.
 	}{
 		"vNode is bound with a vPod": {
 			ExistingObjectInSuper: []runtime.Object{
@@ -375,7 +373,7 @@ func TestVNodeGC(t *testing.T) {
 
 	for k, tc := range testcases {
 		t.Run(k, func(t *testing.T) {
-			tenantActions, _, err := util.RunPatrol(NewPodController, testTenant, tc.ExistingObjectInSuper, tc.ExistingObjectInTenant, tc.WaitDWS, tc.WaitUWS, tc.StateModifyFunc)
+			tenantActions, _, err := util.RunPatrol(NewPodController, testTenant, tc.ExistingObjectInSuper, tc.ExistingObjectInTenant, false, false, tc.StateModifyFunc)
 			if err != nil {
 				t.Errorf("%s: error running patrol: %v", k, err)
 				return

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/controller.go
@@ -19,6 +19,7 @@ package pod
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,6 +63,7 @@ type controller struct {
 	sync.Mutex
 	clusterVNodePodMap map[string]map[string]map[string]struct{}
 	clusterVNodeGCMap  map[string]map[string]VNodeGCStatus
+	vNodeGCGracePeriod time.Duration
 }
 
 type VirtulNodeDeletionPhase string
@@ -100,6 +102,7 @@ func NewPodController(config *config.SyncerConfiguration,
 		informer:           informer,
 		clusterVNodePodMap: make(map[string]map[string]map[string]struct{}),
 		clusterVNodeGCMap:  make(map[string]map[string]VNodeGCStatus),
+		vNodeGCGracePeriod: constants.DefaultvNodeGCGracePeriod,
 	}
 	var mcOptions *mc.Options
 	if options == nil || options.MCOptions == nil {

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/uws_test.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/uws_test.go
@@ -52,7 +52,7 @@ func tenantAssignedPod(name, namespace, uid, nodename string) *v1.Pod {
 	}
 }
 
-func badSuperPod(name, namespace string) *v1.Pod {
+func unKnownSuperPod(name, namespace string) *v1.Pod {
 	return &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -90,6 +90,9 @@ func fakeNode(name string) *v1.Node {
 	return &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
+			Labels: map[string]string{
+				constants.LabelVirtualNode: "true",
+			},
 		},
 	}
 }
@@ -185,7 +188,7 @@ func TestUWPodUpdate(t *testing.T) {
 		},
 		"pPod not created by syncer": {
 			ExistingObjectInSuper: []runtime.Object{
-				badSuperPod("pod-1", superDefaultNSName),
+				unKnownSuperPod("pod-1", superDefaultNSName),
 			},
 			EnquedKey: superDefaultNSName + "/pod-1",
 		},

--- a/incubator/virtualcluster/pkg/syncer/util/test/runDWS.go
+++ b/incubator/virtualcluster/pkg/syncer/util/test/runDWS.go
@@ -54,7 +54,8 @@ func (r *fakeReconciler) Reconcile(request reconciler.Request) (reconciler.Resul
 		res, err = reconciler.Result{}, fmt.Errorf("fake reconciler's controller is not initialized")
 	}
 	r.errCh <- err
-	return res, err
+	// Make sure Reconcile is called once by returning no error.
+	return res, nil
 }
 
 func (r *fakeReconciler) SetResourceSyncer(c manager.ResourceSyncer) {

--- a/incubator/virtualcluster/pkg/syncer/util/test/runPatrol.go
+++ b/incubator/virtualcluster/pkg/syncer/util/test/runPatrol.go
@@ -55,6 +55,8 @@ func (r *fakePatrolReconciler) SetResourceSyncer(c manager.ResourceSyncer) {
 	r.resourceSyncer = c
 }
 
+type controllerStateModifier func(manager.ResourceSyncer)
+
 func RunPatrol(
 	newControllerFunc controllerNew,
 	testTenant *v1alpha1.Virtualcluster,
@@ -62,6 +64,7 @@ func RunPatrol(
 	existingObjectInTenant []runtime.Object,
 	waitDWS bool,
 	waitUWS bool,
+	controllerStateModifyFunc controllerStateModifier,
 ) ([]core.Action, []core.Action, error) {
 	// setup fake tenant cluster
 	tenantClientset := fake.NewSimpleClientset()
@@ -116,6 +119,11 @@ func RunPatrol(
 	fakePatrolRc.SetResourceSyncer(resourceSyncer)
 	fakeDWRc.SetResourceSyncer(resourceSyncer)
 	fakeUWRc.SetResourceSyncer(resourceSyncer)
+
+	// Update controller internal state
+	if controllerStateModifyFunc != nil {
+		controllerStateModifyFunc(resourceSyncer)
+	}
 
 	// register tenant cluster to controller.
 	resourceSyncer.AddCluster(tenantCluster)

--- a/incubator/virtualcluster/pkg/syncer/util/test/runUWS.go
+++ b/incubator/virtualcluster/pkg/syncer/util/test/runUWS.go
@@ -46,7 +46,8 @@ func (r *fakeUWReconciler) BackPopulate(key string) error {
 		err = fmt.Errorf("fake reconciler's upward controller is not initialized")
 	}
 	r.errCh <- err
-	return err
+	// Make sure the BackPopulate is called once by returning no error
+	return nil
 }
 
 func (r *fakeUWReconciler) SetResourceSyncer(c manager.ResourceSyncer) {


### PR DESCRIPTION
This change has the done the following to enable vNode GC mock tests:

- Instead of using another go routine, the periodic gc checker is moved to Pod PatrollerDo method. 
- Introduce `vNodeGCGracePeriod` field in Pod controller so that we can manipulate the value.
- Change RunPatrol to allow calling external function to manipulate the controller state. 

The checker code coverage increases from 62% to 80% with the added tests.