### PR TITLE
[VC]: Switch to distroless image

### DIFF
--- a/incubator/virtualcluster/hack/lib/docker-image.sh
+++ b/incubator/virtualcluster/hack/lib/docker-image.sh
@@ -59,7 +59,13 @@ create_docker_image() {
     IFS=$oldifs
 
     local binary_name="$1"
-    local base_image="$2"
+    local base_image=$2
+    local image_user=""
+    BASE_IMAGE=${BASE_IMAGE:-debian}
+    if [ "$BASE_IMAGE" == "distroless" ]; then
+      base_image="gcr.io/distroless/static:nonroot"
+      image_user="USER nonroot:nonroot"
+    fi
     local docker_build_path="${binary_dir}/${binary_name}.dockerbuild"
     local docker_file_path="${docker_build_path}/Dockerfile"
     local binary_file_path="${binary_dir}/${binary_name}"
@@ -73,6 +79,7 @@ create_docker_image() {
       cat <<EOF > "${docker_file_path}"
 FROM ${base_image}
 COPY ${binary_name} /usr/local/bin/${binary_name}
+${image_user}
 EOF
       "${DOCKER[@]}" build -q -t "${docker_image_tag}" "${docker_build_path}" >/dev/null
     ) &


### PR DESCRIPTION
This switches the container used to build the VC components to `distroless` to follow  https://github.com/kubernetes/enhancements/blob/8fd69422d913706c0badb30b78ac07698c9aaecd/keps/sig-release/1729-rebase-images-to-distroless/README.md KEP. This shaved about 30mb per container.

#### Before

<img width="793" alt="PNG image 2" src="https://user-images.githubusercontent.com/177822/82042597-03523480-965f-11ea-834b-b56e0c4e868a.png">

#### After

<img width="810" alt="PNG image" src="https://user-images.githubusercontent.com/177822/82042764-4d3b1a80-965f-11ea-8640-9fec500da793.png">

Signed-off-by: Chris Hein <me@chrishein.com>