### PR TITLE
[VC] Fix a nulltpr crash

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/resources/node/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/node/controller.go
@@ -61,7 +61,8 @@ func NewNodeController(config *config.SyncerConfiguration,
 	vcInformer vcinformers.VirtualClusterInformer,
 	options *manager.ResourceSyncerOptions) (manager.ResourceSyncer, *mc.MultiClusterController, *uw.UpwardController, error) {
 	c := &controller{
-		nodeClient: client.CoreV1(),
+		nodeNameToCluster: make(map[string]map[string]struct{}),
+		nodeClient:        client.CoreV1(),
 	}
 
 	var mcOptions *mc.Options


### PR DESCRIPTION
PR #745 introduces a bug such that the nodeNameToCluster map is mistakenly removed. This change fixes it.