### PR TITLE
[VC] vc health checker, output in metric and event

### DIFF
--- a/incubator/virtualcluster/cmd/syncer/app/config/config.go
+++ b/incubator/virtualcluster/cmd/syncer/app/config/config.go
@@ -21,8 +21,8 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	restclient "k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/record"
 
 	vcclient "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/client/clientset/versioned"
 	vcinformers "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/client/informers/externalversions/tenancy/v1alpha1"
@@ -51,8 +51,8 @@ type Config struct {
 	Kubeconfig *restclient.Config
 
 	// the event sink
-	Recorder    events.EventRecorder
-	Broadcaster events.EventBroadcaster
+	Recorder    record.EventRecorder
+	Broadcaster record.EventBroadcaster
 
 	// LeaderElection is optional.
 	LeaderElection *leaderelection.LeaderElectionConfig

--- a/incubator/virtualcluster/cmd/syncer/app/options/options.go
+++ b/incubator/virtualcluster/cmd/syncer/app/options/options.go
@@ -33,7 +33,6 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
@@ -145,8 +144,8 @@ func (o *ResourceSyncerOptions) Config() (*syncerappconfig.Config, error) {
 	}
 
 	// Prepare event clients.
-	eventBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: superMasterClient.EventsV1beta1().Events("")})
-	recorder := eventBroadcaster.NewRecorder(clientgokubescheme.Scheme, constants.ResourceSyncerUserAgent)
+	eventBroadcaster := record.NewBroadcaster()
+	recorder := eventBroadcaster.NewRecorder(clientgokubescheme.Scheme, corev1.EventSource{Component: constants.ResourceSyncerUserAgent})
 	leaderElectionBroadcaster := record.NewBroadcaster()
 	leaderElectionRecorder := leaderElectionBroadcaster.NewRecorder(clientgokubescheme.Scheme, corev1.EventSource{Component: constants.ResourceSyncerUserAgent})
 

--- a/incubator/virtualcluster/cmd/syncer/app/server.go
+++ b/incubator/virtualcluster/cmd/syncer/app/server.go
@@ -25,6 +25,7 @@ import (
 	"os"
 
 	"k8s.io/apiserver/pkg/util/term"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/leaderelection"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/cli/globalflag"
@@ -92,11 +93,12 @@ func Run(cc *syncerconfig.CompletedConfig, stopCh <-chan struct{}) error {
 		cc.VirtualClusterClient,
 		cc.VirtualClusterInformer,
 		cc.SuperMasterClient,
-		cc.SuperMasterInformerFactory)
+		cc.SuperMasterInformerFactory,
+		cc.Recorder)
 
 	// Prepare the event broadcaster.
 	if cc.Broadcaster != nil && cc.SuperMasterClient != nil {
-		cc.Broadcaster.StartRecordingToSink(stopCh)
+		cc.Broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: cc.SuperMasterClient.CoreV1().Events("")})
 	}
 
 	// Start all informers.

--- a/incubator/virtualcluster/config/setup/all_in_one.yaml
+++ b/incubator/virtualcluster/config/setup/all_in_one.yaml
@@ -252,6 +252,14 @@ rules:
     - watch
 - apiGroups:
     - ""
+    - storage.k8s.io
+  resources:
+    - events
+  verbs:
+    - create
+    - patch
+- apiGroups:
+    - ""
   resources:
     - namespaces/status
     - pods/status

--- a/incubator/virtualcluster/config/setup/all_in_one_aliyun.yaml
+++ b/incubator/virtualcluster/config/setup/all_in_one_aliyun.yaml
@@ -253,6 +253,14 @@ rules:
     - watch
 - apiGroups:
     - ""
+    - storage.k8s.io
+  resources:
+    - events
+  verbs:
+    - create
+    - patch
+- apiGroups:
+    - ""
   resources:
     - namespaces/status
     - pods/status

--- a/incubator/virtualcluster/pkg/syncer/metrics/metrics.go
+++ b/incubator/virtualcluster/pkg/syncer/metrics/metrics.go
@@ -33,6 +33,7 @@ const (
 	CheckerRemedyKey         = "checker_remedy_count"
 	CheckerScanDurationKey   = "checker_scan_duaration_seconds"
 	UWSOperationDurationKey  = "uws_operations_duration_seconds"
+	ClusterHealthKey         = "virtual_cluster_health"
 )
 
 var (
@@ -95,6 +96,14 @@ var (
 		},
 		[]string{"uws_resource"},
 	)
+	ClusterHealthStats = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: ResourceSyncerSubsystem,
+			Name:      ClusterHealthKey,
+			Help:      "Last checker scan status for virtual clusters.",
+		},
+		[]string{"status"},
+	)
 )
 
 var registerMetrics sync.Once
@@ -109,6 +118,7 @@ func Register() {
 		prometheus.MustRegister(CheckerRemedyStats)
 		prometheus.MustRegister(CheckerScanDuration)
 		prometheus.MustRegister(UWSOperationDuration)
+		prometheus.MustRegister(ClusterHealthStats)
 	})
 }
 


### PR DESCRIPTION
```
[root@vm virtualcluster]# k describe vc -n tenant1admin   vc-sample-1
Name:         vc-sample-1
Namespace:    tenant1admin
Labels:       controller-tools.k8s.io=1.0
Annotations:  <none>
API Version:  tenancy.x-k8s.io/v1alpha1
Kind:         VirtualCluster
Metadata:
  Creation Timestamp:  2020-06-02T03:25:27Z
  Finalizers:
    virtualcluster.finalizer.native
  Generation:        4
  Resource Version:  2301078
  Self Link:         /apis/tenancy.x-k8s.io/v1alpha1/namespaces/tenant1admin/virtualclusters/vc-sample-1
  UID:               b43b5578-a480-11ea-8ccc-525400c042d5
Spec:
  Cluster Domain:        cluster.local
  Cluster Version Name:  cv-sample-np
  Opaque Meta Prefixes:
    tenancy.x-k8s.io
    a.b
  Pki Expire Days:  365
  Transparent Meta Prefixes:
    k8s.net.status
Status:
  Conditions:
    Last Transition Time:  2020-06-02T03:25:27Z
    Message:               retry: 3
    Reason:                ClusterCreating
    Status:
    Last Transition Time:  2020-06-02T03:26:29Z
    Message:               tenant master is running
    Reason:                TenantMasterRunning
    Status:
  Message:                 tenant master is running
  Phase:                   Running
  Reason:                  TenantMasterRunning
Events:
  Type     Reason           Age   From                  Message
  ----     ------           ----  ----                  -------
  Warning  ClusterUnHealth  38s   namespace-controller  VirtualCluster tenant1admin-bc9a8b-vc-sample-1 unhealth
[root@vm virtualcluster]# k get event -A
NAMESPACE      LAST SEEN   TYPE      REASON             OBJECT                            MESSAGE
tenant1admin   4m23s       Warning   ClusterUnHealth    virtualcluster/vc-sample-1        VirtualCluster tenant1admin-bc9a8b-vc-sample-1 unhealth
tenant1admin   3m23s       Warning   ClusterUnHealth    virtualcluster/vc-sample-1        VirtualCluster tenant1admin-bc9a8b-vc-sample-1 unhealth
tenant1admin   2m23s       Warning   ClusterUnHealth    virtualcluster/vc-sample-1        VirtualCluster tenant1admin-bc9a8b-vc-sample-1 unhealth
tenant1admin   47s         Warning   ClusterUnHealth    virtualcluster/vc-sample-1        VirtualCluster tenant1admin-bc9a8b-vc-sample-1 unhealth
```

Signed-off-by: zhuangqh <zhuangqhc@gmail.com>