### PR TITLE
Removes CannotUpdate when source object deleted

### DIFF
--- a/incubator/hnc/api/v1alpha1/hierarchy_types.go
+++ b/incubator/hnc/api/v1alpha1/hierarchy_types.go
@@ -193,6 +193,15 @@ type Condition struct {
 	Affects []AffectedObject `json:"affects,omitempty"`
 }
 
+func (c Condition) String() string {
+	affects := fmt.Sprint(c.Affects)
+	msg := c.Msg
+	if len(msg) > 100 {
+		msg = msg[:100] + "..."
+	}
+	return fmt.Sprintf("%s: %s (affects %s)", c.Code, msg, affects)
+}
+
 // AffectedObject defines uniquely identifiable objects.
 type AffectedObject struct {
 	Group     string `json:"group,omitempty"`
@@ -230,8 +239,8 @@ func (a AffectedObject) String() string {
 	}
 
 	// No namespace -> it *is* a namespace
-	if a.Namespace != "" {
-		return a.Namespace
+	if a.Namespace == "" {
+		return a.Name
 	}
 
 	// Generic object (note that Group may be empty for core objects, don't worry about it)

--- a/incubator/hnc/hack/test-issue-771.sh
+++ b/incubator/hnc/hack/test-issue-771.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+echo "-------------------------------------------------------------"
+echo "Setting up simple tree a -> b"
+
+p="issue-771-a"
+c="issue-771-b"
+kubectl create ns $p
+kubectl create ns $c
+sleep 1
+kubectl hns set $c --parent $p
+kubectl hns tree $p
+
+
+echo "-------------------------------------------------------------"
+echo "Creating unpropagatable object; both namespaces should have a condition"
+
+kubectl create rolebinding --clusterrole=cluster-admin --serviceaccount=default:default -n $p foo
+sleep 1
+kubectl hns tree $p
+
+echo "-------------------------------------------------------------"
+echo "Deleting unpropagatable object; all conditions should be cleared"
+
+kubectl delete rolebinding -n $p foo
+sleep 1
+kubectl hns tree $p
+
+echo "-------------------------------------------------------------"
+echo "Cleaning up"
+kubectl delete ns $c $p


### PR DESCRIPTION
See issue #771. The CannotUpdate condition wasn't being cleared, since
conditions are indexed on the source object, but if the source object is
deleted and the propagated object (and its inheritedFrom label) was
never saved to the apiserver, we have no way to look up the condition by
the source object. This change simply looks through *all* conditions on
the same namespace as the missing object and removes the appropriate
ones; see the comments for more details.

This change also improves the logging for objects so that every action
(create, update or delete) is logged, as are the reasons for enqueuing
other objects or HCs for reconciliation. This should make postmortems
easier.

Tested: new testing script (hack/test-issue-771.sh) fails without this
fix and passes with it. Existing test scripts all pass as expected.

Fixed #771 