### PR TITLE
Make HNC container run as non root

### DIFF
--- a/incubator/hnc/Dockerfile
+++ b/incubator/hnc/Dockerfile
@@ -18,9 +18,12 @@ COPY third_party/ third_party/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager ./cmd/manager/main.go
 
+# Copied from kubebuilder scaffold to run as nonroot at
+# https://github.com/kubernetes-sigs/kubebuilder/blob/7af89cb00c224c57ece37dc14ea37caf1eb769db/pkg/scaffold/v2/dockerfile.go#L60
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
+USER nonroot:nonroot
 ENTRYPOINT ["/manager"]

--- a/incubator/hnc/cmd/manager/main.go
+++ b/incubator/hnc/cmd/manager/main.go
@@ -57,6 +57,7 @@ var (
 	testLog              bool
 	internalCert         bool
 	qps                  int
+	webhookServerPort    int
 )
 
 func init() {
@@ -81,6 +82,7 @@ func main() {
 	flag.IntVar(&maxReconciles, "max-reconciles", 1, "Number of concurrent reconciles to perform.")
 	flag.IntVar(&qps, "apiserver-qps-throttle", 50, "The maximum QPS to the API server.")
 	flag.BoolVar(&stats.SuppressObjectTags, "suppress-object-tags", true, "If true, suppresses the kinds of object metrics to reduce metric cardinality.")
+	flag.IntVar(&webhookServerPort, "webhook-server-port", 443, "The port that the webhook server serves at.")
 	flag.Parse()
 
 	// Enable OpenCensus exporters to export metrics
@@ -128,6 +130,7 @@ func main() {
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   leaderElectionId,
+		Port:               webhookServerPort,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/incubator/hnc/config/default/manager_auth_proxy_patch.yaml
+++ b/incubator/hnc/config/default/manager_auth_proxy_patch.yaml
@@ -8,6 +8,13 @@ metadata:
 spec:
   template:
     spec:
+      securityContext:
+        # Generally to run as non root, the GID and UID can be any number between
+        # 1 to 65535 except for root, which is 0. If PodSecurityPolicy (PSP) is
+        # enabled, adjust the GID and UID to meet the specific requirement in PSP.
+        fsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
       - name: kube-rbac-proxy
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.0
@@ -21,6 +28,7 @@ spec:
           name: https
       - name: manager
         args:
+        - "--webhook-server-port=9443"
         - "--metrics-addr=127.0.0.1:8080"
         - "--enable-leader-election"
         - "--leader-election-id=hnc-controller-leader-election-helper"

--- a/incubator/hnc/config/default/manager_webhook_patch.yaml
+++ b/incubator/hnc/config/default/manager_webhook_patch.yaml
@@ -9,7 +9,7 @@ spec:
       containers:
       - name: manager
         ports:
-        - containerPort: 443
+        - containerPort: 9443
           name: webhook-server
           protocol: TCP
         volumeMounts:

--- a/incubator/hnc/config/webhook/service.yaml
+++ b/incubator/hnc/config/webhook/service.yaml
@@ -7,6 +7,6 @@ metadata:
 spec:
   ports:
     - port: 443
-      targetPort: 443
+      targetPort: 9443
   selector:
     control-plane: controller-manager


### PR DESCRIPTION
Make the HNC container image run as non root. Add securityContext in the
HNC pod to make containers in it run as non root.

Add a port flag that defaults to 443 in the code. Since the container is
run as non root, it's not able to use ports below 1024 reserved for root
only. Therefore, in the pod manifest, set port flag to 9443 and have the
webhook service map the 443 port to targetPort 9443 in the conainer.

Tested on a GKE cluster with PSP of notrunasroot is enabled.