### PR TITLE
Remove the term "self-serve (sub)namespace"

### DIFF
--- a/incubator/hnc/api/v1alpha1/hierarchy_types.go
+++ b/incubator/hnc/api/v1alpha1/hierarchy_types.go
@@ -68,8 +68,8 @@ type HierarchyConfigurationSpec struct {
 	// Parent indicates the parent of this namespace, if any.
 	Parent string `json:"parent,omitempty"`
 
-	// AllowCascadingDelete indicates if the self-serve subnamespaces of this namespace are allowed
-	// to cascading delete.
+	// AllowCascadingDelete indicates if the subnamespaces of this namespace are allowed to cascading
+	// delete.
 	AllowCascadingDelete bool `json:"allowCascadingDelete,omitempty"`
 }
 

--- a/incubator/hnc/pkg/kubectl/create.go
+++ b/incubator/hnc/pkg/kubectl/create.go
@@ -32,15 +32,15 @@ var createCmd = &cobra.Command{
 			fmt.Println("Error: parent must be set via --namespace or -n")
 			os.Exit(1)
 		}
-		// Create the hns instance, the custom resource representing the self-serve subnamespace.
+		// Create the hns instance, the custom resource representing the subnamespace.
 		// TODO: ensure the specified child doesn't already exist and the parent is allowed
-		//  to create self-serve subnamespaces through the admission controller. See issue
+		//  to create subnamespaces through the admission controller. See issue
 		//  https://github.com/kubernetes-sigs/multi-tenancy/issues/458
 		client.createHierarchicalNamespace(parent, args[0])
 	},
 }
 
 func newCreateCmd() *cobra.Command {
-	createCmd.Flags().StringP("namespace", "n", "", "The parent namespace for the new self-serve subnamespace")
+	createCmd.Flags().StringP("namespace", "n", "", "The parent namespace for the new subnamespace")
 	return createCmd
 }

--- a/incubator/hnc/pkg/kubectl/set.go
+++ b/incubator/hnc/pkg/kubectl/set.go
@@ -168,7 +168,7 @@ func normalizeStringArray(in []string) []string {
 func newSetCmd() *cobra.Command {
 	setCmd.Flags().BoolP("root", "r", false, "Removes the current parent namespace, making this namespace a root")
 	setCmd.Flags().StringP("parent", "p", "", "Sets the parent namespace")
-	setCmd.Flags().BoolP("allowCascadingDelete", "a", false, "Allows cascading deletion of its self-serve subnamespaces.")
-	setCmd.Flags().BoolP("forbidCascadingDelete", "f", false, "Protects cascading deletion of its self-serve subnamespaces.")
+	setCmd.Flags().BoolP("allowCascadingDelete", "a", false, "Allows cascading deletion of its subnamespaces.")
+	setCmd.Flags().BoolP("forbidCascadingDelete", "f", false, "Protects cascading deletion of its subnamespaces.")
 	return setCmd
 }

--- a/incubator/hnc/pkg/reconcilers/hierarchical_namespace.go
+++ b/incubator/hnc/pkg/reconcilers/hierarchical_namespace.go
@@ -70,11 +70,11 @@ func (r *HierarchicalNamespaceReconciler) Reconcile(req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	// Report "Forbidden" state and early exit if the namespace is not allowed to
-	// self-serve namespaces but has bypassed the webhook and successfully created
-	// the hns instance. Forbidden HNSes won't have finalizers.
-	// TODO refactor/split the EX map for 1) reconciler exclusion and 2) self-serve not allowed
-	//  purposes. See issue: https://github.com/kubernetes-sigs/multi-tenancy/issues/495
+	// Report "Forbidden" state and early exit if the namespace is not allowed to have subnamespaces
+	// but has bypassed the webhook and successfully created the hns instance. Forbidden HNSes won't
+	// have finalizers.
+	// TODO refactor/split the EX map for 1) reconciler exclusion and 2) subnamespaces exclusion
+	// purposes. See issue: https://github.com/kubernetes-sigs/multi-tenancy/issues/495
 	if config.EX[pnm] {
 		inst.Status.State = api.Forbidden
 		return ctrl.Result{}, r.writeInstance(ctx, log, inst)
@@ -91,7 +91,7 @@ func (r *HierarchicalNamespaceReconciler) Reconcile(req ctrl.Request) (ctrl.Resu
 	}
 
 	// Update the state. If the owned child namespace doesn't exist, create it.
-	// (This is how a self-service namespace is created through a CR)
+	// (This is how a subnamespace is created through a CR)
 	r.updateState(log, inst, cnsInst)
 	if inst.Status.State == api.Missing {
 		if err := r.writeNamespace(ctx, log, nm, pnm); err != nil {

--- a/incubator/hnc/pkg/reconcilers/hierarchical_namespace_test.go
+++ b/incubator/hnc/pkg/reconcilers/hierarchical_namespace_test.go
@@ -49,7 +49,7 @@ var _ = Describe("HierarchicalNamespace", func() {
 		Eventually(getHNSState(ctx, fooName, barName)).Should(Equal(api.Ok))
 	})
 
-	It("should set the hns.status.state to Forbidden if the owner is not allowed to self-serve subnamespaces", func() {
+	It("should set the hns.status.state to Forbidden if the owner is not allowed to subnamespaces", func() {
 		kube_system_hns_bar := newHierarchicalNamespace(barName, "kube-system")
 		updateHierarchicalNamespace(ctx, kube_system_hns_bar)
 		Eventually(getHNSState(ctx, "kube-system", barName)).Should(Equal(api.Forbidden))


### PR DESCRIPTION
The documentation now uses the term "subnamespaces" so all internal and
external code should use that as well.

Tested: none

Addresses #667 