### PR TITLE
Simpler HNCConfig reconciler triggers

### DIFF
--- a/incubator/hnc/internal/forest/forest.go
+++ b/incubator/hnc/internal/forest/forest.go
@@ -30,10 +30,6 @@ type Forest struct {
 	// We can also move the lock out of the forest and pass it to all reconcilers that need the lock.
 	// In that way, we don't need to put the list in the forest.
 	types []TypeSyncer
-
-	// ObjectsStatusSyncer is the ConfigReconciler that an object reconciler can call if the status of the HNCConfiguration
-	// object needs to be updated.
-	ObjectsStatusSyncer NumObjectsSyncer
 }
 
 type namedNamespaces map[string]*Namespace
@@ -52,12 +48,6 @@ type TypeSyncer interface {
 	GetMode() api.SynchronizationMode
 	// GetNumPropagatedObjects returns the number of propagated objects on the apiserver.
 	GetNumPropagatedObjects() int
-}
-
-// NumObjectsSyncer syncs the number of propagated and source objects. ConfigReconciler implements the
-// interface so that it can be called by an ObjectReconciler if the number of propagated or source objects is changed.
-type NumObjectsSyncer interface {
-	SyncNumObjects(logr.Logger)
 }
 
 func NewForest() *Forest {

--- a/incubator/hnc/internal/reconcilers/hierarchy_config.go
+++ b/incubator/hnc/internal/reconcilers/hierarchy_config.go
@@ -66,6 +66,7 @@ type HierarchyConfigReconciler struct {
 	// simply hard to tell when one ends and another begins).
 	reconcileID int32
 
+	// sar is the Subnamespace Anchor Reconciler
 	sar *AnchorReconciler
 }
 

--- a/incubator/hnc/internal/reconcilers/setup.go
+++ b/incubator/hnc/internal/reconcilers/setup.go
@@ -27,7 +27,7 @@ func Create(mgr ctrl.Manager, f *forest.Forest, maxReconciles int) error {
 		return fmt.Errorf("cannot create anchor reconciler: %s", err.Error())
 	}
 
-	// Create the HierarchyConfigReconciler with HNSReconciler enabled.
+	// Create the HierarchyConfigReconciler with a pointer to the Anchor reconciler.
 	hcr := &HierarchyConfigReconciler{
 		Client:   mgr.GetClient(),
 		Log:      ctrl.Log.WithName("reconcilers").WithName("Hierarchy"),
@@ -40,7 +40,7 @@ func Create(mgr ctrl.Manager, f *forest.Forest, maxReconciles int) error {
 	}
 
 	// Create the ConfigReconciler.
-	cr := &ConfigReconciler{
+	hnccrSingleton = &ConfigReconciler{
 		Client:                 mgr.GetClient(),
 		Log:                    ctrl.Log.WithName("reconcilers").WithName("HNCConfiguration"),
 		Manager:                mgr,
@@ -48,7 +48,7 @@ func Create(mgr ctrl.Manager, f *forest.Forest, maxReconciles int) error {
 		Trigger:                make(chan event.GenericEvent),
 		HierarchyConfigUpdates: hcChan,
 	}
-	if err := cr.SetupWithManager(mgr); err != nil {
+	if err := hnccrSingleton.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("cannot create Config reconciler: %s", err.Error())
 	}
 


### PR DESCRIPTION
Rather than going through the forest, keep an in-memory singleton and
let anyone ask for the HNC Config to be re-reconciled (in preparation
for work on #736).

Tested: unit tests; verified that this worked properly with the fix to
issue #736.

/assign @sophieliu15 
/cc @yiqigao217 