### PR TITLE
Don't unpropagate objects after CRDs are deleted

### DIFF
--- a/incubator/hnc/hack/test-delete-hc-crd.sh
+++ b/incubator/hnc/hack/test-delete-hc-crd.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Fail on any error
+set -e
+
+echo "THIS TEST WILL DELETE CRITICAL PARTS OF HNC. DO NOT RUN UNLESS YOU KNOW WHAT YOU'RE DOING"
+echo "You have five seconds to turn back!"
+sleep 5
+
+echo "-------------------------------------------------------"
+echo "Creating parent and child"
+
+kubectl create ns delete-hc-crd-parent
+kubectl create ns delete-hc-crd-child
+kubectl hns set delete-hc-crd-child --parent delete-hc-crd-parent
+
+echo "-------------------------------------------------------"
+echo "Create a rolebinding in parent and validate that it propagates to the child"
+
+kubectl create rolebinding --clusterrole=view --serviceaccount=default:default -n delete-hc-crd-parent foo
+sleep 1
+
+echo "-------------------------------------------------------"
+echo "The rolebinding should now appear in the child:"
+
+kubectl get -oyaml rolebinding foo -n delete-hc-crd-child
+
+echo "-------------------------------------------------------"
+echo "Delete the CRD. HNC IS NOW IN A BAD STATE AND MUST BE REINSTALLED"
+
+kubectl delete customresourcedefinition.apiextensions.k8s.io/hierarchyconfigurations.hnc.x-k8s.io
+
+echo "-------------------------------------------------------"
+echo "Sleeping for 5s to give HNC the chance to delete the RB (but it shouldn't)"
+
+sleep 5
+
+echo "-------------------------------------------------------"
+echo "Verify that the rolebinding still exists"
+
+kubectl get -oyaml rolebinding foo -n delete-hc-crd-child
+
+echo "Success!!!"


### PR DESCRIPTION
This change ensures that if the HierarchyConfig CRD is deleted before
the HNC pod, it will not delete the propagated objects. This reduces the
surprises when uninstalling HNC.

Tested: verified by hand that I can still delete the HC and this has the
effect of resetting the parent, and that cascading deletion still works.
Wrote a new test that verifies that the objects are not deleted after
five seconds, and verified that this test fails on HEAD but passes with
this patch.