### PR TITLE
Reconcile external namespaces and update tree labels

### DIFF
--- a/incubator/hnc/api/v1alpha1/hierarchy_types.go
+++ b/incubator/hnc/api/v1alpha1/hierarchy_types.go
@@ -34,6 +34,8 @@ const (
 	MetaGroup                  = "hnc.x-k8s.io"
 	LabelInheritedFrom         = MetaGroup + "/inheritedFrom"
 	FinalizerHasOwnedNamespace = MetaGroup + "/hasOwnedNamespace"
+	LabelTreeDepthSuffix       = ".tree." + MetaGroup + "/depth"
+	AnnotationManagedBy        = MetaGroup + "/managedBy"
 )
 
 // Condition codes. *All* codes must also be documented in the comment to Condition.Code, be

--- a/incubator/hnc/internal/forest/namespace.go
+++ b/incubator/hnc/internal/forest/namespace.go
@@ -41,6 +41,12 @@ type Namespace struct {
 
 	// Anchors store a list of anchors in the namespace.
 	Anchors []string
+
+	// ExternalTreeLabels stores external tree labels if this namespace is an external namespace.
+	// It will be empty if the namespace is not external. External namespace will at least have one
+	// tree label of itself. The key is the tree label without ".tree.hnc.x-k8s.io/depth" suffix.
+	// The value is the depth.
+	ExternalTreeLabels map[string]int
 }
 
 // Name returns the name of the namespace, of "<none>" if the namespace is nil.
@@ -135,4 +141,9 @@ func (ns *Namespace) SetAnchors(anchors []string) (diff []string) {
 
 	ns.Anchors = anchors
 	return
+}
+
+// IsExternal returns true if the namespace is not managed by HNC.
+func (ns *Namespace) IsExternal() bool {
+	return len(ns.ExternalTreeLabels) > 0
 }

--- a/incubator/hnc/internal/reconcilers/test_helpers_test.go
+++ b/incubator/hnc/internal/reconcilers/test_helpers_test.go
@@ -104,6 +104,20 @@ func createNSWithLabel(ctx context.Context, prefix string, label map[string]stri
 	return nm
 }
 
+// createNSWithLabelAnnotation has similar function to createNS with label and annotation
+// as additional parameters.
+func createNSWithLabelAnnotation(ctx context.Context, prefix string, l map[string]string, a map[string]string) string {
+	nm := createNSName(prefix)
+
+	// Create the namespace
+	ns := &corev1.Namespace{}
+	ns.SetLabels(l)
+	ns.SetAnnotations(a)
+	ns.Name = nm
+	Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+	return nm
+}
+
 func updateHNCConfig(ctx context.Context, c *api.HNCConfiguration) error {
 	if c.CreationTimestamp.IsZero() {
 		return k8sClient.Create(ctx, c)


### PR DESCRIPTION
Part of #763 

Add `forest.Namespace.ExternalTreeLabels` field to store external
hierarchy in memory. Add `syncExternalNamespace()` func in
`HierarchyConfigReconciler` to update the external tree labels in the
forest. Enqueue descedants if the namespace is converted from external
to internal or vice versa so that the external tree labels can be
removed or propagated to the descendant namespaces.

Skip `syncSubnamespaceParent()`, `syncParent()`, `syncLabel()` for external
namespaces. In `syncLabel()`, for an internal namespace, if the root
ancestor is an external namespace, propagate all the external tree
labels too.

Tested by "make test" with three new integration test cases.