### PR TITLE
[VC] Back populate super master clusterIP to tenant service object

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/cluster/cluster.go
+++ b/incubator/virtualcluster/pkg/syncer/cluster/cluster.go
@@ -149,6 +149,10 @@ func (c *Cluster) GetSpec() (*v1alpha1.VirtualClusterSpec, error) {
 	if !prefixesSet.Has(constants.DefaultOpaqueMetaPrefix) {
 		spec.OpaqueMetaPrefixes = append(spec.OpaqueMetaPrefixes, constants.DefaultOpaqueMetaPrefix)
 	}
+	prefixesSet = sets.NewString(spec.TransparentMetaPrefixes...)
+	if !prefixesSet.Has(constants.DefaultTransparentMetaPrefix) {
+		spec.TransparentMetaPrefixes = append(spec.TransparentMetaPrefixes, constants.DefaultTransparentMetaPrefix)
+	}
 
 	return spec, nil
 }

--- a/incubator/virtualcluster/pkg/syncer/constants/constants.go
+++ b/incubator/virtualcluster/pkg/syncer/constants/constants.go
@@ -77,7 +77,11 @@ const (
 	// According to controller workqueue default rate limiter algorithm, retry 16 times takes around 180 seconds.
 	MaxReconcileRetryAttempts = 16
 
-	DefaultOpaqueMetaPrefix = "tenancy.x-k8s.io"
+	DefaultOpaqueMetaPrefix      = "tenancy.x-k8s.io"
+	DefaultTransparentMetaPrefix = "transparency.tenancy.x-k8s.io"
+
+	// LabelSuperClusterIP is used to inform the tenant service about the cluster IP used in super master.
+	LabelSuperClusterIP = "transparency.tenancy.x-k8s.io/clusterIP"
 
 	// Override the client-go default 5 qps and 10 burst, which are too samll for syncer.
 	DefaultSyncerClientQPS   = 1000

--- a/incubator/virtualcluster/pkg/syncer/resources/service/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/service/controller.go
@@ -114,10 +114,10 @@ func NewServiceController(config *config.SyncerConfiguration,
 			FilterFunc: func(obj interface{}) bool {
 				switch t := obj.(type) {
 				case *v1.Service:
-					return isLoadBalancerService(t)
+					return isBackPopulateService(t)
 				case cache.DeletedFinalStateUnknown:
 					if e, ok := t.Obj.(*v1.Service); ok {
-						return isLoadBalancerService(e)
+						return isBackPopulateService(e)
 					}
 					utilruntime.HandleError(fmt.Errorf("unable to convert object %v to *v1.Service", obj))
 					return false
@@ -141,8 +141,8 @@ func NewServiceController(config *config.SyncerConfiguration,
 	return c, multiClusterServiceController, upwardServiceController, nil
 }
 
-func isLoadBalancerService(svc *v1.Service) bool {
-	return svc.Spec.Type == v1.ServiceTypeLoadBalancer
+func isBackPopulateService(svc *v1.Service) bool {
+	return svc.Spec.Type == v1.ServiceTypeLoadBalancer || svc.Spec.Type == v1.ServiceTypeClusterIP
 }
 
 func (c *controller) enqueueService(obj interface{}) {

--- a/incubator/virtualcluster/pkg/syncer/resources/service/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/service/uws.go
@@ -56,7 +56,7 @@ func (c *controller) BackPopulate(key string) error {
 	}
 
 	// Make sure the super cluster IP is added to the annotation so that it can be back populated to the tenant object
-	if pService.Spec.ClusterIP != "" && (pService.Annotations == nil || pService.Annotations[constants.LabelSuperClusterIP] != pService.Spec.ClusterIP) {
+	if pService.Spec.ClusterIP != "" && pService.Annotations[constants.LabelSuperClusterIP] != pService.Spec.ClusterIP {
 		if pService.Annotations == nil {
 			pService.Annotations = make(map[string]string)
 		}

--- a/incubator/virtualcluster/pkg/syncer/resources/service/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/service/uws.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
@@ -54,6 +55,20 @@ func (c *controller) BackPopulate(key string) error {
 		return err
 	}
 
+	// Make sure the super cluster IP is added to the annotation so that it can be back populated to the tenant object
+	if pService.Spec.ClusterIP != "" && (pService.Annotations == nil || pService.Annotations[constants.LabelSuperClusterIP] != pService.Spec.ClusterIP) {
+		if pService.Annotations == nil {
+			pService.Annotations = make(map[string]string)
+		}
+		pService.Annotations[constants.LabelSuperClusterIP] = pService.Spec.ClusterIP
+		_, err = c.serviceClient.Services(pNamespace).Update(pService)
+		if err != nil {
+			return err
+		}
+		// wait for the next reconcile for the rest of backpopulate work.
+		return nil
+	}
+
 	clusterName, vNamespace := conversion.GetVirtualOwner(pService)
 	if clusterName == "" || vNamespace == "" {
 		klog.Infof("drop service %s/%s which is not belongs to any tenant", pNamespace, pName)
@@ -77,8 +92,30 @@ func (c *controller) BackPopulate(key string) error {
 		return fmt.Errorf("failed to create client from cluster %s config: %v", clusterName, err)
 	}
 
+	spec, err := c.multiClusterServiceController.GetSpec(clusterName)
+	if err != nil {
+		return err
+	}
+
+	var newService *v1.Service
+	updatedMeta := conversion.Equality(c.config, spec).CheckUWObjectMetaEquality(&pService.ObjectMeta, &vService.ObjectMeta)
+	if updatedMeta != nil {
+		newService = vService.DeepCopy()
+		newService.ObjectMeta = *updatedMeta
+		if _, err = tenantClient.CoreV1().Services(vService.Namespace).Update(newService); err != nil {
+			return fmt.Errorf("failed to back populate service %s/%s meta update for cluster %s: %v", vService.Namespace, vService.Name, clusterName, err)
+		}
+	}
+
 	if !equality.Semantic.DeepEqual(vService.Status, pService.Status) {
-		newService := vService.DeepCopy()
+		if newService == nil {
+			newService = vService.DeepCopy()
+		} else {
+			// vService has been updated, let us fetch the lastest version.
+			if newService, err = tenantClient.CoreV1().Services(vService.Namespace).Get(vService.Name, metav1.GetOptions{}); err != nil {
+				return fmt.Errorf("failed to retrieve vService %s/%s from cluster %s: %v", vService.Namespace, vService.Name, clusterName, err)
+			}
+		}
 		newService.Status = pService.Status
 		if _, err = tenantClient.CoreV1().Services(vService.Namespace).UpdateStatus(newService); err != nil {
 			return fmt.Errorf("failed to back populate service %s/%s status update for cluster %s: %v", vService.Namespace, vService.Name, clusterName, err)


### PR DESCRIPTION
In vc, the tenant service and super master service have different cluster ips since the cluster ip allocations are done by separate service controllers in tenant master and super master individually. The Pods can use super master cluster ip to access service or other Pod without any problem. But tenant dns cannot translate service dnsname to super master cluster ip since it can only see  the tenant master cluster ip. 

This change is the first step towards resolving the problem. The syncer now will populate the super master service cluster ip in the annotation of the tenant service object. Other components now can get the super master cluster IP from tenant perspective if it is needed.