### PR TITLE
enable workqueue prometheus metrics

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
+++ b/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
@@ -117,7 +117,7 @@ func NewMCController(name string, objectType runtime.Object, options Options) (*
 	}
 
 	if c.Queue == nil {
-		c.Queue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+		c.Queue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), name)
 	}
 
 	return c, nil

--- a/incubator/virtualcluster/pkg/syncer/metrics/metrics.go
+++ b/incubator/virtualcluster/pkg/syncer/metrics/metrics.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	_ "k8s.io/kubernetes/pkg/util/workqueue/prometheus"
 )
 
 const (


### PR DESCRIPTION
Enable prometheus metrics for uws queue, mccontroller queue and syncer queue.
These metrics is helpful for location problem that sync slowly or create virtual cluster slowly.
