### PR TITLE
Disable leader election

### DIFF
--- a/incubator/hnc/config/default/manager_auth_proxy_patch.yaml
+++ b/incubator/hnc/config/default/manager_auth_proxy_patch.yaml
@@ -30,8 +30,6 @@ spec:
         args:
         - "--webhook-server-port=9443"
         - "--metrics-addr=127.0.0.1:8080"
-        - "--enable-leader-election"
-        - "--leader-election-id=hnc-controller-leader-election-helper"
         - "--max-reconciles=10"
         - "--apiserver-qps-throttle=50"
         - "--enable-internal-cert-management=true"

--- a/incubator/hnc/config/manager/manager.yaml
+++ b/incubator/hnc/config/manager/manager.yaml
@@ -25,8 +25,7 @@ spec:
       containers:
       - command:
         - /manager
-        args: # overridden if manager_auth_proxy_patch.yaml is used
-        - --enable-leader-election
+        args: {} # overridden if manager_auth_proxy_patch.yaml is used
         image: controller:latest
         name: manager
         resources:


### PR DESCRIPTION
We only have one pod in our deployment, so leader election does nothing
but add about 10s of delay when HNC starts up. Let's get rid of it for
now.

Tested: measured ~11s of startup delay with and without leader election.
I've been running without it for a few days and everything seems to work
fine.