### PR TITLE
Don't add empty AffectedObject entries

### DIFF
--- a/incubator/hnc/internal/forest/namespaceconditions.go
+++ b/incubator/hnc/internal/forest/namespaceconditions.go
@@ -159,7 +159,7 @@ func (ns *Namespace) Conditions() []api.Condition {
 	for cm, objs := range byCM {
 		// If the only affected object is unnamed (e.g., it refers to the current namespace), omit it.
 		c := api.Condition{Code: cm.code, Msg: cm.msg}
-		if len(objs) > 0 || objs[0].Name != "" {
+		if len(objs) > 0 && objs[0].Name != "" {
 			api.SortAffectedObjects(objs)
 			c.Affects = objs
 		}


### PR DESCRIPTION
Minor typo was ensuring that it looks like there were lists of affected
objects even though in reality, there were none other than the namespace
itself.

Tested: redeployed HNC and verified that the empty list disappeared both
in YAML and when viewed via `kubectl hns describe`.

Fixes #746 
/assign @yiqigao217 