### PR TITLE
Don't delete subnses with the Anchor CRD

### DIFF
--- a/incubator/hnc/hack/test-delete-anchor-crd.sh
+++ b/incubator/hnc/hack/test-delete-anchor-crd.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Fail on any error
+set -e
+
+echo "THIS TEST WILL DELETE CRITICAL PARTS OF HNC. DO NOT RUN UNLESS YOU KNOW WHAT YOU'RE DOING"
+echo "You have five seconds to turn back!"
+sleep 5
+
+echo "-------------------------------------------------------"
+echo "Creating parent and deletable child"
+
+kubectl create ns delete-crd-parent
+kubectl hns create delete-crd-child -n delete-crd-parent
+kubectl hns set delete-crd-child --allowCascadingDelete
+
+
+echo "-------------------------------------------------------"
+echo "Delete the CRD. HNC IS NOW IN A BAD STATE AND MUST BE REINSTALLED"
+
+kubectl delete customresourcedefinition.apiextensions.k8s.io/subnamespaceanchors.hnc.x-k8s.io
+
+
+echo "-------------------------------------------------------"
+echo "Verify that the namespace still exists"
+
+kubectl get ns delete-crd-child
+
+echo "Success!!!"

--- a/incubator/hnc/hack/test-issue-501.sh
+++ b/incubator/hnc/hack/test-issue-501.sh
@@ -40,8 +40,8 @@ kubectl hns tree parent
 
 echo "----------------------------------------------------"
 echo "${bold}Test-1:${normal} If the subnamespace doesn't allow cascadingDelete and the HNS is missing in the owner namespace, it should have 'HNS_MISSING' condition while its descendants shoudn't have any conditions."
-echo "${bold}Operation:${normal} delete 'sub1' hns in 'parent' - kubectl delete hns sub1 -n parent"
-kubectl delete hns sub1 -n parent
+echo "${bold}Operation:${normal} delete 'sub1' subns in 'parent' - kubectl delete subns sub1 -n parent"
+kubectl delete subns sub1 -n parent
 sleep 1
 echo "${bold}Expected:${normal} 'sub1' namespace is not deleted and should have 'HNS_MISSING' condition; no other conditions."
 echo "${bold}Result:${normal}"
@@ -49,7 +49,7 @@ kubectl hns tree parent
 
 echo "----------------------------------------------------"
 echo "${bold}Test-2:${normal} If the HNS is not missing, it should unset the 'HNS_MISSING' condition in the subnamespace."
-echo "${bold}Operation:${normal} recreate the 'sub1' hns in 'parent' - kubectl hns create sub1 -n parent"
+echo "${bold}Operation:${normal} recreate the 'sub1' subns in 'parent' - kubectl hns create sub1 -n parent"
 kubectl hns create sub1 -n parent
 sleep 1
 echo "${bold}Expected:${normal} no conditions."
@@ -60,8 +60,8 @@ echo "----------------------------------------------------"
 echo "${bold}Test-3:${normal} If the subnamespace allows cascadingDelete and the HNS is deleted, it should cascading delete all immediate subnamespaces."
 echo "${bold}Operation:${normal} 1) allow cascadingDelete in 'ochid1' - kubectl hns set sub1 --allowCascadingDelete=true"
 kubectl hns set sub1 --allowCascadingDelete=true
-echo "2) delete 'sub1' hns in 'parent' - kubectl delete hns sub1 -n parent"
-kubectl delete hns sub1 -n parent
+echo "2) delete 'sub1' subns in 'parent' - kubectl delete subns sub1 -n parent"
+kubectl delete subns sub1 -n parent
 echo "Waiting 3s for the namespaces to be deleted..."
 sleep 3
 echo "${bold}Expected:${normal} 'sub1', 'sub1-sub1', 'sub2-sub1' should all be gone"

--- a/incubator/hnc/internal/reconcilers/hnc_config.go
+++ b/incubator/hnc/internal/reconcilers/hnc_config.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -544,7 +544,7 @@ func (r *ConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(&api.HNCConfiguration{}).
 		Watches(&source.Channel{Source: r.Trigger}, &handler.EnqueueRequestForObject{}).
-		Watches(&source.Kind{Type: &v1beta1.CustomResourceDefinition{}},
+		Watches(&source.Kind{Type: &apiextensions.CustomResourceDefinition{}},
 			&handler.EnqueueRequestsFromMapFunc{ToRequests: crdMapFn}).
 		Complete(r)
 	if err != nil {

--- a/incubator/hnc/internal/reconcilers/hnc_config_test.go
+++ b/incubator/hnc/internal/reconcilers/hnc_config_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/rbac/v1"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha1"
@@ -508,19 +508,19 @@ func removeHNCConfigTypeWithMode(ctx context.Context, apiVersion, kind string, m
 }
 
 func createCronTabCRD(ctx context.Context) {
-	crontab := v1beta1.CustomResourceDefinition{
+	crontab := apiextensions.CustomResourceDefinition{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "CustomResourceDefinition",
 			APIVersion: "apiextensions.k8s.io/v1beta1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "crontabs.stable.example.com",
 		},
-		Spec: v1beta1.CustomResourceDefinitionSpec{
+		Spec: apiextensions.CustomResourceDefinitionSpec{
 			Group: "stable.example.com",
-			Versions: []v1beta1.CustomResourceDefinitionVersion{
+			Versions: []apiextensions.CustomResourceDefinitionVersion{
 				{Name: "v1", Served: true, Storage: true},
 			},
-			Names: v1beta1.CustomResourceDefinitionNames{
+			Names: apiextensions.CustomResourceDefinitionNames{
 				Singular: "crontab",
 				Plural:   "crontabs",
 				Kind:     "CronTab",


### PR DESCRIPTION
A reasonable admin action is to call `kubectl delete -f manifests.yaml`,
but this will delete the CRDs and hence the subnamespace anchors. If any
namespace have cascading deletion enabled, this will delete the
namespaces themselves, which is surprising and destructive. This change
disables cascading deletion if the Anchor CRD itself is being deleted,
as opposed to any one anchor CR.

Tested: Added hack/test-delete-anchor-crd.sh and confirmed that it fails
on HEAD and passes with this fix. Also verified that log messages looked
good. Tried deleting some subnamespaces with and without setting
allowCascadingDelete and everything worked properly. Also reran
test-issue-501.sh, which _mostly_ worked although it looks like the
webhooks now prevent us from getting a SubnamespaceAnchorMissing
condition (which is good).