### PR TITLE
Reduce default cardinality of metrics

### DIFF
--- a/incubator/hnc/cmd/manager/main.go
+++ b/incubator/hnc/cmd/manager/main.go
@@ -78,6 +78,7 @@ func main() {
 	flag.BoolVar(&testLog, "enable-test-log", false, "Enables test log.")
 	flag.IntVar(&maxReconciles, "max-reconciles", 1, "Number of concurrent reconciles to perform.")
 	flag.IntVar(&qps, "apiserver-qps-throttle", 50, "The maximum QPS to the API server.")
+	flag.BoolVar(&stats.SuppressObjectTags, "suppress-object-tags", true, "If true, suppresses the kinds of object metrics to reduce metric cardinality.")
 	flag.Parse()
 
 	// Enable OpenCensus exporters to export metrics

--- a/incubator/hnc/pkg/stats/stats.go
+++ b/incubator/hnc/pkg/stats/stats.go
@@ -71,7 +71,7 @@ func StartObjReconcile(gvk schema.GroupVersionKind) {
 	stats.objects[gk].totalReconciles.incr()
 	stats.objects[gk].curReconciles.incr()
 
-	recordTagMetric(stats.objects[gk].totalReconciles, objectReconcileTotal, KeyGroupKind, gk.String())
+	recordObjectMetric(stats.objects[gk].totalReconciles, objectReconcileTotal, gk)
 	// Only update the maxConcurrent value in StartReconcile() since it's impossible to
 	// get the max from StopReconcile() when the reconcile number decrements.
 	peak.concurrentObjectReconcile[gk] = max(peak.concurrentObjectReconcile[gk], stats.objects[gk].curReconciles)
@@ -103,7 +103,7 @@ func WriteObject(gvk schema.GroupVersionKind) {
 	gk := gvk.GroupKind()
 	stats.objects[gk].apiWrites.incr()
 
-	recordTagMetric(stats.objects[gk].apiWrites, objectWritesTotal, KeyGroupKind, gk.String())
+	recordObjectMetric(stats.objects[gk].apiWrites, objectWritesTotal, gk)
 }
 
 func init() {


### PR DESCRIPTION
We got a few comments internally that we shouldn't be putting too many
tags on our metrics by default. I also doubt that detailed stats would
be that useful unless we're doing performance testing, so I made the
GroupKind object tags flag-enabled and disabled them by default

Tested: running HNC on StackDriver, I observed that by default,
GroupKind tags are not displayed on our metrics, but restarting HNC with
--suppress-object-tags=false brought them back.