### PR TITLE
Integrate GK cert as the default internal cert

### DIFF
--- a/incubator/hnc/Dockerfile
+++ b/incubator/hnc/Dockerfile
@@ -13,6 +13,7 @@ RUN go mod download
 COPY api/ api/
 COPY cmd/ cmd/
 COPY pkg/ pkg/
+COPY third_party/ third_party/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager ./cmd/manager/main.go

--- a/incubator/hnc/Makefile
+++ b/incubator/hnc/Makefile
@@ -43,7 +43,7 @@ all: test docker-build
 
 # Run tests
 test: build
-	go test ./api/... ./cmd/... ./pkg/... -coverprofile cover.out
+	go test ./api/... ./cmd/... ./pkg/... ./third_party/... -coverprofile cover.out
 
 # Builds all binaries (manager and kubectl) and manifests
 build: generate fmt vet manifests
@@ -128,15 +128,15 @@ endif
 # deleting the CRDs will cause all the existing hierarchy configs to be wiped
 # away and b) if we don't delete the deployment, a new image won't be pulled
 # unless the tag changes.
-deploy: deploy-prereq docker-push kubectl manifests
+deploy: docker-push kubectl manifests
 	-kubectl -n hnc-system delete deployment hnc-controller-manager
 	kubectl apply -f manifests/hnc-manager.yaml
 
 deploy-watch:
 	kubectl logs -n hnc-system --follow deployment/hnc-controller-manager manager
 
-# Installs prerequisites. See https://cert-manager.io/docs/installation/kubernetes/ for why we're not validating our YAML.
-deploy-prereq:
+# Installs cert-manager. See https://cert-manager.io/docs/installation/kubernetes/ for why we're not validating our YAML.
+deploy-cm:
 	@kubectl cluster-info
 	-kubectl create namespace cert-manager
 	kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.11.0/cert-manager.yaml
@@ -166,7 +166,7 @@ kind-reboot:
 # Creates a local kind cluster, destroying the old one if necessary. It's not
 # *necessary* to call this wih CONFIG=kind but it's not a bad idea either so
 # the correct manifests get created.
-kind-reset: kind-reboot deploy-prereq
+kind-reset: kind-reboot
 	@echo "If this didn't work, ensure you ran 'source devenv' to point kubectl at kind'"
 
 # Convenience target to deploy specifically for kind

--- a/incubator/hnc/cmd/manager/main.go
+++ b/incubator/hnc/cmd/manager/main.go
@@ -32,7 +32,6 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	// +kubebuilder:scaffold:imports
 
@@ -48,6 +47,18 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 )
 
+var (
+	metricsAddr          string
+	maxReconciles        int
+	enableLeaderElection bool
+	leaderElectionId     string
+	novalidation         bool
+	debugLogs            bool
+	testLog              bool
+	internalCert         bool
+	qps                  int
+)
+
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
 
@@ -58,16 +69,6 @@ func init() {
 }
 
 func main() {
-	var (
-		metricsAddr          string
-		maxReconciles        int
-		enableLeaderElection bool
-		leaderElectionId     string
-		novalidation         bool
-		debugLogs            bool
-		testLog              bool
-		qps                  int
-	)
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
@@ -76,6 +77,7 @@ func main() {
 	flag.BoolVar(&novalidation, "novalidation", false, "Disables validating webhook")
 	flag.BoolVar(&debugLogs, "debug-logs", false, "Shows verbose logs in a human-friendly format.")
 	flag.BoolVar(&testLog, "enable-test-log", false, "Enables test log.")
+	flag.BoolVar(&internalCert, "enable-internal-cert-management", false, "Enables internal cert management.")
 	flag.IntVar(&maxReconciles, "max-reconciles", 1, "Number of concurrent reconciles to perform.")
 	flag.IntVar(&qps, "apiserver-qps-throttle", 50, "The maximum QPS to the API server.")
 	flag.Parse()
@@ -131,6 +133,26 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Make sure certs are generated and valid if webhooks are enabled and internal certs are used.
+	setupFinished, err := validators.CreateCertsIfNeeded(mgr, novalidation, internalCert)
+	if err != nil {
+		setupLog.Error(err, "unable to set up cert rotation")
+		os.Exit(1)
+	}
+
+	go startControllers(mgr, setupFinished)
+
+	setupLog.Info("starting manager")
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		setupLog.Error(err, "problem running manager")
+		os.Exit(1)
+	}
+}
+
+func startControllers(mgr ctrl.Manager, setupFinished chan struct{}) {
+	// Block until the setup finishes.
+	<-setupFinished
+
 	if testLog {
 		stats.StartLoggingActivity()
 	}
@@ -143,42 +165,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Create validating admission controllers
+	// Create all validating admission controllers.
 	if !novalidation {
-		// Create webhook for Hierarchy
 		setupLog.Info("Registering validating webhook (won't work when running locally; use --novalidation)")
-		mgr.GetWebhookServer().Register(validators.HierarchyServingPath, &webhook.Admission{Handler: &validators.Hierarchy{
-			Log:    ctrl.Log.WithName("validators").WithName("Hierarchy"),
-			Forest: f,
-		}})
-
-		// Create webhooks for managed objects
-		mgr.GetWebhookServer().Register(validators.ObjectsServingPath, &webhook.Admission{Handler: &validators.Object{
-			Log:    ctrl.Log.WithName("validators").WithName("Object"),
-			Forest: f,
-		}})
-
-		// Create webhook for the config
-		mgr.GetWebhookServer().Register(validators.ConfigServingPath, &webhook.Admission{Handler: &validators.HNCConfig{
-			Log: ctrl.Log.WithName("validators").WithName("HNCConfig"),
-		}})
-
-		// Create webhook for the HierarchicalNamespaces.
-		mgr.GetWebhookServer().Register(validators.HierarchicalNamespaceServingPath, &webhook.Admission{Handler: &validators.HierarchicalNamespace{
-			Log:    ctrl.Log.WithName("validators").WithName("HierarchicalNamespace"),
-			Forest: f,
-		}})
-
-		// Create webhook for the namespaces (core type).
-		mgr.GetWebhookServer().Register(validators.NamespaceServingPath, &webhook.Admission{Handler: &validators.Namespace{
-			Log:    ctrl.Log.WithName("validators").WithName("Namespace"),
-			Forest: f,
-		}})
-	}
-
-	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		setupLog.Error(err, "problem running manager")
-		os.Exit(1)
+		validators.Create(mgr, f)
 	}
 }

--- a/incubator/hnc/config/default/kustomization.yaml
+++ b/incubator/hnc/config/default/kustomization.yaml
@@ -17,7 +17,13 @@ bases:
 - ../rbac
 - ../manager
 - ../webhook
-- ../certmanager
+# Add cert management. Only one of the ../internalcert and the
+# ../certmanager should be enabled. Please make sure the
+# "enable-internal-cert-management" flag is set to true or removed
+# in "manager_auth_proxy_patch.yaml" file in this directory after
+# switching to the internal or external cert here.
+- ../internalcert
+#- ../certmanager
 
 patchesStrategicMerge:
   # Protect the /metrics endpoint by putting it behind auth.
@@ -32,34 +38,36 @@ patchesStrategicMerge:
 #- manager_prometheus_metrics_patch.yaml
 
 - manager_webhook_patch.yaml
-
-- webhookcainjection_patch.yaml
-
-# the following config is for teaching kustomize how to do var substitution
-vars:
-- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-  objref:
-    kind: Certificate
-    group: cert-manager.io
-    version: v1alpha2
-    name: serving-cert # this name should match the one in certificate.yaml
-  fieldref:
-    fieldpath: metadata.namespace
-- name: CERTIFICATE_NAME
-  objref:
-    kind: Certificate
-    group: cert-manager.io
-    version: v1alpha2
-    name: serving-cert # this name should match the one in certificate.yaml
-- name: SERVICE_NAMESPACE # namespace of the service
-  objref:
-    kind: Service
-    version: v1
-    name: webhook-service
-  fieldref:
-    fieldpath: metadata.namespace
-- name: SERVICE_NAME
-  objref:
-    kind: Service
-    version: v1
-    name: webhook-service
+#  # Uncomment below if ../certmanager is enabled.
+#  # Add additional "cert-manager" component to inject ca into
+#  # the ValidatingWebhookConfiguration resource.
+#- webhookcainjection_patch.yaml
+#
+## the following config is for teaching kustomize how to do var substitution
+#vars:
+#  - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+#    objref:
+#      kind: Certificate
+#      group: cert-manager.io
+#      version: v1alpha2
+#      name: serving-cert # this name should match the one in certificate.yaml
+#    fieldref:
+#      fieldpath: metadata.namespace
+#  - name: CERTIFICATE_NAME
+#    objref:
+#      kind: Certificate
+#      group: cert-manager.io
+#      version: v1alpha2
+#      name: serving-cert # this name should match the one in certificate.yaml
+#  - name: SERVICE_NAMESPACE # namespace of the service
+#    objref:
+#      kind: Service
+#      version: v1
+#      name: webhook-service
+#    fieldref:
+#      fieldpath: metadata.namespace
+#  - name: SERVICE_NAME
+#    objref:
+#      kind: Service
+#      version: v1
+#      name: webhook-service

--- a/incubator/hnc/config/default/manager_auth_proxy_patch.yaml
+++ b/incubator/hnc/config/default/manager_auth_proxy_patch.yaml
@@ -26,3 +26,4 @@ spec:
         - "--leader-election-id=hnc-controller-leader-election-helper"
         - "--max-reconciles=10"
         - "--apiserver-qps-throttle=50"
+        - "--enable-internal-cert-management=true"

--- a/incubator/hnc/config/internalcert/kustomization.yaml
+++ b/incubator/hnc/config/internalcert/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- manifests.yaml

--- a/incubator/hnc/config/internalcert/manifests.yaml
+++ b/incubator/hnc/config/internalcert/manifests.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: webhook-server-cert
+  namespace: system

--- a/incubator/hnc/go.mod
+++ b/incubator/hnc/go.mod
@@ -14,7 +14,9 @@ require (
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
+	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.5.0
+	github.com/prometheus/common v0.9.1
 	github.com/spf13/cobra v0.0.5
 	go.opencensus.io v0.22.3
 	go.uber.org/atomic v1.4.0 // indirect

--- a/incubator/hnc/go.sum
+++ b/incubator/hnc/go.sum
@@ -43,8 +43,10 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1CELW+XaDYmOH4hkBN4/N9og/AsOv7E=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -570,6 +572,7 @@ google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiq
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.23.1 h1:q4XQuHFC6I28BKZpo6IYyb3mNO+l7lSOxRuYTCiDfXk=
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/incubator/hnc/pkg/validators/setup.go
+++ b/incubator/hnc/pkg/validators/setup.go
@@ -1,0 +1,78 @@
+package validators
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/forest"
+	cert "github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/third_party/open-policy-agent/gatekeeper/pkg/webhook"
+)
+
+const (
+	serviceName     = "hnc-webhook-service"
+	vwhName         = "hnc-validating-webhook-configuration"
+	caName          = "hnc-ca"
+	caOrganization  = "hnc"
+	secretNamespace = "hnc-system"
+	secretName      = "hnc-webhook-server-cert"
+	certDir         = "/tmp/k8s-webhook-server/serving-certs"
+)
+
+// DNSName is <service name>.<namespace>.svc
+var dnsName = fmt.Sprintf("%s.%s.svc", serviceName, secretNamespace)
+
+// CreateCertsIfNeeded creates all certs for webhooks. This function is called from main.go.
+func CreateCertsIfNeeded(mgr ctrl.Manager, novalidation, internalCert bool) (chan struct{}, error) {
+	setupFinished := make(chan struct{})
+	if novalidation || !internalCert {
+		close(setupFinished)
+		return setupFinished, nil
+	}
+
+	return setupFinished, cert.AddRotator(mgr, &cert.CertRotator{
+		SecretKey: types.NamespacedName{
+			Namespace: secretNamespace,
+			Name:      secretName,
+		},
+		CertDir:        certDir,
+		CAName:         caName,
+		CaOrganization: caOrganization,
+		DNSName:        dnsName,
+		CertsMounted:   setupFinished,
+	}, vwhName)
+}
+
+// Create creates all validators. This function is called from main.go.
+func Create(mgr ctrl.Manager, f *forest.Forest) {
+	// Create webhook for Hierarchy
+	mgr.GetWebhookServer().Register(HierarchyServingPath, &webhook.Admission{Handler: &Hierarchy{
+		Log:    ctrl.Log.WithName("validators").WithName("Hierarchy"),
+		Forest: f,
+	}})
+
+	// Create webhooks for managed objects
+	mgr.GetWebhookServer().Register(ObjectsServingPath, &webhook.Admission{Handler: &Object{
+		Log:    ctrl.Log.WithName("validators").WithName("Object"),
+		Forest: f,
+	}})
+
+	// Create webhook for the config
+	mgr.GetWebhookServer().Register(ConfigServingPath, &webhook.Admission{Handler: &HNCConfig{
+		Log: ctrl.Log.WithName("validators").WithName("HNCConfig"),
+	}})
+
+	// Create webhook for the HierarchicalNamespaces.
+	mgr.GetWebhookServer().Register(HierarchicalNamespaceServingPath, &webhook.Admission{Handler: &HierarchicalNamespace{
+		Log:    ctrl.Log.WithName("validators").WithName("HierarchicalNamespace"),
+		Forest: f,
+	}})
+
+	// Create webhook for the namespaces (core type).
+	mgr.GetWebhookServer().Register(NamespaceServingPath, &webhook.Admission{Handler: &Namespace{
+		Log:    ctrl.Log.WithName("validators").WithName("Namespace"),
+		Forest: f,
+	}})
+}

--- a/incubator/hnc/third_party/open-policy-agent/gatekeeper/LICENSE
+++ b/incubator/hnc/third_party/open-policy-agent/gatekeeper/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/incubator/hnc/third_party/open-policy-agent/gatekeeper/README.md
+++ b/incubator/hnc/third_party/open-policy-agent/gatekeeper/README.md
@@ -1,0 +1,8 @@
+# open-policy-agent/gatekeeper
+
+Forked from open-policy-agent/gatekeeper.
+
+This fork adds Gatekeeper cert management into HNC as the default internal cert management. 
+
+The original code can be found at https://github.com/open-policy-agent/gatekeeper/blob/master/pkg/webhook/certs.go.
+

--- a/incubator/hnc/third_party/open-policy-agent/gatekeeper/pkg/webhook/certs.go
+++ b/incubator/hnc/third_party/open-policy-agent/gatekeeper/pkg/webhook/certs.go
@@ -1,0 +1,536 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	certName               = "tls.crt"
+	keyName                = "tls.key"
+	caCertName             = "ca.crt"
+	caKeyName              = "ca.key"
+	rotationCheckFrequency = 12 * time.Hour
+	certValidityDuration   = 10 * 365 * 24 * time.Hour
+)
+
+var crLog = logf.Log.WithName("cert-rotation")
+
+var vwhGVK = schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1beta1", Kind: "ValidatingWebhookConfiguration"}
+
+var _ manager.Runnable = &CertRotator{}
+
+// AddRotator adds the CertRotator and ReconcileVWH to the manager.
+func AddRotator(mgr manager.Manager, cr *CertRotator, vwhName string) error {
+	cr.client = mgr.GetClient()
+	cr.certsNotMounted = make(chan struct{})
+	if err := mgr.Add(cr); err != nil {
+		return err
+	}
+
+	vwhKey := types.NamespacedName{Name: vwhName}
+	reconciler := &ReconcileVWH{
+		client:    mgr.GetClient(),
+		scheme:    mgr.GetScheme(),
+		ctx:       context.Background(),
+		secretKey: cr.SecretKey,
+		vwhKey:    vwhKey,
+	}
+	if err := addController(mgr, reconciler, cr.SecretKey, vwhKey); err != nil {
+		return err
+	}
+	return nil
+}
+
+// CertRotator contains cert artifacts and a channel to close when the certs are ready.
+type CertRotator struct {
+	client          client.Client
+	SecretKey       types.NamespacedName
+	CertDir         string
+	CAName          string
+	CaOrganization  string
+	DNSName         string
+	CertsMounted    chan struct{}
+	certsNotMounted chan struct{}
+}
+
+// Start starts the CertRotator runnable to rotate certs and ensure the certs are ready.
+func (cr *CertRotator) Start(stop <-chan (struct{})) error {
+	// explicitly rotate on the first round so that the certificate
+	// can be bootstrapped, otherwise manager exits before a cert can be written
+	crLog.Info("starting cert rotator controller")
+	defer crLog.Info("stopping cert rotator controller")
+	if err := cr.refreshCertIfNeeded(); err != nil {
+		crLog.Error(err, "could not refresh cert on startup")
+		return err
+	}
+
+	// Once the certs are ready, close the channel.
+	go cr.ensureCertsExist()
+
+	ticker := time.NewTicker(rotationCheckFrequency)
+
+tickerLoop:
+	for {
+		select {
+		case <-ticker.C:
+			if err := cr.refreshCertIfNeeded(); err != nil {
+				crLog.Error(err, "error rotating certs")
+			}
+		case <-stop:
+			break tickerLoop
+		case <-cr.certsNotMounted:
+			return errors.New("could not mount certs")
+		}
+	}
+
+	ticker.Stop()
+	return nil
+}
+
+// refreshCertIfNeeded returns whether there's any error when refreshing the certs if needed.
+func (cr *CertRotator) refreshCertIfNeeded() error {
+	refreshFn := func() (bool, error) {
+		secret := &corev1.Secret{}
+		if err := cr.client.Get(context.Background(), cr.SecretKey, secret); err != nil {
+			return false, errors.Wrap(err, "acquiring secret to update certificates")
+		}
+		if secret.Data == nil || !cr.validCACert(secret.Data[caCertName], secret.Data[caKeyName]) {
+			crLog.Info("refreshing CA and server certs")
+			if err := cr.refreshCerts(true, secret); err != nil {
+				crLog.Error(err, "could not refresh CA and server certs")
+				return false, nil
+			}
+			crLog.Info("server certs refreshed")
+			return true, nil
+		}
+		// make sure our reconciler is initialized on startup (either this or the above refreshCerts() will call this)
+		if !cr.validServerCert(secret.Data[caCertName], secret.Data[certName], secret.Data[keyName]) {
+			crLog.Info("refreshing server certs")
+			if err := cr.refreshCerts(false, secret); err != nil {
+				crLog.Error(err, "could not refresh server certs")
+				return false, nil
+			}
+			crLog.Info("server certs refreshed")
+			return true, nil
+		}
+		crLog.Info("no cert refresh needed")
+		return true, nil
+	}
+	if err := wait.ExponentialBackoff(wait.Backoff{
+		Duration: 10 * time.Millisecond,
+		Factor:   2,
+		Jitter:   1,
+		Steps:    10,
+	}, refreshFn); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cr *CertRotator) refreshCerts(refreshCA bool, secret *corev1.Secret) error {
+	var caArtifacts *KeyPairArtifacts
+	if refreshCA {
+		var err error
+		caArtifacts, err = cr.createCACert()
+		if err != nil {
+			return err
+		}
+	} else {
+		var err error
+		caArtifacts, err = buildArtifactsFromSecret(secret)
+		if err != nil {
+			return err
+		}
+	}
+	cert, key, err := cr.createCertPEM(caArtifacts)
+	if err != nil {
+		return err
+	}
+	if err := cr.writeSecret(cert, key, caArtifacts, secret); err != nil {
+		return err
+	}
+	return nil
+}
+
+func injectCertToWebhook(vwh *unstructured.Unstructured, certPem []byte) error {
+	webhooks, found, err := unstructured.NestedSlice(vwh.Object, "webhooks")
+	if err != nil {
+		return err
+	}
+	if !found {
+		return errors.New("`webhooks` field not found in ValidatingWebhookConfiguration")
+	}
+	for i, h := range webhooks {
+		hook, ok := h.(map[string]interface{})
+		if !ok {
+			return errors.Errorf("webhook %d is not well-formed", i)
+		}
+		if err := unstructured.SetNestedField(hook, base64.StdEncoding.EncodeToString(certPem), "clientConfig", "caBundle"); err != nil {
+			return err
+		}
+		webhooks[i] = hook
+	}
+	if err := unstructured.SetNestedSlice(vwh.Object, webhooks, "webhooks"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cr *CertRotator) writeSecret(cert, key []byte, caArtifacts *KeyPairArtifacts, secret *corev1.Secret) error {
+	populateSecret(cert, key, caArtifacts, secret)
+	return cr.client.Update(context.Background(), secret)
+}
+
+// KeyPairArtifacts stores cert artifacts.
+type KeyPairArtifacts struct {
+	Cert    *x509.Certificate
+	Key     *rsa.PrivateKey
+	CertPEM []byte
+	KeyPEM  []byte
+}
+
+func populateSecret(cert, key []byte, caArtifacts *KeyPairArtifacts, secret *corev1.Secret) {
+	if secret.Data == nil {
+		secret.Data = make(map[string][]byte)
+	}
+	secret.Data[caCertName] = caArtifacts.CertPEM
+	secret.Data[caKeyName] = caArtifacts.KeyPEM
+	secret.Data[certName] = cert
+	secret.Data[keyName] = key
+}
+
+func buildArtifactsFromSecret(secret *corev1.Secret) (*KeyPairArtifacts, error) {
+	caPem, ok := secret.Data[caCertName]
+	if !ok {
+		return nil, errors.New(fmt.Sprintf("Cert secret is not well-formed, missing %s", caCertName))
+	}
+	keyPem, ok := secret.Data[caKeyName]
+	if !ok {
+		return nil, errors.New(fmt.Sprintf("Cert secret is not well-formed, missing %s", caKeyName))
+	}
+	caDer, _ := pem.Decode(caPem)
+	if caDer == nil {
+		return nil, errors.New("bad CA cert")
+	}
+	caCert, err := x509.ParseCertificate(caDer.Bytes)
+	if err != nil {
+		return nil, errors.Wrap(err, "while parsing CA cert")
+	}
+	keyDer, _ := pem.Decode(keyPem)
+	if keyDer == nil {
+		return nil, errors.New("bad CA cert")
+	}
+	key, err := x509.ParsePKCS1PrivateKey(keyDer.Bytes)
+	if err != nil {
+		return nil, errors.Wrap(err, "while parsing CA key")
+	}
+	return &KeyPairArtifacts{
+		Cert:    caCert,
+		CertPEM: caPem,
+		KeyPEM:  keyPem,
+		Key:     key,
+	}, nil
+}
+
+// createCACert creates the self-signed CA cert and private key that will
+// be used to sign the server certificate
+func (cr *CertRotator) createCACert() (*KeyPairArtifacts, error) {
+	now := time.Now()
+	begin := now.Add(-1 * time.Hour)
+	end := now.Add(certValidityDuration)
+	templ := &x509.Certificate{
+		SerialNumber: big.NewInt(0),
+		Subject: pkix.Name{
+			CommonName:   cr.CAName,
+			Organization: []string{cr.CaOrganization},
+		},
+		NotBefore:             begin,
+		NotAfter:              end,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, errors.Wrap(err, "generating key")
+	}
+	der, err := x509.CreateCertificate(rand.Reader, templ, templ, key.Public(), key)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating certificate")
+	}
+	certPEM, keyPEM, err := pemEncode(der, key)
+	if err != nil {
+		return nil, errors.Wrap(err, "encoding PEM")
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing certificate")
+	}
+
+	return &KeyPairArtifacts{Cert: cert, Key: key, CertPEM: certPEM, KeyPEM: keyPEM}, nil
+}
+
+// createCertPEM takes the results of createCACert and uses it to create the
+// PEM-encoded public certificate and private key, respectively
+func (cr *CertRotator) createCertPEM(ca *KeyPairArtifacts) ([]byte, []byte, error) {
+	now := time.Now()
+	begin := now.Add(-1 * time.Hour)
+	end := now.Add(certValidityDuration)
+	templ := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: cr.DNSName,
+		},
+		NotBefore:             begin,
+		NotAfter:              end,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "generating key")
+	}
+	der, err := x509.CreateCertificate(rand.Reader, templ, ca.Cert, key.Public(), ca.Key)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "creating certificate")
+	}
+	certPEM, keyPEM, err := pemEncode(der, key)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "encoding PEM")
+	}
+	return certPEM, keyPEM, nil
+}
+
+// pemEncode takes a certificate and encodes it as PEM
+func pemEncode(certificateDER []byte, key *rsa.PrivateKey) ([]byte, []byte, error) {
+	certBuf := &bytes.Buffer{}
+	if err := pem.Encode(certBuf, &pem.Block{Type: "CERTIFICATE", Bytes: certificateDER}); err != nil {
+		return nil, nil, errors.Wrap(err, "encoding cert")
+	}
+	keyBuf := &bytes.Buffer{}
+	if err := pem.Encode(keyBuf, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}); err != nil {
+		return nil, nil, errors.Wrap(err, "encoding key")
+	}
+	return certBuf.Bytes(), keyBuf.Bytes(), nil
+}
+
+func lookaheadTime() time.Time {
+	return time.Now().Add(90 * 24 * time.Hour)
+}
+
+func (cr *CertRotator) validServerCert(caCert, cert, key []byte) bool {
+	valid, err := validCert(caCert, cert, key, cr.DNSName, lookaheadTime())
+	if err != nil {
+		return false
+	}
+	return valid
+}
+
+func (cr *CertRotator) validCACert(cert, key []byte) bool {
+	valid, err := validCert(cert, cert, key, cr.CAName, lookaheadTime())
+	if err != nil {
+		return false
+	}
+	return valid
+}
+
+func validCert(caCert, cert, key []byte, dnsName string, at time.Time) (bool, error) {
+	if len(caCert) == 0 || len(cert) == 0 || len(key) == 0 {
+		return false, errors.New("empty cert")
+	}
+
+	pool := x509.NewCertPool()
+	caDer, _ := pem.Decode(caCert)
+	if caDer == nil {
+		return false, errors.New("bad CA cert")
+	}
+	cac, err := x509.ParseCertificate(caDer.Bytes)
+	if err != nil {
+		return false, errors.Wrap(err, "parsing CA cert")
+	}
+	pool.AddCert(cac)
+
+	_, err = tls.X509KeyPair(cert, key)
+	if err != nil {
+		return false, errors.Wrap(err, "building key pair")
+	}
+
+	b, _ := pem.Decode(cert)
+	if b == nil {
+		return false, errors.New("bad private key")
+	}
+
+	crt, err := x509.ParseCertificate(b.Bytes)
+	if err != nil {
+		return false, errors.Wrap(err, "parsing cert")
+	}
+	_, err = crt.Verify(x509.VerifyOptions{
+		DNSName:     dnsName,
+		Roots:       pool,
+		CurrentTime: at,
+	})
+	if err != nil {
+		return false, errors.Wrap(err, "verifying cert")
+	}
+	return true, nil
+}
+
+// controller code for making sure the CA cert on the
+// validatingwebhookconfiguration doesn't get clobbered
+
+var _ handler.Mapper = &mapper{}
+
+type mapper struct {
+	secretKey types.NamespacedName
+	vwhKey    types.NamespacedName
+}
+
+func (m *mapper) Map(object handler.MapObject) []reconcile.Request {
+	if object.Meta.GetNamespace() != m.vwhKey.Namespace {
+		return nil
+	}
+	if object.Meta.GetName() != m.vwhKey.Name {
+		return nil
+	}
+	return []reconcile.Request{{NamespacedName: m.secretKey}}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func addController(mgr manager.Manager, r reconcile.Reconciler, secretKey, vwhKey types.NamespacedName) error {
+	// Create a new controller
+	c, err := controller.New(("validating-webhook-controller"), mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to the provided ValidatingWebhookConfiguration
+	s := &corev1.Secret{}
+	if err := c.Watch(&source.Kind{Type: s}, &handler.EnqueueRequestForObject{}); err != nil {
+		return err
+	}
+
+	vwh := &unstructured.Unstructured{}
+	vwh.SetGroupVersionKind(vwhGVK)
+	mapper := &handler.EnqueueRequestsFromMapFunc{ToRequests: &mapper{
+		secretKey: secretKey,
+		vwhKey:    vwhKey,
+	}}
+	if err := c.Watch(&source.Kind{Type: vwh}, mapper); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &ReconcileVWH{}
+
+// ReconcileVWH reconciles a validatingwebhookconfiguration, making sure it
+// has the appropriate CA cert
+type ReconcileVWH struct {
+	client    client.Client
+	scheme    *runtime.Scheme
+	ctx       context.Context
+	secretKey types.NamespacedName
+	vwhKey    types.NamespacedName
+}
+
+// Reconcile reads that state of the cluster for a validatingwebhookconfiguration
+// object and makes sure the most recent CA cert is included
+func (r *ReconcileVWH) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	if request.NamespacedName != r.secretKey {
+		return reconcile.Result{}, nil
+	}
+	secret := &corev1.Secret{}
+	if err := r.client.Get(r.ctx, request.NamespacedName, secret); err != nil {
+		if k8sErrors.IsNotFound(err) {
+			// Object not found, return.  Created objects are automatically garbage collected.
+			// For additional cleanup logic use finalizers.
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{Requeue: true}, err
+	}
+
+	vwh := &unstructured.Unstructured{}
+	vwh.SetGroupVersionKind(vwhGVK)
+	if err := r.client.Get(r.ctx, r.vwhKey, vwh); err != nil {
+		if k8sErrors.IsNotFound(err) {
+			// Object not found, return.  Created objects are automatically garbage collected.
+			// For additional cleanup logic use finalizers.
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{Requeue: true}, err
+	}
+
+	if secret.GetDeletionTimestamp().IsZero() {
+		artifacts, err := buildArtifactsFromSecret(secret)
+		if err != nil {
+			crLog.Error(err, "secret is not well-formed, cannot update ValidatingWebhookConfiguration")
+			return reconcile.Result{}, nil
+		}
+		crLog.Info("ensuring CA cert on ValidatingWebhookConfiguration")
+		if err = injectCertToWebhook(vwh, artifacts.CertPEM); err != nil {
+			crLog.Error(err, "unable to inject cert to webhook")
+			return reconcile.Result{}, err
+		}
+		if err := r.client.Update(r.ctx, vwh); err != nil {
+			return reconcile.Result{Requeue: true}, err
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// ensureCertsExist ensure the cert files exist.
+func (cr *CertRotator) ensureCertsExist() {
+	checkFn := func() (bool, error) {
+		certFile := cr.CertDir + "/" + certName
+		_, err := os.Stat(certFile)
+		if err == nil {
+			return true, nil
+		}
+		return false, nil
+	}
+	if err := wait.ExponentialBackoff(wait.Backoff{
+		Duration: 1 * time.Second,
+		Factor:   2,
+		Jitter:   1,
+		Steps:    10,
+	}, checkFn); err != nil {
+		crLog.Error(err, "max retries for checking certs existence")
+		close(cr.certsNotMounted)
+		return
+	}
+	crLog.Info(fmt.Sprintf("certs are ready in %s", cr.CertDir))
+	close(cr.CertsMounted)
+}

--- a/incubator/hnc/third_party/open-policy-agent/gatekeeper/pkg/webhook/certs_test.go
+++ b/incubator/hnc/third_party/open-policy-agent/gatekeeper/pkg/webhook/certs_test.go
@@ -1,0 +1,152 @@
+package webhook
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+var (
+	cr = &CertRotator{
+		CAName:         "ca",
+		CaOrganization: "org",
+		DNSName:        "service.namespace",
+	}
+)
+
+func TestCertSigning(t *testing.T) {
+	caArtifacts, err := cr.createCACert()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cert, key, err := cr.createCertPEM(caArtifacts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !cr.validServerCert(caArtifacts.CertPEM, cert, key) {
+		t.Error("Generated cert is not valid")
+	}
+}
+
+func TestCertExpiry(t *testing.T) {
+	caArtifacts, err := cr.createCACert()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cert, key, err := cr.createCertPEM(caArtifacts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !cr.validServerCert(caArtifacts.CertPEM, cert, key) {
+		t.Error("Generated cert is not valid")
+	}
+
+	valid, err := validCert(caArtifacts.CertPEM, cert, key, cr.DNSName, time.Now().Add(11*365*24*time.Hour))
+	if err == nil {
+		t.Error("Generated cert has not expired when it should have")
+	}
+	if valid {
+		t.Error("Expired cert is still valid")
+	}
+}
+
+func TestBadCA(t *testing.T) {
+	caArtifacts, err := cr.createCACert()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cert, key, err := cr.createCertPEM(caArtifacts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	badCAArtifacts, err := cr.createCACert()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cr.validServerCert(badCAArtifacts.CertPEM, cert, key) {
+		t.Error("Generated cert is valid when it should not be")
+	}
+}
+
+func TestSelfSignedCA(t *testing.T) {
+	caArtifacts, err := cr.createCACert()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !cr.validCACert(caArtifacts.CertPEM, caArtifacts.KeyPEM) {
+		t.Error("Generated cert is not valid")
+	}
+}
+
+func TestCAExpiry(t *testing.T) {
+	caArtifacts, err := cr.createCACert()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !cr.validCACert(caArtifacts.CertPEM, caArtifacts.KeyPEM) {
+		t.Error("Generated cert is not valid")
+	}
+
+	valid, err := validCert(caArtifacts.CertPEM, caArtifacts.CertPEM, caArtifacts.KeyPEM, cr.CAName, time.Now().Add(11*365*24*time.Hour))
+	if err == nil {
+		t.Error("Generated cert has not expired when it should have")
+	}
+	if valid {
+		t.Error("Expired cert is still valid")
+	}
+}
+
+func TestSecretRoundTrip(t *testing.T) {
+	caArtifacts, err := cr.createCACert()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cert, key, err := cr.createCertPEM(caArtifacts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !cr.validServerCert(caArtifacts.CertPEM, cert, key) {
+		t.Fatal("Generated cert is not valid")
+	}
+
+	secret := &corev1.Secret{}
+	populateSecret(cert, key, caArtifacts, secret)
+	art2, err := buildArtifactsFromSecret(secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !cr.validServerCert(art2.CertPEM, cert, key) {
+		t.Fatal("Recovered cert is not valid")
+	}
+
+	cert2, key2, err := cr.createCertPEM(art2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !cr.validServerCert(caArtifacts.CertPEM, cert2, key2) {
+		t.Fatal("Second generated cert is not valid")
+	}
+}
+
+func TestEmptyIsInvalid(t *testing.T) {
+	if cr.validServerCert([]byte{}, []byte{}, []byte{}) {
+		t.Fatal("empty cert is valid")
+	}
+	if cr.validCACert([]byte{}, []byte{}) {
+		t.Fatal("empty CA cert is valid")
+	}
+}


### PR DESCRIPTION
Fork the cert management from open-policy-agent/gatekeeper repo to serve
as the default internal cert management for HNC.

Add an "enable-internal-cert-management" flag to switch between using
the internal cert (integrated Gatekeeper cert) or the external cert
"cert-manager".

Update main.go to start the controller manager with internal certs first
and once the cert files are ready, add other controllers and webhooks if
webhook is enabled and internal certs are used.

Refactor the cert generation and validator startup into
pkg/validators/setup.go.

To use external cert-manager, update config/default/kustomization.yaml
and manager_auth_proxy_patch.yaml as instructed. Run 'make deploy-cm'
before 'make deploy'.

Tested on a GKE cluster. The manager restarts 0 times and the webhooks
are working as expected.

Fixes #653 