### PR TITLE
[Incubator][VC] allow user to specify a log file for vc-manager

### DIFF
--- a/incubator/virtualcluster/go.mod
+++ b/incubator/virtualcluster/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aliyun/alibaba-cloud-sdk-go v1.60.324
 	github.com/emicklei/go-restful v2.9.6+incompatible
 	github.com/go-logr/logr v0.1.0
+	github.com/go-logr/zapr v0.1.0
 	github.com/google/cadvisor v0.34.0
 	github.com/onsi/gomega v1.5.0
 	github.com/pkg/errors v0.8.1
@@ -13,6 +14,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
+	go.uber.org/zap v1.9.1
 	golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 // indirect
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9
 	k8s.io/api v0.16.5

--- a/incubator/virtualcluster/pkg/controller/util/logr/util.go
+++ b/incubator/virtualcluster/pkg/controller/util/logr/util.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logr
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+// NewLoggerToFile creates a new logr.Logger based on the zap.Logger. If the
+// 'logFile' is not empty, log to stderr and the 'logFile', otherwise, log to
+// the stderr only
+func NewLoggerToFile(logFile string) (logr.Logger, error) {
+	if logFile == "" {
+		return logf.ZapLogger(false), nil
+	}
+	// logs to both stderr and 'logFile'
+	cfg := zap.NewProductionConfig()
+	cfg.OutputPaths = []string{
+		"stderr",
+		logFile,
+	}
+	zLogr, err := cfg.Build()
+	if err != nil {
+		return nil, err
+	}
+	return zapr.NewLogger(zLogr), nil
+}


### PR DESCRIPTION
1. generate logr.Logger based on zap.Logger
2. allow zap.Logger to output the log to a user-specified file
3. if the user does not specify any log file, log to stderr only