### PR TITLE
[Incubator][VC]Implement super master namespace GC

### DIFF
--- a/incubator/virtualcluster/cmd/syncer/app/config/config.go
+++ b/incubator/virtualcluster/cmd/syncer/app/config/config.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/tools/leaderelection"
 
+	vcclient "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/client/clientset/versioned"
 	vcinformers "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/client/informers/externalversions/tenancy/v1alpha1"
 	syncerconfig "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
 )
@@ -34,7 +35,9 @@ type Config struct {
 	ComponentConfig syncerconfig.SyncerConfiguration
 
 	// the general kube client
-	SecretClient           corev1.SecretsGetter
+	SecretClient corev1.SecretsGetter
+	// virtual cluster CR client
+	VirtualClusterClient   vcclient.Interface
 	VirtualClusterInformer vcinformers.VirtualclusterInformer
 
 	// the super master client

--- a/incubator/virtualcluster/cmd/syncer/app/options/options.go
+++ b/incubator/virtualcluster/cmd/syncer/app/options/options.go
@@ -157,6 +157,7 @@ func (o *ResourceSyncerOptions) Config() (*syncerappconfig.Config, error) {
 	}
 
 	c.SecretClient = superMasterClient.CoreV1()
+	c.VirtualClusterClient = virtualClusterClient
 	c.VirtualClusterInformer = vcinformers.NewSharedInformerFactory(virtualClusterClient, 0).Tenancy().V1alpha1().Virtualclusters()
 	c.SuperMasterClient = superMasterClient
 	c.SuperMasterInformerFactory = informers.NewSharedInformerFactory(superMasterClient, 0)

--- a/incubator/virtualcluster/cmd/syncer/app/server.go
+++ b/incubator/virtualcluster/cmd/syncer/app/server.go
@@ -89,6 +89,7 @@ resource isolation policy specified in Tenant CRD.`,
 func Run(cc *syncerconfig.CompletedConfig, stopCh <-chan struct{}) error {
 	ss := syncer.New(&cc.ComponentConfig,
 		cc.SecretClient,
+		cc.VirtualClusterClient,
 		cc.VirtualClusterInformer,
 		cc.SuperMasterClient,
 		cc.SuperMasterInformerFactory)

--- a/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_aliyun.go
+++ b/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_aliyun.go
@@ -43,7 +43,6 @@ import (
 	kubeutil "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/util/kube"
 	strutil "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/controller/util/strings"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
-	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
 )
 
 const (
@@ -513,13 +512,11 @@ PollASK:
 	}
 
 	// 4. create the root namesapce of the Virtualcluster
-	vcNs := conversion.ToClusterKey(vc)
-
-	err = kubeutil.CreateRootNS(mpa, vcNs, vc.Name, string(vc.UID))
+	vcNs, err := kubeutil.CreateRootNS(mpa, vc)
 	if err != nil {
 		return err
 	}
-	log.Info("virtualcluster ns is created", "ns", vcNs)
+	log.Info("virtualcluster root ns is created", "ns", vcNs)
 
 	// 5. get kubeconfig of the newly created ASK
 	kbCfg, err := getASKKubeConfig(cli, clsID, askCfg.regionID, askCfg.privateKbCfg)

--- a/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_native.go
+++ b/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_native.go
@@ -71,10 +71,8 @@ func (mpn *MasterProvisionerNative) CreateVirtualCluster(vc *tenancyv1alpha1.Vir
 			vc.Spec.ClusterVersionName)
 		return err
 	}
-	rootNS := conversion.ToClusterKey(vc)
-
 	// 1. create the root ns
-	err = kubeutil.CreateRootNS(mpn, rootNS, vc.Name, string(vc.UID))
+	_, err = kubeutil.CreateRootNS(mpn, vc)
 	if err != nil {
 		return err
 	}

--- a/incubator/virtualcluster/pkg/syncer/cluster/cluster.go
+++ b/incubator/virtualcluster/pkg/syncer/cluster/cluster.go
@@ -133,8 +133,8 @@ func (c *Cluster) GetClusterName() string {
 	return c.key
 }
 
-func (c *Cluster) GetOwnerInfo() (string, string) {
-	return c.vcName, c.vcUID
+func (c *Cluster) GetOwnerInfo() (string, string, string) {
+	return c.vcName, c.vcNamespace, c.vcUID
 }
 
 // GetSpec returns the virtual cluster spec.

--- a/incubator/virtualcluster/pkg/syncer/cluster/fake_cluster.go
+++ b/incubator/virtualcluster/pkg/syncer/cluster/fake_cluster.go
@@ -53,8 +53,8 @@ func (c *fakeCluster) GetClusterName() string {
 	return c.key
 }
 
-func (c *fakeCluster) GetOwnerInfo() (string, string) {
-	return c.vc.Name, string(c.vc.UID)
+func (c *fakeCluster) GetOwnerInfo() (string, string, string) {
+	return c.vc.Name, c.vc.Namespace, string(c.vc.UID)
 }
 
 func (c *fakeCluster) GetSpec() (*v1alpha1.VirtualclusterSpec, error) {

--- a/incubator/virtualcluster/pkg/syncer/constants/constants.go
+++ b/incubator/virtualcluster/pkg/syncer/constants/constants.go
@@ -37,6 +37,14 @@ const (
 	LabelSecretName = "tenancy.x-k8s.io/secret.name"
 	// LabelAdminKubeConfig is the kubeconfig in base64 format for tenant master.
 	LabelAdminKubeConfig = "tenancy.x-k8s.io/admin-kubeconfig"
+	// LabelVCName is the name of the VC CR that owns the object.
+	LabelVCName = "tenancy.x-k8s.io/vcname"
+	// LabelVCNamespace is the namespace of the VC CR that owns the object.
+	LabelVCNamespace = "tenancy.x-k8s.io/vcnamespace"
+	// LabelVCUID is the uid of the VC CR that owns the object.
+	LabelVCUID = "tenancy.x-k8s.io/vcuid"
+	// LabelVCRootNS means the namespace is the rootns created by vc-manager.
+	LabelVCRootNS = "tenancy.x-k8s.io/vcrootns"
 
 	// LabelServiceAccountUID is the tenant service account UID related to the secret.
 	LabelServiceAccountUID = "tenancy.x-k8s.io/service-account.UID"

--- a/incubator/virtualcluster/pkg/syncer/conversion/helper.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/helper.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	listersv1 "k8s.io/client-go/listers/core/v1"
@@ -122,7 +121,7 @@ func BuildMetadata(cluster, targetNamespace string, obj runtime.Object) (runtime
 	return target, nil
 }
 
-func BuildSuperMasterNamespace(cluster, vcName, vcUID string, obj runtime.Object) (runtime.Object, error) {
+func BuildSuperMasterNamespace(cluster, vcName, vcNamespace, vcUID string, obj runtime.Object) (runtime.Object, error) {
 	target := obj.DeepCopyObject()
 	m, err := meta.Accessor(target)
 	if err != nil {
@@ -136,20 +135,17 @@ func BuildSuperMasterNamespace(cluster, vcName, vcUID string, obj runtime.Object
 	anno[constants.LabelCluster] = cluster
 	anno[constants.LabelUID] = string(m.GetUID())
 	anno[constants.LabelNamespace] = m.GetName()
+	// We put owner infomation in annotation instead of  metav1.OwnerReference because vc is a namespace scope resource
+	// and metav1.OwnerReference does not provide namespace field. The owner information is needed for super master ns gc.
+	anno[constants.LabelVCName] = vcName
+	anno[constants.LabelVCNamespace] = vcNamespace
+	anno[constants.LabelVCUID] = vcUID
 	m.SetAnnotations(anno)
 
 	ResetMetadata(m)
 
 	targetName := ToSuperMasterNamespace(cluster, m.GetName())
 	m.SetName(targetName)
-	owner := []metav1.OwnerReference{
-		metav1.OwnerReference{
-			APIVersion: v1alpha1.SchemeGroupVersion.String(),
-			Kind:       "Virtualcluster",
-			Name:       vcName,
-			UID:        types.UID(vcUID),
-		}}
-	m.SetOwnerReferences(owner)
 	return target, nil
 }
 

--- a/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
+++ b/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
@@ -82,7 +82,7 @@ type Cache interface {
 // ClusterInterface decouples the controller package from the cluster package.
 type ClusterInterface interface {
 	GetClusterName() string
-	GetOwnerInfo() (string, string)
+	GetOwnerInfo() (string, string, string)
 	GetSpec() (*v1alpha1.VirtualclusterSpec, error)
 	AddEventHandler(runtime.Object, clientgocache.ResourceEventHandler) error
 	GetClientSet() (clientset.Interface, error)
@@ -284,13 +284,13 @@ func (c *MultiClusterController) GetSpec(clusterName string) (*v1alpha1.Virtualc
 
 }
 
-func (c *MultiClusterController) GetOwnerInfo(clusterName string) (string, string, error) {
+func (c *MultiClusterController) GetOwnerInfo(clusterName string) (string, string, string, error) {
 	cluster := c.getCluster(clusterName)
 	if cluster == nil {
-		return "", "", fmt.Errorf("could not find cluster %s", clusterName)
+		return "", "", "", fmt.Errorf("could not find cluster %s", clusterName)
 	}
-	name, uid := cluster.GetOwnerInfo()
-	return name, uid, nil
+	name, namespace, uid := cluster.GetOwnerInfo()
+	return name, namespace, uid, nil
 }
 
 // GetClusterNames returns the name list of all managed tenant clusters

--- a/incubator/virtualcluster/pkg/syncer/resources/namespace/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/namespace/checker.go
@@ -36,32 +36,64 @@ import (
 func (c *controller) StartPatrol(stopCh <-chan struct{}) error {
 	defer utilruntime.HandleCrash()
 
-	if !cache.WaitForCacheSync(stopCh, c.nsSynced) {
+	if !cache.WaitForCacheSync(stopCh, c.nsSynced, c.vcSynced) {
 		return fmt.Errorf("failed to wait for caches to sync before starting Namespace checker")
 	}
 	c.namespacePatroller.Start(stopCh)
 	return nil
 }
 
+//  shouldBeGabageCollected checks if the owner vc object is deleted or not. If so, the namespace should be garbage collected.
+func (c *controller) shouldBeGabageCollected(ns *v1.Namespace) bool {
+	vcName := ns.Annotations[constants.LabelVCName]
+	vcNamespace := ns.Annotations[constants.LabelVCNamespace]
+	if vcName == "" || vcNamespace == "" {
+		return false
+	}
+	vc, err := c.vcLister.Virtualclusters(vcNamespace).Get(vcName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// vc does not exist, double check against the apiserver
+			if _, apiservererr := c.vcClient.TenancyV1alpha1().Virtualclusters(vcNamespace).Get(vcName, metav1.GetOptions{}); apiservererr != nil {
+				if errors.IsNotFound(apiservererr) {
+					// vc does not exist in apiserver as well
+					return true
+				}
+			}
+		}
+	} else {
+		// vc exists, check the uid
+		if ns.Annotations[constants.LabelVCUID] != string(vc.UID) {
+			if v, err := c.vcClient.TenancyV1alpha1().Virtualclusters(vcNamespace).Get(vcName, metav1.GetOptions{}); err == nil {
+				if ns.Annotations[constants.LabelVCUID] != string(v.UID) {
+					// uid is indeed different
+					return true
+				}
+			}
+		}
+		klog.V(4).Infof("pNamespace %s's owner vc exists.", ns.Name)
+	}
+	return false
+}
+
 // PatrollerDo checks to see if namespaces in super master informer cache and tenant master
 // keep consistency.
 func (c *controller) PatrollerDo() {
-	clusterNames := c.multiClusterNamespaceController.GetClusterNames()
-	if len(clusterNames) == 0 {
-		klog.Infof("tenant masters has no clusters, give up period checker")
-		return
-	}
 	defer metrics.RecordCheckerScanDuration("namespace", time.Now())
-	wg := sync.WaitGroup{}
-
-	for _, clusterName := range clusterNames {
-		wg.Add(1)
-		go func(clusterName string) {
-			defer wg.Done()
-			c.checkNamespacesOfTenantCluster(clusterName)
-		}(clusterName)
+	clusterNames := c.multiClusterNamespaceController.GetClusterNames()
+	if len(clusterNames) != 0 {
+		wg := sync.WaitGroup{}
+		for _, clusterName := range clusterNames {
+			wg.Add(1)
+			go func(clusterName string) {
+				defer wg.Done()
+				c.checkNamespacesOfTenantCluster(clusterName)
+			}(clusterName)
+		}
+		wg.Wait()
+	} else {
+		klog.Infof("tenant masters has no clusters, still check pNamespace for gc purpose.")
 	}
-	wg.Wait()
 
 	pNamespaces, err := c.nsLister.List(labels.Everything())
 	if err != nil {
@@ -70,24 +102,32 @@ func (c *controller) PatrollerDo() {
 	}
 
 	for _, pNamespace := range pNamespaces {
-		clusterName, vNamespace := conversion.GetVirtualOwner(pNamespace)
-		if len(clusterName) == 0 || len(vNamespace) == 0 {
-			continue
-		}
 		shouldDelete := false
-		vNamespaceObj, err := c.multiClusterNamespaceController.Get(clusterName, "", vNamespace)
-		if errors.IsNotFound(err) {
-			shouldDelete = true
-		}
-		if err == nil {
-			vNs := vNamespaceObj.(*v1.Namespace)
-			if pNamespace.Annotations[constants.LabelUID] != string(vNs.UID) {
+		if pNamespace.Annotations[constants.LabelVCRootNS] == "true" {
+			if c.shouldBeGabageCollected(pNamespace) {
 				shouldDelete = true
-				klog.Warningf("Found pNamespace %s delegated UID is different from tenant object.", pNamespace.Name)
+			}
+		} else {
+			clusterName, vNamespace := conversion.GetVirtualOwner(pNamespace)
+			if len(clusterName) == 0 || len(vNamespace) == 0 {
+				continue
+			}
+			vNamespaceObj, err := c.multiClusterNamespaceController.Get(clusterName, "", vNamespace)
+			if err != nil {
+				// if vc object is deleted, we should reach here
+				if errors.IsNotFound(err) || c.shouldBeGabageCollected(pNamespace) {
+					shouldDelete = true
+				}
+			} else {
+				vNs := vNamespaceObj.(*v1.Namespace)
+				if pNamespace.Annotations[constants.LabelUID] != string(vNs.UID) {
+					shouldDelete = true
+					klog.Warningf("Found pNamespace %s delegated UID is different from tenant object.", pNamespace.Name)
+				}
 			}
 		}
+
 		if shouldDelete {
-			// vNamespace not found and pNamespace still exist, we need to delete pNamespace manually
 			opts := &metav1.DeleteOptions{
 				PropagationPolicy: &constants.DefaultDeletionPolicy,
 				Preconditions:     metav1.NewUIDPreconditions(string(pNamespace.UID)),

--- a/incubator/virtualcluster/pkg/syncer/resources/namespace/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/namespace/dws.go
@@ -85,12 +85,12 @@ func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, e
 }
 
 func (c *controller) reconcileNamespaceCreate(clusterName, targetNamespace, requestUID string, vNamespace *v1.Namespace) error {
-	vcName, vcUID, err := c.multiClusterNamespaceController.GetOwnerInfo(clusterName)
+	vcName, vcNamespace, vcUID, err := c.multiClusterNamespaceController.GetOwnerInfo(clusterName)
 	if err != nil {
 		return err
 	}
 
-	newObj, err := conversion.BuildSuperMasterNamespace(clusterName, vcName, vcUID, vNamespace)
+	newObj, err := conversion.BuildSuperMasterNamespace(clusterName, vcName, vcNamespace, vcUID, vNamespace)
 	if err != nil {
 		return err
 	}

--- a/incubator/virtualcluster/pkg/syncer/resources/namespace/dws_test.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/namespace/dws_test.go
@@ -46,9 +46,12 @@ func superNamespace(name, uid, clusterKey string) *v1.Namespace {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Annotations: map[string]string{
-				constants.LabelUID:       uid,
-				constants.LabelCluster:   clusterKey,
-				constants.LabelNamespace: "default",
+				constants.LabelUID:         uid,
+				constants.LabelCluster:     clusterKey,
+				constants.LabelNamespace:   "default",
+				constants.LabelVCName:      "test",
+				constants.LabelVCNamespace: "tenant-1",
+				constants.LabelVCUID:       "7374a172-c35d-45b1-9c8e-bf5c5b614937",
 			},
 		},
 	}
@@ -112,7 +115,7 @@ func TestDWNamespaceCreation(t *testing.T) {
 
 	for k, tc := range testcases {
 		t.Run(k, func(t *testing.T) {
-			actions, reconcileErr, err := util.RunDownwardSync(NewNamespaceController,
+			actions, reconcileErr, err := util.RunDownwardSyncWithVCClient(NewNamespaceController,
 				testTenant,
 				tc.ExistingObjectInSuper,
 				[]runtime.Object{tc.ExistingObjectInTenant},
@@ -201,7 +204,7 @@ func TestDWNamespaceDeletion(t *testing.T) {
 
 	for k, tc := range testcases {
 		t.Run(k, func(t *testing.T) {
-			actions, reconcileErr, err := util.RunDownwardSync(NewNamespaceController, testTenant, tc.ExistingObjectInSuper, nil, tc.EnqueueObject)
+			actions, reconcileErr, err := util.RunDownwardSyncWithVCClient(NewNamespaceController, testTenant, tc.ExistingObjectInSuper, nil, tc.EnqueueObject)
 			if err != nil {
 				t.Errorf("%s: error running downward sync: %v", k, err)
 				return

--- a/incubator/virtualcluster/pkg/syncer/resources/register.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/register.go
@@ -17,6 +17,8 @@ limitations under the License.
 package resources
 
 import (
+	vcclient "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/client/clientset/versioned"
+	vcinformers "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/client/informers/externalversions/tenancy/v1alpha1"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 
@@ -36,8 +38,13 @@ import (
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/resources/storageclass"
 )
 
-func Register(config *config.SyncerConfiguration, client clientset.Interface, informerFactory informers.SharedInformerFactory, controllerManager *manager.ControllerManager) {
-	namespace.Register(config, client.CoreV1(), informerFactory.Core().V1(), controllerManager)
+func Register(config *config.SyncerConfiguration,
+	client clientset.Interface,
+	informerFactory informers.SharedInformerFactory,
+	vcClient vcclient.Interface,
+	vcInformer vcinformers.VirtualclusterInformer,
+	controllerManager *manager.ControllerManager) {
+	namespace.Register(config, client.CoreV1(), informerFactory.Core().V1(), vcClient, vcInformer, controllerManager)
 	pod.Register(config, client.CoreV1(), informerFactory.Core().V1(), controllerManager)
 	configmap.Register(config, client.CoreV1(), informerFactory.Core().V1().ConfigMaps(), controllerManager)
 	secret.Register(config, client.CoreV1(), informerFactory.Core().V1().Secrets(), controllerManager)

--- a/incubator/virtualcluster/pkg/syncer/syncer.go
+++ b/incubator/virtualcluster/pkg/syncer/syncer.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	vcclient "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/client/clientset/versioned"
 	vcinformers "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/client/informers/externalversions/tenancy/v1alpha1"
 	vclisters "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/client/listers/tenancy/v1alpha1"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
@@ -77,6 +78,7 @@ type Bootstrap interface {
 func New(
 	config *config.SyncerConfiguration,
 	secretClient v1core.SecretsGetter,
+	virtualClusterClient vcclient.Interface,
 	virtualClusterInformer vcinformers.VirtualclusterInformer,
 	superMasterClient clientset.Interface,
 	superMasterInformers informers.SharedInformerFactory,
@@ -110,7 +112,7 @@ func New(
 	multiClusterControllerManager := manager.New()
 	syncer.controllerManager = multiClusterControllerManager
 
-	resources.Register(config, superMasterClient, superMasterInformers, multiClusterControllerManager)
+	resources.Register(config, superMasterClient, superMasterInformers, virtualClusterClient, virtualClusterInformer, multiClusterControllerManager)
 
 	return syncer
 }

--- a/incubator/virtualcluster/pkg/syncer/util/test/runPatrol.go
+++ b/incubator/virtualcluster/pkg/syncer/util/test/runPatrol.go
@@ -27,6 +27,8 @@ import (
 	fakeClient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	fakevcclient "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/client/clientset/versioned/fake"
+	vcinformerFactory "github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/client/informers/externalversions"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/cluster"
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
@@ -56,6 +58,151 @@ func (r *fakePatrolReconciler) SetResourceSyncer(c manager.ResourceSyncer) {
 }
 
 type controllerStateModifier func(manager.ResourceSyncer)
+
+func RunPatrolWithVCClient(
+	newControllerFunc controllerWithVCClientNew,
+	testTenant *v1alpha1.Virtualcluster,
+	existingObjectInSuper []runtime.Object,
+	existingObjectInTenant []runtime.Object,
+	existingObjectInVCClient []runtime.Object,
+	waitDWS bool,
+	waitUWS bool,
+	controllerStateModifyFunc controllerStateModifier,
+) ([]core.Action, []core.Action, error) {
+	// setup fake tenant cluster
+	tenantClientset := fake.NewSimpleClientset()
+	tenantClient := fakeClient.NewFakeClient()
+	if existingObjectInTenant != nil {
+		tenantClientset = fake.NewSimpleClientset(existingObjectInTenant...)
+		// For controller runtime client, if the informer cache is empty, the request goes to client obj tracker.
+		// Hence we don't have to populate the infomer cache.
+		tenantClient = fakeClient.NewFakeClient(existingObjectInTenant...)
+	}
+	tenantCluster, err := cluster.NewFakeTenantCluster(testTenant, tenantClientset, tenantClient)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating tenantCluster: %v", err)
+	}
+
+	// setup fake super cluster
+	superClient := fake.NewSimpleClientset()
+	if existingObjectInSuper != nil {
+		superClient = fake.NewSimpleClientset(existingObjectInSuper...)
+	}
+	superInformer := informers.NewSharedInformerFactory(superClient, 0)
+	// setup fake vc client
+	vcClient := fakevcclient.NewSimpleClientset()
+	if existingObjectInVCClient != nil {
+		vcClient = fakevcclient.NewSimpleClientset(existingObjectInVCClient...)
+	}
+	vcInformer := vcinformerFactory.NewSharedInformerFactory(vcClient, 0).Tenancy().V1alpha1().Virtualclusters()
+	// Add obj to vc informer cache
+	for _, each := range existingObjectInVCClient {
+		_, ok := each.(*v1alpha1.Virtualcluster)
+		if !ok {
+			return nil, nil, fmt.Errorf("only vc object can be added to vc informer cache: %v", each)
+		}
+		vcInformer.Informer().GetStore().Add(each)
+	}
+
+	// setup fake controller
+	syncDWS := make(chan error)
+	defer close(syncDWS)
+	syncUWS := make(chan error)
+	defer close(syncUWS)
+	syncPatrol := make(chan error)
+	defer close(syncPatrol)
+
+	fakePatrolRc := &fakePatrolReconciler{errCh: syncPatrol}
+	fakeDWRc := &fakeReconciler{errCh: syncDWS}
+	fakeUWRc := &fakeUWReconciler{errCh: syncUWS}
+
+	rsOptions := &manager.ResourceSyncerOptions{
+		MCOptions:     &mc.Options{Reconciler: fakeDWRc},
+		UWOptions:     &uw.Options{Reconciler: fakeUWRc},
+		PatrolOptions: &pa.Options{Reconciler: fakePatrolRc},
+		IsFake:        true,
+	}
+
+	resourceSyncer, _, _, err := newControllerFunc(
+		&config.SyncerConfiguration{
+			DisableServiceAccountToken: true,
+		},
+		superClient.CoreV1(),
+		superInformer.Core().V1(),
+		vcClient,
+		vcInformer,
+		rsOptions,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating controller: %v", err)
+	}
+	fakePatrolRc.SetResourceSyncer(resourceSyncer)
+	fakeDWRc.SetResourceSyncer(resourceSyncer)
+	fakeUWRc.SetResourceSyncer(resourceSyncer)
+
+	// Update controller internal state
+	if controllerStateModifyFunc != nil {
+		controllerStateModifyFunc(resourceSyncer)
+	}
+
+	// register tenant cluster to controller.
+	resourceSyncer.AddCluster(tenantCluster)
+	defer resourceSyncer.RemoveCluster(tenantCluster)
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	// add object to super informer.
+	for _, each := range existingObjectInSuper {
+		informer := getObjectInformer(superInformer.Core().V1(), each)
+		informer.GetStore().Add(each)
+	}
+	go resourceSyncer.StartDWS(stopCh)
+	go resourceSyncer.StartUWS(stopCh)
+	go resourceSyncer.StartPatrol(stopCh)
+
+	// wait to be called
+	select {
+	case _ = <-syncPatrol:
+	case <-time.After(10 * time.Second):
+		return nil, nil, fmt.Errorf("timeout waiting for syncPatrol")
+	}
+	if waitDWS {
+		select {
+		case _ = <-syncDWS:
+		case <-time.After(10 * time.Second):
+			return nil, nil, fmt.Errorf("timeout waiting for syncDWS")
+		}
+	}
+	if waitUWS {
+		select {
+		case _ = <-syncUWS:
+		case <-time.After(10 * time.Second):
+			return nil, nil, fmt.Errorf("timeout waiting for syncUWS")
+		}
+	}
+
+	tenantActions := tenantClientset.Actions()
+	superActions := superClient.Actions()
+
+	// filter readonly action while we check the write operation in tests.
+	for i := 0; i < len(tenantActions); {
+		if tenantActions[i].GetVerb() == "get" {
+			tenantActions = append(tenantActions[:i], tenantActions[i+1:]...)
+		} else {
+			i++
+		}
+	}
+	for i := 0; i < len(superActions); {
+		if superActions[i].GetVerb() == "get" {
+			superActions = append(superActions[:i], superActions[i+1:]...)
+		} else {
+			i++
+		}
+	}
+
+	return tenantActions, superActions, nil
+}
 
 func RunPatrol(
 	newControllerFunc controllerNew,


### PR DESCRIPTION
We were adding owner reference to all the super master namespace which points to VC CR. We expect when VC CR is removed, the gc controller will automatically remove super master namespace. This mechanism has a flaw such that vc object is namespace scoped object. Namespace object's owner has to be a cluster scope object otherwise the gc controller may not find the owner and delete the namespace unexpectedly. 

This change resolves the problem by applying lazy gc relying on the namespace periodic checker. 
Once a VC CR is removed, the checker will identify those orphan namespaces and remove them. 

New mocker tests are added. Since the namespace controller now needs the vc client/informer, I choose to duplicate some mock test framework code in this change. More clean up can be done in future change.

