### PR TITLE
More robust server checks

### DIFF
--- a/incubator/hnc/pkg/forest/forest.go
+++ b/incubator/hnc/pkg/forest/forest.go
@@ -450,15 +450,16 @@ func (ns *Namespace) HasLocalCritCondition() bool {
 	return ns.HasCondition(api.AffectedObject{}, "")
 }
 
-// HasCritCondition returns if the namespace or any of its ancestors has any critical condition.
-func (ns *Namespace) HasCritCondition() bool {
+// GetCritAncestor returns the name of the first ancestor with a critical condition, or the empty
+// string if there are no such ancestors. It *can* return the name of the current namespace.
+func (ns *Namespace) GetCritAncestor() string {
 	if ns.HasLocalCritCondition() {
-		return true
+		return ns.name
 	}
 	if ns.Parent() == nil {
-		return false
+		return ""
 	}
-	return ns.Parent().HasCritCondition()
+	return ns.Parent().GetCritAncestor()
 }
 
 // HasCondition returns true if there's a condition with the given object and code. If code is the

--- a/incubator/hnc/pkg/reconcilers/hierarchy_config.go
+++ b/incubator/hnc/pkg/reconcilers/hierarchy_config.go
@@ -357,7 +357,7 @@ func (r *HierarchyConfigReconciler) syncAnchors(log logr.Logger, ns *forest.Name
 
 func (r *HierarchyConfigReconciler) syncLabel(log logr.Logger, nsInst *corev1.Namespace, ns *forest.Namespace) {
 	// Depth label only makes sense if there's no error condition.
-	if ns.HasCritCondition() {
+	if ns.GetCritAncestor() != "" {
 		return
 	}
 

--- a/incubator/hnc/pkg/reconcilers/object.go
+++ b/incubator/hnc/pkg/reconcilers/object.go
@@ -239,7 +239,7 @@ func (r *ObjectReconciler) syncWithForest(ctx context.Context, log logr.Logger, 
 	// what we'd _like_ to do. We still needed to sync the forest since we want to know when objects
 	// are added and removed, so we can sync them properly if the critical condition is resolved, but
 	// don't do anything else for now.
-	if r.Forest.Get(inst.GetNamespace()).HasCritCondition() {
+	if r.Forest.Get(inst.GetNamespace()).GetCritAncestor() != "" {
 		return actionNop, nil
 	}
 
@@ -397,7 +397,7 @@ func (r *ObjectReconciler) syncSource(ctx context.Context, log logr.Logger, src 
 
 func (r *ObjectReconciler) enqueueDescendants(ctx context.Context, log logr.Logger, src *unstructured.Unstructured) {
 	sns := r.Forest.Get(src.GetNamespace())
-	if sns.HasCritCondition() {
+	if sns.GetCritAncestor() != "" {
 		// There's no point enqueuing anything if the source namespace has a crit condition since we'll
 		// just skip any action anyway.
 		log.Info("Source object has changed but namespace has critical condition; will not enqueue descendants")


### PR DESCRIPTION
Now that we have subnamespaces, we can't have missing namespaces in the
middle of a tree, only at the root. Simplify the authz checks to reflect
this, and better handle the two reasons why the namespace might be
missing (HNC is starting up vs the namespace is truly orphaned).

Tested: manually confirmed that we can fix namespaces with the
CritParentMissing condition, either by making it a root or recreating
the missing parent. Also manually confirmed that we can't change the
properties of a namespace with a critical ancestor. Added logs and
verified that we're checking authz on the correct namespaces in multiple
cases. Also added new tests to confirm all of this automatically.