### PR TITLE
Enables the path to the config to be passed in as a flag

### DIFF
--- a/benchmarks/documentation/run.md
+++ b/benchmarks/documentation/run.md
@@ -32,6 +32,11 @@ tenantA:
 go test ./e2e/tests
 ```
 
+#### You can also pass in the path to your  config. The path can either be absolute or a relative file to `benchmarks/e2e/config`
+```shell 
+go test ./e2e/tests -config <path-to-config>
+```
+
 ### To see a more verbose output from the test
 
 ```shell

--- a/benchmarks/e2e/config/config.go
+++ b/benchmarks/e2e/config/config.go
@@ -5,7 +5,8 @@ import (
 	"reflect"
 )
 
-const ConfigPath = "../../config.yaml"
+// ConfigFlagType is the type for flags for the tests
+var ConfigPath string
 
 type BenchmarkConfig struct {
 	Adminkubeconfig string     `yaml:"adminKubeconfig"`

--- a/benchmarks/e2e/config/utils.go
+++ b/benchmarks/e2e/config/utils.go
@@ -1,13 +1,13 @@
 package test
 
 import (
-	"io/ioutil"
-	"os"
 	"errors"
 	"gopkg.in/yaml.v2"
+	"io/ioutil"
 	kubernetes "k8s.io/client-go/kubernetes"
 	clientcmd "k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubernetes/test/e2e/framework"
+	"os"
 )
 
 func GetContextFromKubeconfig(kubeconfigpath string) string {

--- a/benchmarks/e2e/tests/e2e_test.go
+++ b/benchmarks/e2e/tests/e2e_test.go
@@ -6,6 +6,7 @@ import (
 
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/config"
+	configutil "sigs.k8s.io/multi-tenancy/benchmarks/e2e/config"
 )
 
 // handleFlags sets up all flags and parses the command line.
@@ -13,6 +14,8 @@ func handleFlags() {
 	config.CopyFlags(config.Flags, flag.CommandLine)
 	framework.RegisterCommonFlags(flag.CommandLine)
 	framework.RegisterClusterFlags(flag.CommandLine)
+	flag.StringVar(&configutil.ConfigPath,"config", "../../config.yaml",
+		"Path of the config file for the tests")
 }
 
 func init() {


### PR DESCRIPTION
This pull request allows for the config file to be passed in as a flag with an appropriate default value when the flag isn't provided.

This makes testing easier as the config.yaml in the repo doesn't need to be replaced or rewritten