### PR TITLE
Let HNC propagate builtin admin rolebindings

### DIFF
--- a/incubator/hnc/config/rbac/role.yaml
+++ b/incubator/hnc/config/rbac/role.yaml
@@ -13,7 +13,9 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
+  - impersonate
   - list
   - patch
   - update

--- a/incubator/hnc/hack/test-issue-772.sh
+++ b/incubator/hnc/hack/test-issue-772.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+echo "-------------------------------------------------------------"
+echo "Setting up simple tree a -> b"
+
+p="issue-772-a"
+c="issue-772-b"
+kubectl create ns $p
+kubectl create ns $c
+sleep 1
+kubectl hns set $c --parent $p
+kubectl hns tree $p
+
+
+echo "-------------------------------------------------------------"
+echo "Creating admin rolebinding object and waiting 2s"
+
+kubectl create rolebinding --clusterrole=admin --serviceaccount=default:default -n $p foo
+sleep 2
+
+
+echo "-------------------------------------------------------------"
+echo "Object should exist in the child, and there should be no conditions"
+
+kubectl get rolebinding foo -n $c -oyaml
+kubectl hns tree $p
+
+echo "-------------------------------------------------------------"
+echo "Cleaning up"
+kubectl delete ns $c $p

--- a/incubator/hnc/internal/reconcilers/object.go
+++ b/incubator/hnc/internal/reconcilers/object.go
@@ -89,7 +89,11 @@ type ObjectReconciler struct {
 	propagatedObjects namespacedNameSet
 }
 
-// +kubebuilder:rbac:groups=*,resources=*,verbs=get;list;watch;create;update;patch;delete
+// HNC doesn't actually need all these permissions, but we *do* need to have them to be able to
+// propagate RoleBindings for them. These match the permissions required by the builtin `admin`
+// role, as seen in hack/test-issue-772.sh.
+//
+// +kubebuilder:rbac:groups=*,resources=*,verbs=get;list;watch;create;update;patch;delete;deletecollection;impersonate
 
 // SyncNamespace can be called manually by the HierarchyConfigReconciler when the hierarchy changes.
 // It enqueues all the current objects in the namespace and local copies of the original objects


### PR DESCRIPTION
I _think_ HNC used to be able to propagate the `admin` role, but there
were several permission (deletecollection, impersonate) that don't
appear to be working in 1.15. I've now added these permissions to the
HNC service account so it can grant them.

Tested: new hack/test-issue-772.sh verifies that HNC can propagate the
`admin` builtin; it fails without this change and passes with it. The
existing hack/test-issue-771.sh, which uses `cluster-admin`, continues
to be unpropagateable as expected.

Fixes #772 

/assign @yiqigao217 