### PR TITLE
Setup e2e tests and add sample test cases

### DIFF
--- a/incubator/hnc/Makefile
+++ b/incubator/hnc/Makefile
@@ -176,6 +176,16 @@ kind-reset: kind-reboot
 kind-deploy:
 	CONFIG=kind $(MAKE) deploy
 
+###################### E2E TEST #########################
+
+.PHONY: e2e-test
+e2e-test: deploy
+	go test ./e2e/...
+
+.PHONY: local-e2e-test
+local-e2e-test: kind-deploy
+	go test ./e2e/...
+
 ###################### RELEASE ACTIONS #########################
 # Build the container image by Cloud Build and build YAMLs locally
 #

--- a/incubator/hnc/e2e/tests/e2e_test.go
+++ b/incubator/hnc/e2e/tests/e2e_test.go
@@ -1,0 +1,21 @@
+package test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+)
+
+const namspacePrefix = "e2e-test-"
+
+func TestE2e(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	SetDefaultEventuallyTimeout(time.Second * 2)
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"HNC Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}

--- a/incubator/hnc/e2e/tests/namespace_test.go
+++ b/incubator/hnc/e2e/tests/namespace_test.go
@@ -1,0 +1,66 @@
+package test
+
+import (
+	"os/exec"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Namespace", func() {
+	var (
+		prefix string
+	)
+
+	BeforeEach(func() {
+		prefix = namspacePrefix+"namespace-"
+	})
+
+	It("should create and delete a namespace", func() {
+		// Create a namespace "a"
+		cmd := exec.Command("kubectl", "create", "ns", prefix+"a")
+		Expect(cmd.Run()).Should(BeNil())
+
+		// The namespace "a" should exist.
+		cmd = exec.Command("kubectl", "get", "ns", prefix+"a")
+		Expect(cmd.Run()).Should(BeNil())
+
+		// Delete the created namespace "a"
+		cmd = exec.Command("kubectl", "delete", "ns", prefix+"a")
+		Expect(cmd.Run()).Should((BeNil()))
+
+		// The namespace "a" should not exist.
+		cmd = exec.Command("kubectl", "get", "ns", prefix+"a")
+		Expect(cmd.Run()).Should(Not(BeNil()))
+	})
+
+	It("should have 'CritParentMissing' condition on orphaned namespace", func() {
+		// Create a namespace "a"
+		cmd := exec.Command("kubectl", "create", "ns", prefix+"a")
+		Expect(cmd.Run()).Should(BeNil())
+
+		// Create a namespace "b"
+		cmd = exec.Command("kubectl", "create", "ns", prefix+"b")
+		Expect(cmd.Run()).Should(BeNil())
+
+		// Set "b" as a child of "a"
+		cmd = exec.Command("kubectl", "hns", "set", "b", "--parent", "a")
+		Expect(cmd.Run()).Should(BeNil())
+
+		// Delete the created namespace "a"
+		cmd = exec.Command("kubectl", "delete", "ns", prefix+"a")
+		Expect(cmd.Run()).Should((BeNil()))
+
+		// "b" should have 'CritParentMissing' condition. The command to use:
+		// kubectl get hierarchyconfigurations.hnc.x-k8s.io hierarchy -n b -o jsonpath='{.status.conditions..code}'
+		out, err := exec.Command("kubectl","get","hierarchyconfigurations.hnc.x-k8s.io","hierarchy","-n","b","-o", "jsonpath='{.status.conditions..code}'").Output()
+		// Convert []byte to string and remove the quotes to get the condition value.
+		condition := string(out)[1:len(out)-1]
+		Expect(err).Should(BeNil())
+		Expect(condition).Should(Equal("CritParentMissing"))
+
+		// Clean up - delete namespace "b"
+		cmd = exec.Command("kubectl", "delete", "ns", prefix+"b")
+		Expect(cmd.Run()).Should((BeNil()))
+	})
+})

--- a/incubator/hnc/e2e/tests/subnamespace_test.go
+++ b/incubator/hnc/e2e/tests/subnamespace_test.go
@@ -1,0 +1,50 @@
+package test
+
+import (
+	"os/exec"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Subnamespaces", func() {
+	var (
+		prefix string
+	)
+
+	BeforeEach(func() {
+		prefix = namspacePrefix+"subnamespace-"
+	})
+
+	It("should create and delete a subnamespace", func() {
+		// Create a namespace "a"
+		cmd := exec.Command("kubectl", "create", "ns", prefix+"a")
+		Expect(cmd.Run()).Should(BeNil())
+
+		// The namespace "a" should exist.
+		cmd = exec.Command("kubectl", "get", "ns", prefix+"a")
+		Expect(cmd.Run()).Should(BeNil())
+
+		// Create subnamespace "b" for "a"
+		cmd = exec.Command("kubectl", "hns", "create", prefix+"b", "-n", prefix+"a")
+		Expect(cmd.Run()).Should(BeNil())
+
+		// The namespace "b" should exist.
+		cmd = exec.Command("kubectl", "get", "ns", prefix+"b")
+		Expect(cmd.Run()).Should((BeNil()))
+
+		// The namespace "b" should have a "subnamespaceOf:a" annotation. The command to use:
+		// kubectl get ns b -o jsonpath='{.metadata.annotations.hnc\.x-k8s\.io/subnamespaceOf}'
+		out, err := exec.Command("kubectl", "get", "ns", prefix+"b", "-o", "jsonpath='{.metadata.annotations.hnc\\.x-k8s\\.io/subnamespaceOf}'").Output()
+		// Convert []byte to string and remove the quotes to get the "subnamesapceOf" annotation value.
+		pnm := string(out)[1:len(out)-1]
+		Expect(err).Should(BeNil())
+		Expect(pnm).Should(Equal(prefix+"a"))
+
+		// Clean up by setting allowCascadingDelete on "a" and then deleting "a".
+		cmd = exec.Command("kubectl", "hns", "set", prefix+"a", "-a")
+		Expect(cmd.Run()).Should((BeNil()))
+		cmd = exec.Command("kubectl", "delete", "ns", prefix+"a")
+		Expect(cmd.Run()).Should((BeNil()))
+	})
+})


### PR DESCRIPTION
E2e tests can be run locally by 'make kind-reset', 'make local-e2e-test'
or on a cluster by 'make e2e-test' now.

Use os/exec to run 'kubectl' and 'kubectl hns' commands in golang and
use the ginkgo framework for e2e test.

The sample test cases experiment getting 'subnamespaceOf' annotation and
'CritParentMissing' condition besides creating/deleting/getting
resources successfully or unsuccessfully as expected.

We will add more e2e test cases from this on.

Part of #785 