### PR TITLE
Enable removing bad subns anchors safely 

### DIFF
--- a/incubator/hnc/hack/test-issue-797-leaf.sh
+++ b/incubator/hnc/hack/test-issue-797-leaf.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+# Set up namespace structure
+echo "----------------------------------------------------"
+echo "${bold}Creating a race condition of two parents with the same leaf subns (anchor)"
+echo "Creating two root namespaces 'p1' and 'p2'...${normal}"
+kubectl create ns p1
+kubectl create ns p2
+sleep 1
+
+echo "${bold}Disabling webhook to generate the race condition...${normal}"
+kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io hnc-validating-webhook-configuration
+sleep 1
+
+echo "${bold}Creating subns (anchor) 'sub' in both 'p1' and 'p2'...${normal}"
+kubectl hns create sub -n p1
+kubectl hns create sub -n p2
+sleep 1
+
+echo "${bold}Subnamespace 'sub' should be created and have 'p1' as the 'subnamespaceOf' annoation value:${normal}"
+kubectl get ns sub -o yaml
+
+echo "${bold}Creating a 'test-secret' in the subnamespace 'sub'${normal}"
+kubectl create secret generic test-secret --from-literal=key=value -n sub
+
+echo "${bold}subns (anchor) 'sub' in 'p2' should have 'status: conflict' because it's a bad anchor:${normal}"
+kubectl get subns sub -n p2 -o yaml
+
+echo "${bold}Enabling webhook again...${normal}"
+kubectl apply -f manifests/hnc-manager.yaml
+
+echo "----------------------------------------------------"
+echo "${bold}Test-1:${normal} Remove subns (anchor) in the bad parent 'p2'"
+echo "${bold}Operation:${normal} - kubectl delete subns sub -n p2"
+kubectl delete subns sub -n p2
+echo "${bold}Expected:${normal} The bad subns (anchor) is deleted successfully but the 'sub' is not deleted (still contains the 'test-secret'):"
+echo "Getting secrets in the 'sub' namespace..."
+kubectl get secret -n sub
+
+echo "----------------------------------------------------"
+echo "${bold}Test-2:${normal} Remove subns (anchor) in the good parent 'p1'."
+echo "${bold}Operation:${normal} - kubectl delete subns sub -n p1"
+kubectl delete subns sub -n p1
+echo "${bold}Expected:${normal} The subns (anchor) is deleted successfully and the 'sub' is also deleted:"
+kubectl get ns sub -o yaml
+
+echo "----------------------------------------------------"
+echo "${bold}Cleaning up${normal}"
+kubectl hns set p1 -a
+kubectl delete ns p1
+kubectl delete ns p2

--- a/incubator/hnc/hack/test-issue-797-non-leaf.sh
+++ b/incubator/hnc/hack/test-issue-797-non-leaf.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+# Set up namespace structure
+echo "----------------------------------------------------"
+echo "${bold}Creating a race condition of two parents with the same non-leaf subns (anchor)"
+echo "Creating two root namespaces 'p1' and 'p2'...${normal}"
+kubectl create ns p1
+kubectl create ns p2
+sleep 1
+
+echo "${bold}Disabling webhook to generate the race condition...${normal}"
+kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io hnc-validating-webhook-configuration
+sleep 1
+
+echo "${bold}Creating subns (anchor) 'sub' in both 'p1' and 'p2'...${normal}"
+kubectl hns create sub -n p1
+kubectl hns create sub -n p2
+sleep 1
+
+echo "${bold}Subnamespace 'sub' should be created and have 'p1' as the 'subnamespaceOf' annoation value:${normal}"
+kubectl get ns sub -o yaml
+
+echo "${bold}Creating a 'test-secret' in the subnamespace 'sub'${normal}"
+kubectl create secret generic test-secret --from-literal=key=value -n sub
+
+echo "${bold}subns (anchor) 'sub' in 'p2' should have 'status: conflict' because it's a bad anchor:${normal}"
+kubectl get subns sub -n p2 -o yaml
+
+echo "${bold}Creating subns (anchor) 'sub-sub' in 'sub' to make 'sub' non-leaf...${normal}"
+kubectl hns create sub-sub -n sub
+sleep 1
+
+echo "${bold}Enabling webhook again...${normal}"
+kubectl apply -f manifests/hnc-manager.yaml
+
+echo "----------------------------------------------------"
+echo "${bold}Test-1:${normal} Remove subns (anchor) in the bad parent 'p2'"
+echo "${bold}Operation:${normal} - kubectl delete subns sub -n p2"
+kubectl delete subns sub -n p2
+echo "${bold}Expected:${normal} The bad subns (anchor) is deleted successfully but the 'sub' is not deleted (still contains the 'test-secret'):"
+echo "Getting secrets in the 'sub' namespace..."
+kubectl get secret -n sub
+
+echo "----------------------------------------------------"
+echo "${bold}Test-3:${normal} Remove subns (anchor) in the good parent 'p1'."
+echo "${bold}Operation-1:${normal} Setting allowCascadingDelete in 'sub' - kubectl hns set sub -a"
+kubectl hns set sub -a
+echo "${bold}Operation-2:${normal} - kubectl delete subns sub -n p1"
+kubectl delete subns sub -n p1
+echo "${bold}Expected:${normal} The subns (anchor) is deleted successfully and the 'sub' and 'sub-sub' are deleted:"
+kubectl get ns sub -o yaml
+kubectl get ns sub-sub -o yaml
+
+echo "----------------------------------------------------"
+echo "${bold}Cleaning up${normal}"
+kubectl hns set p1 -a
+kubectl delete ns p1
+kubectl delete ns p2

--- a/incubator/hnc/internal/reconcilers/anchor.go
+++ b/incubator/hnc/internal/reconcilers/anchor.go
@@ -119,14 +119,13 @@ func (r *AnchorReconciler) onDeleting(ctx context.Context, log logr.Logger, inst
 		return false, err
 	}
 
-	cnm := inst.Name
 	log.Info("The anchor is being deleted", "deletingCRD", deletingCRD)
 	switch {
 	case len(inst.ObjectMeta.Finalizers) == 0:
 		// We've finished processing this, nothing to do.
 		log.Info("Do nothing since the finalizers are already gone.")
 		return true, nil
-	case r.shouldDeleteSubns(cnm, snsInst, deletingCRD):
+	case r.shouldDeleteSubns(inst, snsInst, deletingCRD):
 		// The subnamespace is not already being deleted but it allows cascadingDelete or it's a leaf.
 		// Delete the subnamespace, unless the CRD is being deleted, in which case, we want to leave the
 		// namespaces alone.
@@ -160,7 +159,7 @@ func (r *AnchorReconciler) isDeletingCRD(ctx context.Context) (bool, error) {
 
 // shouldDeleteSubns returns true if the namespace still exists and it is a leaf
 // subnamespace or it allows cascading delete unless the CRD is being deleted.
-func (r *AnchorReconciler) shouldDeleteSubns(nm string, inst *corev1.Namespace, deletingCRD bool) bool {
+func (r *AnchorReconciler) shouldDeleteSubns(inst *api.SubnamespaceAnchor, nsInst *corev1.Namespace, deletingCRD bool) bool {
 	r.forest.Lock()
 	defer r.forest.Unlock()
 
@@ -169,16 +168,24 @@ func (r *AnchorReconciler) shouldDeleteSubns(nm string, inst *corev1.Namespace, 
 		return false
 	}
 
-	// If the subnamespace is already being deleted, or has already been deleted,
-	// then there's no need to delete it again.
-	ns := r.forest.Get(nm)
-	if !inst.DeletionTimestamp.IsZero() || !ns.Exists() {
+	cnm := inst.Name
+	pnm := inst.Namespace
+	cns := r.forest.Get(cnm)
+
+	// If the declared subnamespace is not created by this anchor, don't delete it.
+	if cns.Parent().Name() != pnm {
+		return false
+	}
+
+	// If the subnamespace is created by this anchor but is already being deleted,
+	// or has already been deleted, then there's no need to delete it again.
+	if !nsInst.DeletionTimestamp.IsZero() || !cns.Exists() {
 		return false
 	}
 
 	// The subnamespace exists and isn't being deleted. We should delete it if it
 	// doesn't have any children itself, or if cascading deletion is enabled.
-	return ns.ChildNames() == nil || ns.AllowsCascadingDelete()
+	return cns.ChildNames() == nil || cns.AllowsCascadingDelete()
 }
 
 func (r *AnchorReconciler) removeFinalizers(log logr.Logger, inst *api.SubnamespaceAnchor, snsInst *corev1.Namespace) bool {

--- a/incubator/hnc/internal/validators/anchor.go
+++ b/incubator/hnc/internal/validators/anchor.go
@@ -90,6 +90,10 @@ func (v *Anchor) handle(req *anchorRequest) admission.Response {
 	}
 
 	if req.op == v1beta1.Delete {
+		// Allow deleting a bad anchor.
+		if cns.Parent().Name() != pnm {
+			return allow("")
+		}
 		if cns.Exists() && cns.ChildNames() != nil && !cns.AllowsCascadingDelete() {
 			msg := fmt.Sprintf("The subnamespace %s is not a leaf and doesn't allow cascading deletion. Please set allowCascadingDelete flag or make it a leaf first.", cnm)
 			return deny(metav1.StatusReasonForbidden, msg)

--- a/incubator/hnc/internal/validators/anchor_test.go
+++ b/incubator/hnc/internal/validators/anchor_test.go
@@ -69,6 +69,7 @@ func TestAllowCascadingDeleteSubnamespaces(t *testing.T) {
 		{name: "set in ancestor that is not the first full namespace", acd: "a", pnm: "c", cnm: "d"},
 		{name: "unset in leaf", pnm: "d", cnm: "e"},
 		{name: "unset in non-leaf", pnm: "c", cnm: "d", fail: true},
+		{name: "unset in non-leaf but bad anchor", pnm: "b", cnm: "d"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Allow removing bad subns anchor if the subnamespace already exists and
the parent doesn't match. The race condition could happen when two
parents both create the same subns the same time and the webhook is
bypassed because the forest is not updated after the first change. We
would always allow resolving a bad state.

Most importantly, make sure the subnamespace is not deleted with the
deletion of a bad anchor. Before this change, the subnamespace created
from a good anchor will also be deleted when deleting a bad anchor.

Tested by test-issue-797-leaf.sh and test-issue-797-non-leaf.sh, where
they disable the webhook first to generate the race condition in both a
leaf and non-leaf subnamespace and enable the webhook to test the
change. One unit test case is added to the anchor validator too.

Fixes #797 