### PR TITLE
Better handle namespace cycles

### DIFF
--- a/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hierarchyconfigurations.yaml
+++ b/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hierarchyconfigurations.yaml
@@ -89,21 +89,35 @@ spec:
                       webhooks are working properly, there should typically not be
                       any conditions on any namespaces, although some may appear transiently
                       when the HNC controller is restarted. These should quickly resolve
-                      themselves (<30s). \n Currently, the supported values are: \n
-                      - \"CritParentMissing\": the specified parent is missing \n
-                      - \"CritParentInvalid\": the specified parent is invalid (e.g.,
-                      would cause a cycle) \n - \"CritAncestor\": a critical error
+                      themselves (<30s). However, validation webhooks are not perfect,
+                      especially if multiple users are modifying the same namespace
+                      trees quickly, so it's important to monitor for critical conditions
+                      and resolve them if they arise. See the user guide for more
+                      information. \n Currently, the supported values are: \n - \"CritParentMissing\":
+                      the specified parent is missing and the namespace is an orphan.
+                      \n - \"CritCycle\": the namespace is a member of a cycle. For
+                      example, if namespace B says that its parent is namespace A,
+                      but namespace A says that its parent is namespace B, then A
+                      and B are in a cycle with each other and both of them will have
+                      the CritCycle condition. \n - \"CritAncestor\": a critical error
                       exists in an ancestor namespace, so this namespace is no longer
                       being updated either. \n - \"SubnamespaceAnchorMissing\": this
                       namespace is a subnamespace, but the anchor referenced in its
                       `subnamespaceOf` annotation does not exist in the parent. \n
                       - \"CannotPropagateObject\": this namespace contains an object
-                      that couldn't be propagated to one or more of its descendants.
-                      The condition's affect objects will include a list of the copies
-                      that couldn't be updated. \n - \"CannotUpdateObject\": this
-                      namespace has an error when updating a propagated object from
-                      its source. The condition's affected object will point to the
-                      source object."
+                      that couldn't be propagated *out* of this namespace, to one
+                      or more of this namespace's descendants. If the object couldn't
+                      be propagated to *any* descendants - for example, because it
+                      has a finalizer on it (HNC can't propagate objects with finalizers),
+                      the `Affects` field will point to the object in this namespace.
+                      Otherwise, if it couldn't be propagated to *some* descendants,
+                      `Affects` will contain a list of the objects in those descendants
+                      that couldn't be created or updated. \n - \"CannotUpdateObject\":
+                      this namespace has an object that couldn't be propagated *into*
+                      this namespace - that is, it couldn't be created in the first
+                      place, or it couldn't be updated. The `Affects` field will point
+                      to the source object, which will always be in a namespace that's
+                      an ancestor of this namespace."
                     type: string
                   msg:
                     description: A human-readable description of the condition, if

--- a/incubator/hnc/pkg/foresttest/foresttest.go
+++ b/incubator/hnc/pkg/foresttest/foresttest.go
@@ -53,6 +53,9 @@ func Create(desc string) *forest.Forest {
 		if !pns.Exists() {
 			ns.SetLocalCondition(api.CritParentMissing, "no parent")
 		}
+		for _, cnm := range ns.CycleNames() {
+			f.Get(cnm).SetLocalCondition(api.CritCycle, "in cycle")
+		}
 	}
 
 	return f

--- a/incubator/hnc/pkg/kubectl/tree.go
+++ b/incubator/hnc/pkg/kubectl/tree.go
@@ -51,12 +51,16 @@ var treeCmd = &cobra.Command{
 		}
 		for _, nnm := range nsList {
 			hier := client.getHierarchy(nnm)
-			//If we're showing the default list, skip all non-root namespaces since they'll be displayed as part of another namespace's tree.
-			if defaultList && hier.Spec.Parent != "" {
+			// If we're showing the default list, skip all non-root namespaces since they'll be displayed
+			// as part of another namespace's tree. Get the text first though because that will reveal if
+			// the tree's in a cycle, in which case, even though the NS isn't a root, we'll display it
+			// anyway.
+			txt, cycle := nameAndFootnotes(hier)
+			if defaultList && (!cycle && hier.Spec.Parent != "") {
 				continue
 			}
-			fmt.Println(nameAndFootnotes(hier))
-			printSubtree("", hier)
+			fmt.Println(txt)
+			printSubtree("", hier, cycle)
 		}
 		if len(footnotes) > 0 {
 			fmt.Printf("\nConditions:\n")
@@ -68,25 +72,35 @@ var treeCmd = &cobra.Command{
 	},
 }
 
-func printSubtree(prefix string, hier *api.HierarchyConfiguration) {
+func printSubtree(prefix string, hier *api.HierarchyConfiguration, inCycle bool) {
 	for i, cn := range hier.Status.Children {
 		ch := client.getHierarchy(cn)
-		tx := nameAndFootnotes(ch)
+		txt, cycle := nameAndFootnotes(ch)
+		if cycle && inCycle {
+			continue
+		}
 		if i < len(hier.Status.Children)-1 {
-			fmt.Printf("%s├── %s\n", prefix, tx)
-			printSubtree(prefix+"│   ", ch)
+			fmt.Printf("%s├── %s\n", prefix, txt)
+			printSubtree(prefix+"│   ", ch, cycle)
 		} else {
-			fmt.Printf("%s└── %s\n", prefix, tx)
-			printSubtree(prefix+"    ", ch)
+			fmt.Printf("%s└── %s\n", prefix, txt)
+			printSubtree(prefix+"    ", ch, cycle)
 		}
 	}
 }
 
 // nameAndFootnotes returns the text to print to describe the namespace, in the form of the
-// namespace's name along with references to any footnotes. Example: default (1)
-func nameAndFootnotes(hier *api.HierarchyConfiguration) string {
+// namespace's name along with references to any footnotes. Example: default (1).
+//
+// The second param is true if this namespace is part of a cycle, in which case we shouldn't
+// recurse.
+func nameAndFootnotes(hier *api.HierarchyConfiguration) (string, bool) {
+	cycle := false
 	notes := []int{}
 	for _, cond := range hier.Status.Conditions {
+		if cond.Code == api.CritCycle {
+			cycle = true
+		}
 		txt := (string)(cond.Code) + ": " + cond.Msg
 		if idx, ok := footnotesByMsg[txt]; ok {
 			notes = append(notes, idx)
@@ -98,14 +112,14 @@ func nameAndFootnotes(hier *api.HierarchyConfiguration) string {
 	}
 
 	if len(notes) == 0 {
-		return hier.Namespace
+		return hier.Namespace, false
 	}
 	sort.Ints(notes)
 	ns := []string{}
 	for _, n := range notes {
 		ns = append(ns, strconv.Itoa(n))
 	}
-	return fmt.Sprintf("%s (%s)", hier.Namespace, strings.Join(ns, ","))
+	return fmt.Sprintf("%s (%s)", hier.Namespace, strings.Join(ns, ",")), cycle
 }
 
 func newTreeCmd() *cobra.Command {


### PR DESCRIPTION
If a user bypasses the admission controller, they can create namespace
ancestry cycles, but these have never been correctly represented
in-memory in HNC, and therefore were not correctly reported. For
example, only _one_ namespace in a cycle would have the
CritInvalidParent condition, as described in #666.

This commit includes several tightly-coupled changes to fix this:
* The Forest no longer prevents you from creating cycles. Instead,
Namespace.CycleNames() returns a non-nil list of a namespace is in a
cycle, and other methods like AncestryNames() and DescendantNames() are
now cycle-safe.
* The kubectl-hns plugin correctly handles cycles
* The HC reconciler ensures that other cycle members are enqueued when a
cycle is created or broken, and uses the new CritCycle condition on all
members of the cycle instead of the CritInvalidParent condition on only
a single member.

Tested: updated various unit tests. Also verified the following:
* With the admission controller disabled, I can create cycles. All
members of the cycle get the CritCycle condition annotated or removed as
appropriate.
* Descendants of namespaces in a cycle continue to get the CritAncestor
condition.
* With the admission controller *enabled*, I can resolve cycles. I
didn't test anything fancy with the authz checks as the recommended mode
to solve these problems is "I have admin so I can do anything," but the
new unit tests do verify that you need authz to break a cycle.

Fixes #666 