### PR TITLE
Update admission controllers for external hierarchy

### DIFF
--- a/incubator/hnc/config/webhook/manifests.yaml
+++ b/incubator/hnc/config/webhook/manifests.yaml
@@ -76,6 +76,8 @@ webhooks:
     - v1
     operations:
     - DELETE
+    - CREATE
+    - UPDATE
     resources:
     - namespaces
 - clientConfig:

--- a/incubator/hnc/internal/forest/namespace.go
+++ b/incubator/hnc/internal/forest/namespace.go
@@ -42,6 +42,10 @@ type Namespace struct {
 	// Anchors store a list of anchors in the namespace.
 	Anchors []string
 
+	// Manager stores the manager of the namespace. The default value
+	// "hnc.x-k8s.io" means it's managed by HNC.
+	Manager string
+
 	// ExternalTreeLabels stores external tree labels if this namespace is an external namespace.
 	// It will be empty if the namespace is not external. External namespace will at least have one
 	// tree label of itself. The key is the tree label without ".tree.hnc.x-k8s.io/depth" suffix.

--- a/incubator/hnc/internal/reconcilers/hierarchy_config.go
+++ b/incubator/hnc/internal/reconcilers/hierarchy_config.go
@@ -220,13 +220,14 @@ func (r *HierarchyConfigReconciler) syncWithForest(log logr.Logger, nsInst *core
 // syncExternalNamespace sets external tree labels to the namespace in the forest
 // if the namespace is an external namespace not managed by HNC.
 func (r *HierarchyConfigReconciler) syncExternalNamespace(log logr.Logger, nsInst *corev1.Namespace, ns *forest.Namespace) {
-	manager := nsInst.Annotations[api.AnnotationManagedBy]
-	if manager == "" || manager == api.MetaGroup {
+	ns.Manager = nsInst.Annotations[api.AnnotationManagedBy]
+	if ns.Manager == "" || ns.Manager == api.MetaGroup {
 		// If the internal namespace is just converted from an external namespace,
 		// enqueue the descendants to remove the propagated external tree labels.
 		if ns.IsExternal() {
 			r.enqueueAffected(log, "subtree root converts from external to internal", ns.DescendantNames()...)
 		}
+		ns.Manager = api.MetaGroup
 		ns.ExternalTreeLabels = nil
 		return
 	}

--- a/incubator/hnc/internal/validators/hierarchy.go
+++ b/incubator/hnc/internal/validators/hierarchy.go
@@ -176,6 +176,11 @@ func (v *Hierarchy) checkNS(ns *forest.Namespace) admission.Response {
 
 // checkParent validates if the parent is legal based on the current in-memory state of the forest.
 func (v *Hierarchy) checkParent(ns, curParent, newParent *forest.Namespace) admission.Response {
+	if ns.IsExternal() && newParent != nil {
+		msg := fmt.Sprintf("Namespace %q is managed by %q, not HNC, so it cannot have a parent in HNC.", ns.Name(), ns.Manager)
+		return deny(metav1.StatusReasonForbidden, msg)
+	}
+
 	if curParent == newParent {
 		return allow("parent unchanged")
 	}


### PR DESCRIPTION
Part of #763 

Add additional restrictions in admission controllers to deny:
1. Create namespace with existing name in external hierarchy;
2. Update namespace to add "managedBy: other" annotation on namespace
with parent;
3. Make any changes to HierarchyConfiguration in external namespace.

Tested manually on a GKE cluster and by "make test" with new test cases.