### PR TITLE
Fix the namespace validating admission name

### DIFF
--- a/incubator/hnc/config/webhook/manifests.yaml
+++ b/incubator/hnc/config/webhook/manifests.yaml
@@ -68,7 +68,7 @@ webhooks:
       namespace: system
       path: /validate-v1-namespace
   failurePolicy: Fail
-  name: vnamespace.k8s.io
+  name: namespaces.hnc.x-k8s.io
   rules:
   - apiGroups:
     - ""

--- a/incubator/hnc/pkg/validators/namespace.go
+++ b/incubator/hnc/pkg/validators/namespace.go
@@ -23,7 +23,7 @@ const (
 // Note: the validating webhook FAILS CLOSE. This means that if the webhook goes down, all further
 // changes are forbidden.
 //
-// +kubebuilder:webhook:path=/validate-v1-namespace,mutating=false,failurePolicy=fail,groups="",resources=namespaces,verbs=delete,versions=v1,name=vnamespace.k8s.io
+// +kubebuilder:webhook:path=/validate-v1-namespace,mutating=false,failurePolicy=fail,groups="",resources=namespaces,verbs=delete,versions=v1,name=namespaces.hnc.x-k8s.io
 
 type Namespace struct {
 	Log     logr.Logger


### PR DESCRIPTION
This validator was previously called `vnamespace.k8s.io`, unlike all
other HNC validators which had names like
`hierarchyconfiguration.hnc.x-k8s.io`. When the validator rejected
changes, this ambiguous name made it hard to tell where the rejection
was coming from ("what's a vnamespace?" and "which controller is
that?"). The new name - `namespaces.hnc.x-k8s.io` - clearly identifies
the origin (HNC) and cause (namespaces) of the error.

Tested: deployed to my cluster, verified the errors make sense both with
and without the backing service running.

/assign @yiqigao217 