### PR TITLE
Change "owned" namespaces to subnamespaces

### DIFF
--- a/incubator/hnc/api/v1alpha1/hierarchical_namespace.go
+++ b/incubator/hnc/api/v1alpha1/hierarchical_namespace.go
@@ -24,7 +24,7 @@ const (
 	HierarchicalNamespaces           = "hierarchicalnamespaces"
 	HierarchicalNamespacesKind       = "HierarchicalNamespace"
 	HierarchicalNamespacesAPIVersion = MetaGroup + "/v1alpha1"
-	AnnotationOwner                  = MetaGroup + "/ownerReference"
+	SubnamespaceOf                   = MetaGroup + "/subnamespaceOf"
 )
 
 // HNSState describes the state of a hierarchical namespace. The state could be

--- a/incubator/hnc/api/v1alpha1/hierarchy_types.go
+++ b/incubator/hnc/api/v1alpha1/hierarchy_types.go
@@ -123,9 +123,8 @@ type Condition struct {
 	// - "CritAncestor": a critical error exists in an ancestor namespace, so this namespace is no
 	// longer being updated either.
 	//
-	// - "HNSMissing": this namespace is an owned namespace (created by reconciling an hns instance),
-	// but the hns instance is missing in its owner (referenced in its owner annotation) or the owner
-	// namespace is missing.
+	// - "HNSMissing": this namespace is a subnamespace, but the hierarchicalnamespace instance
+	// referenced in its `subnamespaceOf` annotation does not exist in the parent.
 	//
 	// - "CannotPropagateObject": this namespace contains an object that couldn't be propagated to
 	// one or more of its descendants. The condition's affect objects will include a list of the

--- a/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hierarchyconfigurations.yaml
+++ b/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hierarchyconfigurations.yaml
@@ -35,8 +35,8 @@ spec:
           description: HierarchySpec defines the desired state of Hierarchy
           properties:
             allowCascadingDelete:
-              description: AllowCascadingDelete indicates if the self-serve subnamespaces
-                of this namespace are allowed to cascading delete.
+              description: AllowCascadingDelete indicates if the subnamespaces of
+                this namespace are allowed to cascading delete.
               type: boolean
             parent:
               description: Parent indicates the parent of this namespace, if any.
@@ -95,10 +95,9 @@ spec:
                       would cause a cycle) \n - \"CritAncestor\": a critical error
                       exists in an ancestor namespace, so this namespace is no longer
                       being updated either. \n - \"HNSMissing\": this namespace is
-                      an owned namespace (created by reconciling an hns instance),
-                      but the hns instance is missing in its owner (referenced in
-                      its owner annotation) or the owner namespace is missing. \n
-                      - \"CannotPropagateObject\": this namespace contains an object
+                      a subnamespace, but the hierarchicalnamespace instance referenced
+                      in its `subnamespaceOf` annotation does not exist in the parent.
+                      \n - \"CannotPropagateObject\": this namespace contains an object
                       that couldn't be propagated to one or more of its descendants.
                       The condition's affect objects will include a list of the copies
                       that couldn't be updated. \n - \"CannotUpdateObject\": this

--- a/incubator/hnc/hack/test-issue-501.sh
+++ b/incubator/hnc/hack/test-issue-501.sh
@@ -10,79 +10,79 @@ echo "Creating the root 'parent'"
 kubectl create ns parent
 sleep 1
 
-echo "${bold}----Creating the 1st branch of owned namespaces----${normal}"
-echo "Creating owned namespace 'ochild1' for 'parent'"
-kubectl hns create ochild1 -n parent
+echo "${bold}----Creating the 1st branch of subnamespaces----${normal}"
+echo "Creating subnamespace 'sub1' for 'parent'"
+kubectl hns create sub1 -n parent
 sleep 1
-echo "Creating owned namespace 'ochild1ofochild1' for 'ochild1'"
-kubectl hns create ochild1ofochild1 -n ochild1
-echo "Creating owned namespace 'ochild2ofochild1' for 'ochild1'"
-kubectl hns create ochild2ofochild1 -n ochild1
+echo "Creating subnamespace 'sub1-sub1' for 'sub1'"
+kubectl hns create sub1-sub1 -n sub1
+echo "Creating subnamespace 'sub2-sub1' for 'sub1'"
+kubectl hns create sub2-sub1 -n sub1
 
-echo "${bold}----Creating the 2nd branch of owned namespaces----${normal}"
-echo "Creating owned namespace 'ochild2' for 'parent'"
-kubectl hns create ochild2 -n parent
+echo "${bold}----Creating the 2nd branch of subnamespaces----${normal}"
+echo "Creating subnamespace 'sub2' for 'parent'"
+kubectl hns create sub2 -n parent
 sleep 1
-echo "Creating owned namespace 'ochildofochild2' for 'ochild2'"
-kubectl hns create ochildofochild2 -n ochild2
+echo "Creating subnamespace 'sub-sub2' for 'sub2'"
+kubectl hns create sub-sub2 -n sub2
 
-echo "${bold}----Creating the 3rd branch of a mix of unowned and owned namespaces----${normal}"
-echo "Creating a namespace 'nochild' (not-owned-child) and set its parent to 'parent'"
-kubectl create ns nochild
+echo "${bold}----Creating the 3rd branch of a mix of full and subnamespaces----${normal}"
+echo "Creating a namespace 'fullchild' and set its parent to 'parent'"
+kubectl create ns fullchild
 sleep 1
-kubectl hns set nochild --parent parent
-echo "Creating owned namespace 'ochildofnochild' for 'nochild'"
-kubectl hns create ochildofnochild -n nochild
+kubectl hns set fullchild --parent parent
+echo "Creating subnamespace 'sub-fullchild' for 'fullchild'"
+kubectl hns create sub-fullchild -n fullchild
 sleep 1
 
 echo "${bold}Here's the outcome of the tree hierarhy:${normal}"
 kubectl hns tree parent
 
 echo "----------------------------------------------------"
-echo "${bold}Test-1:${normal} If the owned namespace doesn't allow cascadingDelete and the HNS is missing in the owner namespace, it should have 'HNS_MISSING' condition while its descendants shoudn't have any conditions."
-echo "${bold}Operation:${normal} delete 'ochild1' hns in 'parent' - kubectl delete hns ochild1 -n parent"
-kubectl delete hns ochild1 -n parent
+echo "${bold}Test-1:${normal} If the subnamespace doesn't allow cascadingDelete and the HNS is missing in the owner namespace, it should have 'HNS_MISSING' condition while its descendants shoudn't have any conditions."
+echo "${bold}Operation:${normal} delete 'sub1' hns in 'parent' - kubectl delete hns sub1 -n parent"
+kubectl delete hns sub1 -n parent
 sleep 1
-echo "${bold}Expected:${normal} 'ochild1' namespace is not deleted and should have 'HNS_MISSING' condition; no other conditions."
+echo "${bold}Expected:${normal} 'sub1' namespace is not deleted and should have 'HNS_MISSING' condition; no other conditions."
 echo "${bold}Result:${normal}"
 kubectl hns tree parent
 
 echo "----------------------------------------------------"
-echo "${bold}Test-2:${normal} If the HNS is not missing, it should unset the 'HNS_MISSING' condition in the owned namespace."
-echo "${bold}Operation:${normal} recreate the 'ochild1' hns in 'parent' - kubectl hns create ochild1 -n parent"
-kubectl hns create ochild1 -n parent
+echo "${bold}Test-2:${normal} If the HNS is not missing, it should unset the 'HNS_MISSING' condition in the subnamespace."
+echo "${bold}Operation:${normal} recreate the 'sub1' hns in 'parent' - kubectl hns create sub1 -n parent"
+kubectl hns create sub1 -n parent
 sleep 1
 echo "${bold}Expected:${normal} no conditions."
 echo "${bold}Result:${normal}"
 kubectl hns tree parent
 
 echo "----------------------------------------------------"
-echo "${bold}Test-3:${normal} If the owned namespace allows cascadingDelete and the HNS is deleted, it should cascading delete all directly owned namespaces."
-echo "${bold}Operation:${normal} 1) allow cascadingDelete in 'ochid1' - kubectl hns set ochild1 --allowCascadingDelete=true"
-kubectl hns set ochild1 --allowCascadingDelete=true
-echo "2) delete 'ochild1' hns in 'parent' - kubectl delete hns ochild1 -n parent"
-kubectl delete hns ochild1 -n parent
+echo "${bold}Test-3:${normal} If the subnamespace allows cascadingDelete and the HNS is deleted, it should cascading delete all immediate subnamespaces."
+echo "${bold}Operation:${normal} 1) allow cascadingDelete in 'ochid1' - kubectl hns set sub1 --allowCascadingDelete=true"
+kubectl hns set sub1 --allowCascadingDelete=true
+echo "2) delete 'sub1' hns in 'parent' - kubectl delete hns sub1 -n parent"
+kubectl delete hns sub1 -n parent
 echo "Waiting 3s for the namespaces to be deleted..."
 sleep 3
-echo "${bold}Expected:${normal} 'ochild1', 'ochild1ofochild1', 'ochild2ofochild1' should all be gone"
+echo "${bold}Expected:${normal} 'sub1', 'sub1-sub1', 'sub2-sub1' should all be gone"
 echo "${bold}Result:${normal}"
 kubectl hns tree parent
 
 echo "----------------------------------------------------"
-echo "${bold}Test-4:${normal} If the owner namespace allows cascadingDelete and it's deleted, all its directly owned namespaces should be cascading deleted."
+echo "${bold}Test-4:${normal} If the owner namespace allows cascadingDelete and it's deleted, all its subnamespaces should be cascading deleted."
 echo "${bold}Operation:${normal} 1) allow cascadingDelete in 'parent' - kubectl hns set parent --allowCascadingDelete=true"
 kubectl hns set parent --allowCascadingDelete=true
 echo "2) delete 'parent' namespace - kubectl delete ns parent"
 kubectl delete ns parent
 echo "Waiting 3s for the namespaces to be deleted..."
 sleep 3
-echo "${bold}Expected:${normal} only 'nochild' and 'ochildofnochild' should be left and they should have CRIT_ conditions related to missing 'parent'"
+echo "${bold}Expected:${normal} only 'fullchild' and 'sub-fullchild' should be left and they should have CRIT_ conditions related to missing 'parent'"
 echo "${bold}Result:${normal}"
 kubectl hns tree parent
-kubectl hns tree ochild2
-kubectl hns tree nochild
+kubectl hns tree sub2
+kubectl hns tree fullchild
 
 echo "----------------------------------------------------"
 echo "${bold}Cleaning up${normal}"
-kubectl hns set nochild --allowCascadingDelete=true
-kubectl delete ns nochild
+kubectl hns set fullchild --allowCascadingDelete=true
+kubectl delete ns fullchild

--- a/incubator/hnc/pkg/forest/forest.go
+++ b/incubator/hnc/pkg/forest/forest.go
@@ -170,9 +170,9 @@ type Namespace struct {
 	// on this namespace.
 	conditions conditions
 
-	// IsOwned indicates that this namespace is being or was created solely to live as a
+	// IsSub indicates that this namespace is being or was created solely to live as a
 	// subnamespace of the specified parent.
-	IsOwned bool
+	IsSub bool
 
 	// HNSes store a list of HNS instances in the namespace.
 	HNSes []string
@@ -227,7 +227,7 @@ func (ns *Namespace) AllowsCascadingDelete() bool {
 	if ns.allowCascadingDelete == true {
 		return true
 	}
-	if !ns.IsOwned {
+	if !ns.IsSub {
 		return false
 	}
 	// If the owner is missing, it will return the default false.

--- a/incubator/hnc/pkg/reconcilers/hierarchical_namespace_test.go
+++ b/incubator/hnc/pkg/reconcilers/hierarchical_namespace_test.go
@@ -23,23 +23,23 @@ var _ = Describe("HierarchicalNamespace", func() {
 		barName = createNSName("bar")
 	})
 
-	It("should create an owned namespace and update the hierarchy according to the HNS instance", func() {
+	It("should create an subnamespace and update the hierarchy according to the HNS instance", func() {
 		// Create 'bar' hns in 'foo' namespace.
 		foo_hns_bar := newHierarchicalNamespace(barName, fooName)
 		updateHierarchicalNamespace(ctx, foo_hns_bar)
 
-		// It should create the namespace 'bar' with 'foo' in the owner annotation.
+		// It should create the namespace 'bar' with 'foo' in the subnamespaceOf annotation.
 		Eventually(func() string {
-			return getNamespace(ctx, barName).GetAnnotations()[api.AnnotationOwner]
+			return getNamespace(ctx, barName).GetAnnotations()[api.SubnamespaceOf]
 		}).Should(Equal(fooName))
 
-		// It should set the owned namespace "bar" as a child of the owner "foo".
+		// It should set the subnamespace "bar" as a child of the parent "foo".
 		Eventually(func() []string {
 			fooHier := getHierarchy(ctx, fooName)
 			return fooHier.Status.Children
 		}).Should(Equal([]string{barName}))
 
-		// It should set the owner namespace "foo" as the parent of "bar".
+		// It should set the parent namespace "foo" as the parent of "bar".
 		Eventually(func() string {
 			barHier := getHierarchy(ctx, barName)
 			return barHier.Spec.Parent
@@ -49,7 +49,7 @@ var _ = Describe("HierarchicalNamespace", func() {
 		Eventually(getHNSState(ctx, fooName, barName)).Should(Equal(api.Ok))
 	})
 
-	It("should set the hns.status.state to Forbidden if the owner is not allowed to subnamespaces", func() {
+	It("should set the hns.status.state to Forbidden if the parent is not allowed to have subnamespaces", func() {
 		kube_system_hns_bar := newHierarchicalNamespace(barName, "kube-system")
 		updateHierarchicalNamespace(ctx, kube_system_hns_bar)
 		Eventually(getHNSState(ctx, "kube-system", barName)).Should(Equal(api.Forbidden))

--- a/incubator/hnc/pkg/reconcilers/hierarchy_config.go
+++ b/incubator/hnc/pkg/reconcilers/hierarchy_config.go
@@ -155,8 +155,7 @@ func (r *HierarchyConfigReconciler) updateFinalizers(ctx context.Context, log lo
 	// https://github.com/kubernetes-sigs/multi-tenancy/issues/623 as we try to enforce that.
 	switch {
 	case len(hnsnms) == 0:
-		// There's no owned namespaces in this namespace. The HC instance can be
-		// safely deleted anytime.
+		// There are no subnamespaces in this namespace. The HC instance can be safely deleted anytime.
 		if len(inst.ObjectMeta.Finalizers) > 0 {
 			log.Info("Removing finalizers since there's no longer any HNS instance in the namespace.")
 		}
@@ -165,7 +164,7 @@ func (r *HierarchyConfigReconciler) updateFinalizers(ctx context.Context, log lo
 		// If the HC instance is being deleted but not the namespace (which means
 		// it's not a cascading delete), remove the finalizers to let it go through.
 		// This is the only case the finalizers can be removed even when the
-		// namespace has owned namespaces. (A default HC will be recreated later.)
+		// namespace has subnamespaces. (A default HC will be recreated later.)
 		log.Info("Removing finalizers to allow a single deletion of the singleton (not involved in a cascading deletion).")
 		inst.ObjectMeta.Finalizers = nil
 	default:
@@ -205,31 +204,31 @@ func (r *HierarchyConfigReconciler) syncWithForest(log logr.Logger, nsInst *core
 	r.syncConditions(log, inst, ns, hadCrit)
 }
 
-// syncOwner sets the parent to the owner and updates the HNSMissing condition
-// if the HNS instance is missing in the owner namespace according to the forest.
-// The namespace owner annotation is the source of truth of the ownership, since
-// modifying a namespace has higher privilege than what HNC users can do.
+// syncOwner sets the parent to the owner and updates the HNSMissing condition if the HNS instance
+// is missing in the parent namespace according to the forest.  The namespace owner annotation is
+// the source of truth of the ownership (e.g. being a subnamespace), since modifying a namespace has
+// higher privilege than what HNC users can do.
 func (r *HierarchyConfigReconciler) syncOwner(log logr.Logger, inst *api.HierarchyConfiguration, nsInst *corev1.Namespace, ns *forest.Namespace) {
-	// Clear the HNSMissing condition if this is not an owned namespace or to
+	// Clear the HNSMissing condition if this is not a subnamespace or to
 	// reset it for the updated condition later.
 	ns.ClearConditionsByCode(log, api.HNSMissing)
 	nm := ns.Name()
-	onm := nsInst.Annotations[api.AnnotationOwner]
+	onm := nsInst.Annotations[api.SubnamespaceOf]
 	ons := r.Forest.Get(onm)
 
 	if onm == "" {
-		ns.IsOwned = false
+		ns.IsSub = false
 		return
 	}
 
-	ns.IsOwned = true
+	ns.IsSub = true
 
 	if inst.Spec.Parent != onm {
 		log.Info("The parent doesn't match the owner. Setting the owner as the parent.", "parent", inst.Spec.Parent, "owner", onm)
 		inst.Spec.Parent = onm
 	}
 
-	// Look up the HNSes in the owner namespace. Set HNSMissing condition if it's
+	// Look up the HNSes in the parent namespace. Set HNSMissing condition if it's
 	// not there.
 	found := false
 	for _, hnsnm := range ons.HNSes {
@@ -239,7 +238,7 @@ func (r *HierarchyConfigReconciler) syncOwner(log logr.Logger, inst *api.Hierarc
 		}
 	}
 	if !found {
-		ns.SetCondition(api.NewAffectedNamespace(onm), api.HNSMissing, "The HNS instance is missing in the owner namespace")
+		ns.SetCondition(api.NewAffectedNamespace(onm), api.HNSMissing, "The HNS instance is missing in the parent namespace")
 	}
 }
 
@@ -249,9 +248,9 @@ func (r *HierarchyConfigReconciler) markExisting(log logr.Logger, ns *forest.Nam
 	if ns.SetExists() {
 		log.Info("Reconciling new namespace")
 		r.enqueueAffected(log, "relative of newly synced/created namespace", ns.RelativesNames()...)
-		if ns.IsOwned {
-			r.enqueueAffected(log, "owner of the newly synced/created namespace", ns.Parent().Name())
-			r.hnsr.enqueue(log, ns.Name(), ns.Parent().Name(), "the missing owned namespace is found")
+		if ns.IsSub {
+			r.enqueueAffected(log, "parent of the newly synced/created namespace", ns.Parent().Name())
+			r.hnsr.enqueue(log, ns.Name(), ns.Parent().Name(), "the missing subnamespace is found")
 		}
 	}
 }
@@ -348,7 +347,7 @@ func (r *HierarchyConfigReconciler) flushObsoleteObjectConditions(log logr.Logge
 
 // syncHNSes updates the HNS list. If any HNS is created/deleted, it will enqueue
 // the child to update its HNSMissing condition. A modified HNS will appear
-// twice in the change list (one in deleted, one in created), both owned namespace
+// twice in the change list (one in deleted, one in created), both subnamespaces
 // needs to be enqueued in this case.
 func (r *HierarchyConfigReconciler) syncHNSes(log logr.Logger, ns *forest.Namespace, hnsnms []string) {
 	for _, changedHNS := range ns.SetHNSes(hnsnms) {
@@ -584,7 +583,7 @@ func (r *HierarchyConfigReconciler) SetupWithManager(mgr ctrl.Manager, maxReconc
 				}},
 			}
 		})
-	// Maps a HierarchicalNamespace (HNS) instance to the owner singleton.
+	// Maps a HierarchicalNamespace (HNS) instance to the parent singleton.
 	hnsMapFn := handler.ToRequestsFunc(
 		func(a handler.MapObject) []reconcile.Request {
 			return []reconcile.Request{

--- a/incubator/hnc/pkg/validators/hierarchical_namespace_test.go
+++ b/incubator/hnc/pkg/validators/hierarchical_namespace_test.go
@@ -62,6 +62,6 @@ func createOwnedNamespace(f *forest.Forest, pnm, cnm string) *forest.Namespace {
 	pns := f.Get(pnm)
 	cns := createNS(f, cnm, nil)
 	cns.SetParent(pns)
-	cns.IsOwned = true
+	cns.IsSub = true
 	return cns
 }

--- a/incubator/hnc/pkg/validators/hierarchy.go
+++ b/incubator/hnc/pkg/validators/hierarchy.go
@@ -147,9 +147,9 @@ func (v *Hierarchy) checkParent(ns, curParent, newParent *forest.Namespace) admi
 		return deny(metav1.StatusReasonForbidden, "Excluded parent: "+reason)
 	}
 
-	// Prevent changing parent of an owned child
-	if ns.IsOwned {
-		reason := fmt.Sprintf("Cannot set the parent of %q to %q because it's an owned namespace of %q", ns.Name(), newParent.Name(), curParent.Name())
+	// Prevent changing parent of a subnamespace
+	if ns.IsSub {
+		reason := fmt.Sprintf("Cannot set the parent of %q to %q because it's a subnamespace of %q", ns.Name(), newParent.Name(), curParent.Name())
 		return deny(metav1.StatusReasonConflict, "Illegal parent: "+reason)
 	}
 

--- a/incubator/hnc/pkg/validators/namespace_test.go
+++ b/incubator/hnc/pkg/validators/namespace_test.go
@@ -11,18 +11,18 @@ import (
 	"github.com/kubernetes-sigs/multi-tenancy/incubator/hnc/pkg/forest"
 )
 
-func TestDeleteOwnedNamespace(t *testing.T) {
+func TestDeleteSubNamespace(t *testing.T) {
 	// Create a namespace with owner annotation.
-	owned := &corev1.Namespace{}
-	owned.Name = "owned"
-	setOwnerAnnotation(owned)
+	sub := &corev1.Namespace{}
+	sub.Name = "sub"
+	setSubnamespaceOf(sub)
 
 	vns := &Namespace{}
 
 	t.Run("Delete namespace with owner annotation", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		req := &nsRequest{
-			ns: owned,
+			ns: sub,
 			op: v1beta1.Delete,
 		}
 
@@ -40,48 +40,48 @@ func TestDeleteOwnerNamespace(t *testing.T) {
 	vns := &Namespace{Forest: f}
 
 	// Create a namespace
-	owner := &corev1.Namespace{}
-	owner.Name = "owner"
-	ons := createNS(f, "owner", nil)
+	parent := &corev1.Namespace{}
+	parent.Name = "parent"
+	ons := createNS(f, "parent", nil)
 
-	t.Run("Delete a namespace with owned namespaces", func(t *testing.T) {
+	t.Run("Delete a namespace with subnamespaces", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		req := &nsRequest{
-			ns: owner,
+			ns: parent,
 			op: v1beta1.Delete,
 		}
 
-		// Add two owned namespaces and leave allowCascadingDelete unset.
-		cns1 := createOwnedNamespace(f, "owner", "owned1")
-		cns2 := createOwnedNamespace(f, "owner", "owned2")
+		// Add two subnamespaces and leave allowCascadingDelete unset.
+		sub1 := createOwnedNamespace(f, "parent", "sub1")
+		sub2 := createOwnedNamespace(f, "parent", "sub2")
 		// Test
 		got := vns.handle(req)
-		// Report - Shouldn't allow deleting the owner namespace.
+		// Report - Shouldn't allow deleting the parent namespace.
 		logResult(t, got.AdmissionResponse.Result)
 		g.Expect(got.AdmissionResponse.Allowed).Should(BeFalse())
 
 		// Set allowCascadingDelete on one child.
-		cns1.UpdateAllowCascadingDelete(true)
+		sub1.UpdateAllowCascadingDelete(true)
 		// Test
 		got = vns.handle(req)
-		// Report - Still shouldn't allow deleting the owner namespace.
+		// Report - Still shouldn't allow deleting the parent namespace.
 		logResult(t, got.AdmissionResponse.Result)
 		g.Expect(got.AdmissionResponse.Allowed).Should(BeFalse())
 
 		// Set allowCascadingDelete on the other child too.
-		cns2.UpdateAllowCascadingDelete(true)
+		sub2.UpdateAllowCascadingDelete(true)
 		// Test
 		got = vns.handle(req)
-		// Report - Should allow deleting the owner namespace since both owned namespaces allow cascading deletion.
+		// Report - Should allow deleting the parent namespace since both subnamespaces allow cascading deletion.
 		logResult(t, got.AdmissionResponse.Result)
 		g.Expect(got.AdmissionResponse.Allowed).Should(BeTrue())
 
-		// Unset allowCascadingDelete on one child but set allowCascadingDelete on the owner itself.
-		cns2.UpdateAllowCascadingDelete(false)
+		// Unset allowCascadingDelete on one child but set allowCascadingDelete on the parent itself.
+		sub2.UpdateAllowCascadingDelete(false)
 		ons.UpdateAllowCascadingDelete(true)
 		// Test
 		got = vns.handle(req)
-		// Report - Should allow deleting the owner namespace with allowCascadingDelete set on it.
+		// Report - Should allow deleting the parent namespace with allowCascadingDelete set on it.
 		logResult(t, got.AdmissionResponse.Result)
 		g.Expect(got.AdmissionResponse.Allowed).Should(BeTrue())
 
@@ -89,8 +89,8 @@ func TestDeleteOwnerNamespace(t *testing.T) {
 
 }
 
-func setOwnerAnnotation(ns *corev1.Namespace) {
+func setSubnamespaceOf(ns *corev1.Namespace) {
 	a := make(map[string]string)
-	a[api.AnnotationOwner] = "someOwner"
+	a[api.SubnamespaceOf] = "someParent"
 	ns.SetAnnotations(a)
 }


### PR DESCRIPTION
Part of #667. The term "owned" namespace has been changed throughout to
"subnamespace"; the annotation changed from `ownerReference` to
`subnamespaceOf`; the term "owner namespace" has usually been changed to
simply "parent."

Tested: ran hack/test-issue-501.sh; everything works as well as expected
given that the new webhooks prevent us from doing the wrong thing. Also
ran the HNC demo script.

Fixes #667 