### PR TITLE
Allow recreation of missing subns anchors

### DIFF
--- a/incubator/hnc/internal/validators/anchor.go
+++ b/incubator/hnc/internal/validators/anchor.go
@@ -79,6 +79,11 @@ func (v *Anchor) handle(req *anchorRequest) admission.Response {
 		}
 
 		if cns.Exists() {
+			// Forbid this, unless it's to allow an anchor to be created for an existing subnamespace
+			// that's just missing its anchor.
+			if cns.Parent().Name() == pnm && cns.IsSub {
+				return allow("")
+			}
 			msg := fmt.Sprintf("The requested namespace %s already exists. Please use a different name.", cnm)
 			return deny(metav1.StatusReasonConflict, msg)
 		}

--- a/incubator/hnc/internal/validators/anchor_test.go
+++ b/incubator/hnc/internal/validators/anchor_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func TestSubnamespaces(t *testing.T) {
-	// Two roots `a` and `b`, with `c` a subnamespace of `a`
-	f := foresttest.Create("--A")
+	// Two roots `a` and `b`, with `c` a subnamespace of `a`, and `d` a regular child of `b`
+	f := foresttest.Create("--Ab")
 	h := &Anchor{Forest: f}
 	f.Get("c").UpdateAllowCascadingDelete(true)
 
@@ -27,6 +27,8 @@ func TestSubnamespaces(t *testing.T) {
 		{name: "ok-delete", op: v1beta1.Delete, pnm: "a", cnm: "c"},
 		{name: "create anchor in excluded ns", op: v1beta1.Create, pnm: "kube-system", cnm: "brumpf", fail: true},
 		{name: "create anchor with existing ns name", op: v1beta1.Create, pnm: "a", cnm: "b", fail: true},
+		{name: "create anchor for existing non-subns child", op: v1beta1.Create, pnm: "b", cnm: "d", fail: true},
+		{name: "create anchor for existing subns", op: v1beta1.Create, pnm: "a", cnm: "c"},
 		{name: "delete anchor when allowCascadingDelete is false", op: v1beta1.Delete, pnm: "a", cnm: "b", fail: true},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
Without this change, if a subnamespace is missing its anchor, the
condition can never be resolved. This change allows an admin to fix the
problem without disabling the validating webhook.

Tested: new unit test; verified by hand that I can recreate missing
anchors but only with the correct parent.

/assign @yiqigao217 