### PR TITLE
Allow cascadingDelete if any ancestor allows

### DIFF
--- a/incubator/hnc/internal/forest/namespace.go
+++ b/incubator/hnc/internal/forest/namespace.go
@@ -104,22 +104,17 @@ func (ns *Namespace) UpdateAllowCascadingDelete(acd bool) {
 	ns.allowCascadingDelete = acd
 }
 
-// AllowsCascadingDelete returns if the namespace's or any of the owner ancestors'
+// AllowsCascadingDelete returns true if the namespace's or any of the ancestors'
 // allowCascadingDelete field is set to true.
 func (ns *Namespace) AllowsCascadingDelete() bool {
 	if ns.allowCascadingDelete == true {
 		return true
 	}
-	if !ns.IsSub {
+	if ns.parent == nil || ns.CycleNames() != nil {
 		return false
 	}
 
-	// This is a subnamespace so it must have a non-nil parent. If the parent is missing, it will
-	// return the default false.
-	//
-	// Subnamespaces can never be involved in cycles, since those can only occur at the "top" of a
-	// tree and subnamespaces cannot be roots by definition. So this line can't cause a stack
-	// overflow.
+	// This namespace is neither a root nor in a cycle, so this line can't cause a stack overflow.
 	return ns.parent.AllowsCascadingDelete()
 }
 

--- a/incubator/hnc/internal/validators/anchor_test.go
+++ b/incubator/hnc/internal/validators/anchor_test.go
@@ -11,8 +11,9 @@ import (
 )
 
 func TestSubnamespaces(t *testing.T) {
-	// Two roots `a` and `b`, with `c` a subnamespace of `a`, and `d` a regular child of `b`
-	f := foresttest.Create("--Ab")
+	// Two roots `a` and `b`, with `c` a subnamespace of `a`, `e` a regular child of `c`,
+	// `f` a subnamespace of `e` and `d` a regular child of `b`
+	f := foresttest.Create("--AbcE")
 	h := &Anchor{Forest: f}
 	f.Get("c").UpdateAllowCascadingDelete(true)
 
@@ -25,6 +26,7 @@ func TestSubnamespaces(t *testing.T) {
 	}{
 		{name: "ok-create", op: v1beta1.Create, pnm: "a", cnm: "brumpf"},
 		{name: "ok-delete", op: v1beta1.Delete, pnm: "a", cnm: "c"},
+		{name: "ok-delete with allowCascadingDelete set in ancestor", op: v1beta1.Delete, pnm: "e", cnm: "f"},
 		{name: "create anchor in excluded ns", op: v1beta1.Create, pnm: "kube-system", cnm: "brumpf", fail: true},
 		{name: "create anchor with existing ns name", op: v1beta1.Create, pnm: "a", cnm: "b", fail: true},
 		{name: "create anchor for existing non-subns child", op: v1beta1.Create, pnm: "b", cnm: "d", fail: true},


### PR DESCRIPTION
Update the AllowsCascadingDelete() function in the forest to allow it if
any ancestor allows instead of looking up until the first full
namespace.

Tested by a new test case in anchor validator. It failed before the
change in the forest and passed afterwards.

Fixes #730 