### PR TITLE
Make leaf subnamespace deletion easier

### DIFF
--- a/incubator/hnc/hack/test-issue-716-full.sh
+++ b/incubator/hnc/hack/test-issue-716-full.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+# Set up namespace structure
+echo "----------------------------------------------------"
+echo "${bold}Setting up a 2-level tree with 'a' as the root and 'b' as a child of 'a'${normal}"
+echo "Creating the root 'a'"
+kubectl create ns a
+sleep 1
+echo "Creating the child namespace 'b' for 'a'"
+kubectl create ns b
+kubectl hns set b --parent a
+
+echo "${bold}Here's the outcome of the tree hierarhy:${normal}"
+kubectl hns tree a
+
+echo "----------------------------------------------------"
+echo "${bold}Test-1:${normal} Remove parent namespace 'a'."
+echo "${bold}Operation:${normal} delete 'a' - kubectl delete ns a"
+kubectl delete ns a
+echo "${bold}Expected:${normal} Delete successfully."
+echo "${bold}Result:${normal} b should have 'CritParentMissing' condition:"
+kubectl hns tree b
+
+echo "----------------------------------------------------"
+echo "${bold}Test-2:${normal} Remove the orphan 'b'."
+echo "${bold}Operation:${normal} delete 'b' - kubectl delete ns b"
+kubectl delete ns b
+echo "${bold}Expected:${normal} Delete successfully."
+
+echo "----------------------------------------------------"
+echo "${bold}Cleaning up${normal}"
+kubectl delete ns a
+kubectl delete ns b

--- a/incubator/hnc/hack/test-issue-716-leafsub.sh
+++ b/incubator/hnc/hack/test-issue-716-leafsub.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+# Set up namespace structure
+echo "----------------------------------------------------"
+echo "${bold}Setting up a 2-level tree with 'a' as the root and 'b' as a subnamespace of 'a'${normal}"
+echo "Creating the root 'a'"
+kubectl create ns a
+sleep 1
+
+echo "${bold}----Creating a subnamespace 'b'${normal}"
+echo "Creating subnamespace 'b' for 'a'"
+kubectl hns create b -n a
+
+echo "${bold}Here's the outcome of the tree hierarhy:${normal}"
+kubectl hns tree a
+
+echo "----------------------------------------------------"
+echo "${bold}Test-1:${normal} Remove parent namespace 'a' with 'allowCascadingDelete' unset."
+echo "${bold}Operation:${normal} delete 'a' - kubectl delete ns a"
+kubectl delete ns a
+echo "${bold}Expected:${normal} Forbidden because 'allowCacadingDelete' is not set"
+
+echo "----------------------------------------------------"
+echo "${bold}Test-2:${normal} Remove leaf subnamespace without setting 'allowCascadingDelete'."
+echo "${bold}Operation:${normal} delete 'b' subnamespace in 'a' - kubectl delete subns b -n a"
+kubectl delete subns b -n a
+echo "${bold}Expected:${normal} Delete successfully"
+echo "${bold}Current hierarhy:${normal} kubectl hns tree a"
+kubectl hns tree a
+
+echo "----------------------------------------------------"
+echo "${bold}Cleaning up${normal}"
+kubectl delete ns a
+kubectl delete ns b

--- a/incubator/hnc/hack/test-issue-716-nonleafsub.sh
+++ b/incubator/hnc/hack/test-issue-716-nonleafsub.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+# Set up namespace structure
+echo "----------------------------------------------------"
+echo "${bold}Setting up a tree with 'a' as the root, 'b' subnamesapce of 'a' and 'c' subnamespace of 'b'${normal}"
+echo "Creating the root 'a'"
+kubectl create ns a
+sleep 1
+
+echo "${bold}----Creating subnamespaces 'b' and 'c'${normal}"
+echo "Creating subnamespace 'b' for 'a'"
+kubectl hns create b -n a
+sleep 1
+echo "Creating subnamespace 'c' for 'b'"
+kubectl hns create c -n b
+
+echo "${bold}Here's the outcome of the tree hierarhy:${normal}"
+kubectl hns tree a
+
+echo "----------------------------------------------------"
+echo "${bold}Test-1:${normal} Remove non-leaf subnamespace with 'allowCascadingDelete' unset."
+echo "${bold}Operation:${normal} delete 'b' subns in 'a' - kubectl delete subns b -n a"
+kubectl delete subns b -n a
+echo "${bold}Expected:${normal} Forbidden because 'allowCascadingDelete'flag is not set"
+
+echo "----------------------------------------------------"
+echo "${bold}Test-2:${normal} Remove leaf subnamespaces with 'allowCascadingDelete' unset."
+echo "${bold}Operation:${normal} delete 'c' subns in 'b' - kubectl delete subns c -n b"
+kubectl delete subns c -n b
+echo "${bold}Expected:${normal} Delete successfully"
+echo "${bold}Operation:${normal} delete 'b' subns in 'a' - kubectl delete subns b -n a"
+kubectl delete subns b -n a
+echo "${bold}Expected:${normal} Delete successfully"
+
+echo "----------------------------------------------------"
+echo "${bold}Cleaning up${normal}"
+kubectl delete ns c
+kubectl delete ns b
+kubectl delete ns a

--- a/incubator/hnc/internal/forest/namespacestructure.go
+++ b/incubator/hnc/internal/forest/namespacestructure.go
@@ -178,3 +178,18 @@ func (ns *Namespace) populateDescendants(d map[string]bool) {
 		cns.populateDescendants(d)
 	}
 }
+
+// FullDescendantNames returns a sorted list of descendant namespaces that are full namespaces.
+func (ns *Namespace) FullDescendantNames() []string {
+	fd := []string{}
+	for _, dnm := range ns.DescendantNames() {
+		if !ns.forest.Get(dnm).IsSub {
+			fd = append(fd, dnm)
+		}
+	}
+	if len(fd) == 0 {
+		return nil
+	}
+	sort.Strings(fd)
+	return fd
+}

--- a/incubator/hnc/internal/validators/anchor.go
+++ b/incubator/hnc/internal/validators/anchor.go
@@ -90,8 +90,8 @@ func (v *Anchor) handle(req *anchorRequest) admission.Response {
 	}
 
 	if req.op == v1beta1.Delete {
-		if cns.Exists() && !cns.AllowsCascadingDelete() {
-			msg := fmt.Sprintf("The subnamespace %s doesn't allow cascading deletion. Please set allowCascadingDelete flag first.", cnm)
+		if cns.Exists() && cns.ChildNames() != nil && !cns.AllowsCascadingDelete() {
+			msg := fmt.Sprintf("The subnamespace %s is not a leaf and doesn't allow cascading deletion. Please set allowCascadingDelete flag or make it a leaf first.", cnm)
 			return deny(metav1.StatusReasonForbidden, msg)
 		}
 	}

--- a/incubator/hnc/internal/validators/anchor_test.go
+++ b/incubator/hnc/internal/validators/anchor_test.go
@@ -5,33 +5,27 @@ import (
 
 	. "github.com/onsi/gomega"
 	"k8s.io/api/admission/v1beta1"
-
 	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha1"
 	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/foresttest"
 )
 
-func TestSubnamespaces(t *testing.T) {
-	// Two roots `a` and `b`, with `c` a subnamespace of `a`, `e` a regular child of `c`,
-	// `f` a subnamespace of `e` and `d` a regular child of `b`
-	f := foresttest.Create("--AbcE")
+func TestCreateSubnamespaces(t *testing.T) {
+	// Creat namespace "a" as the root with one subnamespace "b" and one full child
+	// namespace "c".
+	f := foresttest.Create("-Aa")
 	h := &Anchor{Forest: f}
-	f.Get("c").UpdateAllowCascadingDelete(true)
 
 	tests := []struct {
 		name string
-		op   v1beta1.Operation
 		pnm  string
 		cnm  string
 		fail bool
 	}{
-		{name: "ok-create", op: v1beta1.Create, pnm: "a", cnm: "brumpf"},
-		{name: "ok-delete", op: v1beta1.Delete, pnm: "a", cnm: "c"},
-		{name: "ok-delete with allowCascadingDelete set in ancestor", op: v1beta1.Delete, pnm: "e", cnm: "f"},
-		{name: "create anchor in excluded ns", op: v1beta1.Create, pnm: "kube-system", cnm: "brumpf", fail: true},
-		{name: "create anchor with existing ns name", op: v1beta1.Create, pnm: "a", cnm: "b", fail: true},
-		{name: "create anchor for existing non-subns child", op: v1beta1.Create, pnm: "b", cnm: "d", fail: true},
-		{name: "create anchor for existing subns", op: v1beta1.Create, pnm: "a", cnm: "c"},
-		{name: "delete anchor when allowCascadingDelete is false", op: v1beta1.Delete, pnm: "a", cnm: "b", fail: true},
+		{name: "with a non-existing name", pnm: "a", cnm: "brumpf"},
+		{name: "in excluded ns", pnm: "kube-system", cnm: "brumpf", fail: true},
+		{name: "with an existing ns name (the ns is not a subnamespace of it)", pnm: "c", cnm: "b", fail: true},
+		{name: "for existing non-subns child", pnm: "a", cnm: "c", fail: true},
+		{name: "for existing subns", pnm: "a", cnm: "b"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -42,7 +36,55 @@ func TestSubnamespaces(t *testing.T) {
 			anchor.ObjectMeta.Name = tc.cnm
 			req := &anchorRequest{
 				anchor: anchor,
-				op:     tc.op,
+				op:     v1beta1.Create,
+			}
+
+			// Test
+			got := h.handle(req)
+
+			// Report
+			logResult(t, got.AdmissionResponse.Result)
+			g.Expect(got.AdmissionResponse.Allowed).ShouldNot(Equal(tc.fail))
+		})
+	}
+}
+
+func TestAllowCascadingDeleteSubnamespaces(t *testing.T) {
+	// Create a chain of namespaces from "a" to "e", with "a" as the root. Among them,
+	// "b", "d" and "e" are subnamespaces. This is set up in a long chain to test that
+	// subnamespaces will look all the way up to get the 'allowCascadingDelete` value
+	// and won't stop looking when the first full namespace ancestor is met.
+	f := foresttest.Create("-AbCD")
+	h := &Anchor{Forest: f}
+
+	tests := []struct {
+		name string
+		acd  string
+		pnm  string
+		cnm  string
+		fail bool
+	}{
+		{name: "set in parent", acd: "c", pnm: "c", cnm: "d"},
+		{name: "set in non-leaf", acd: "d", pnm: "c", cnm: "d"},
+		{name: "set in ancestor that is not the first full namespace", acd: "a", pnm: "c", cnm: "d"},
+		{name: "unset in leaf", pnm: "d", cnm: "e"},
+		{name: "unset in non-leaf", pnm: "c", cnm: "d", fail: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.acd != "" {
+				f.Get(tc.acd).UpdateAllowCascadingDelete(true)
+				defer f.Get(tc.acd).UpdateAllowCascadingDelete(false)
+			}
+
+			// Setup
+			g := NewGomegaWithT(t)
+			anchor := &api.SubnamespaceAnchor{}
+			anchor.ObjectMeta.Namespace = tc.pnm
+			anchor.ObjectMeta.Name = tc.cnm
+			req := &anchorRequest{
+				anchor: anchor,
+				op:     v1beta1.Delete,
 			}
 
 			// Test


### PR DESCRIPTION
Update anchor reconciler and webhook to allow deleting leaf subnamespace
even when allowCascadingDelete is not set.

Tested by three test-issue-716.sh files and new test cases in anchor
validator that the test only passed after the change.

Fixes #716