### PR TITLE
[VC] Add document for tenant dns support

### DIFF
--- a/incubator/virtualcluster/README.md
+++ b/incubator/virtualcluster/README.md
@@ -60,9 +60,7 @@ hence the default grace period is too small.
 The DNS service should be created in `kube-system` namespace using name `kube-dns`. The syncer controller can then
 recognize the DNS service cluster IP in super master and inject it into Pod spec `dnsConfig`.
 
-- Since coredns is installed in tenant master, the service cluster IPs have to be identical in tenant
-master and super master respectively so that coredns can provide correct cluster IP translation for service cname.
-This requires both clusters to have the same CIDR.
+- VirtualCluster supports tenant DNS service using a customized coredns build. See this [document](./doc/tenant-dns.md) for details.
 
 - VirtualCluster fully support tenant service account.
 

--- a/incubator/virtualcluster/config/sampleswithspec/coredns.yaml
+++ b/incubator/virtualcluster/config/sampleswithspec/coredns.yaml
@@ -70,6 +70,32 @@ data:
         loadbalance
     }
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  annotations:
+    prometheus.io/port: "9153"
+    prometheus.io/scrape: "true"
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+spec:
+  selector:
+    k8s-app: kube-dns
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+  - name: metrics
+    port: 9153
+    protocol: TCP
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -159,6 +185,7 @@ spec:
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: kubernetes
+      dnsPolicy: Default
       volumes:
         - name: config-volume
           configMap:
@@ -166,30 +193,3 @@ spec:
             items:
             - key: Corefile
               path: Corefile
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: kube-dns
-  namespace: kube-system
-  annotations:
-    prometheus.io/port: "9153"
-    prometheus.io/scrape: "true"
-  labels:
-    k8s-app: kube-dns
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "CoreDNS"
-spec:
-  selector:
-    k8s-app: kube-dns
-  ports:
-  - name: dns
-    port: 53
-    protocol: UDP
-  - name: dns-tcp
-    port: 53
-    protocol: TCP
-  - name: metrics
-    port: 9153
-    protocol: TCP
-

--- a/incubator/virtualcluster/config/sampleswithspec/coredns.yaml
+++ b/incubator/virtualcluster/config/sampleswithspec/coredns.yaml
@@ -1,0 +1,195 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coredns
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:coredns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  - pods
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:coredns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:coredns
+subjects:
+- kind: ServiceAccount
+  name: coredns
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+data:
+  Corefile: |
+    .:53 {
+        log    
+        errors
+        health {
+          lameduck 5s
+        }
+        ready
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+          fallthrough in-addr.arpa ip6.arpa
+        }
+        prometheus :9153
+        forward . /etc/resolv.conf
+        cache 30
+        loop
+        reload
+        loadbalance
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/name: "CoreDNS"
+spec:
+  # replicas: not specified here:
+  # 1. Default is 1.
+  # 2. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-dns
+    spec:
+      serviceAccountName: coredns
+      tolerations:
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+      nodeSelector:
+        kubernetes.io/os: linux
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: k8s-app
+                operator: In
+                values: ["kube-dns"]
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - name: coredns
+        image: virtualcluster/coredns:v1.6.8
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            memory: 170Mi
+          requests:
+            cpu: 100m
+            memory: 70Mi
+        args: [ "-conf", "/etc/coredns/Corefile" ]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/coredns
+          readOnly: true
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        - containerPort: 9153
+          name: metrics
+          protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - all
+          readOnlyRootFilesystem: true
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8181
+            scheme: HTTP
+        env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: kubernetes
+      volumes:
+        - name: config-volume
+          configMap:
+            name: coredns
+            items:
+            - key: Corefile
+              path: Corefile
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  annotations:
+    prometheus.io/port: "9153"
+    prometheus.io/scrape: "true"
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+spec:
+  selector:
+    k8s-app: kube-dns
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+  - name: metrics
+    port: 9153
+    protocol: TCP
+

--- a/incubator/virtualcluster/doc/tenant-dns.md
+++ b/incubator/virtualcluster/doc/tenant-dns.md
@@ -42,7 +42,7 @@ index 295715e2..155944e8 100644
                 Namespace:    svc.GetNamespace(),
                 Index:        ServiceKey(svc.GetName(), svc.GetNamespace()),
 -               ClusterIP:    svc.Spec.ClusterIP,
-+               ClusterIP:    svc.Annotations["transparency.tenancy.x-k8s.io/clusterIP"],
++               ClusterIP:    func(sCIP string) string { if sCIP == "" { return svc.Spec.ClusterIP } else { return sCIP } } (svc.Annotations["transparency.tenancy.x-k8s.io/clusterIP"]),
                 Type:         svc.Spec.Type,
                 ExternalName: svc.Spec.ExternalName,
 
@@ -60,7 +60,7 @@ git checkout tags/v1.6.8
 the syncer has populated the super master cluster IP in the tenant master service annotation using
 the key `transparency.tenancy.x-k8s.io/clusterIP`.
 ```
-sed -i'' -e 's/svc.Spec.ClusterIP/svc.Annotations["transparency.tenancy.x-k8s.io\/clusterIP"]/g' plugin/kubernetes/object/service.go
+sed -i'' -e 's/svc.Spec.ClusterIP/func(sCIP string) string { if sCIP == "" { return svc.Spec.ClusterIP } else { return sCIP } } (svc.Annotations["transparency.tenancy.x-k8s.io\/clusterIP"])/g' plugin/kubernetes/object/service.go
 ```
 
 3. Compile and build the new image.
@@ -69,8 +69,9 @@ make -f Makefile.release DOCKER=virtualcluster LINUX_ARCH=amd64 release
 make -f Makefile.release DOCKER=virtualcluster LINUX_ARCH=amd64 docker
 ```
 
-Now the customized `coredns` image is ready. We have also prepared a few images for different `coredns`
-versions in the virtualcluster docker hub repo.
+Now the customized `coredns` image is ready, which works on both upstream Kubernetes and
+virtualcluster assuming the annotation key is not abused. We have also prepared a few customized
+images for different `coredns` versions in the virtualcluster docker hub repo.
 
 ## Installation
 

--- a/incubator/virtualcluster/doc/tenant-dns.md
+++ b/incubator/virtualcluster/doc/tenant-dns.md
@@ -1,0 +1,122 @@
+# Tenant DNS Support
+
+Commonly used dns servers are not tenant-aware. Tenant Pods cannot leverage the super master
+dns service because it only recognizes the super master namespaces, not the namespaces (created in tenant masters)
+used by tenant Pods for DNS query. Hence, dedicated dns server has to be installed in every
+tenant master that needs DNS service. Let us take `coredns` for an example in this document.
+
+## Problem
+
+The `coredns` installed in tenant master normally works for Pod and headless service endpoint
+FQDN (Fully Qualified Domain Name) translation.
+However, it cannot provide the correct cluster IP for service FQDN issued by tenant Pods. 
+This is because `coredns` only watches the tenant master and stores the tenant cluster IP in its
+dns records. However, tenant Pods that run in super master would expect to access the cluster IP of the
+synced super master service since it is the actual cluster IP managed by the Kube-proxy in
+physical nodes. The `coredns` would only work for service FQDN query had the cluster IPs of the tenant 
+master service and the synced super master service been the same. Unfortunately, this is difficult
+to achieve even if both the tenant master and the super master use the same service CIDR because:
+- The cluster IPs have to be allocated individually in different masters in order to avoid cluster IP conflict.
+- The service cluster IP is immutable once the service object is created.
+
+As a consequence, `coredns` will always points to the tenant cluster IP for service FQDN query 
+which is a bogus address for tenant Pod to access.
+
+## Solution
+
+The syncer might recreate the tenant master service after super master service is created using
+the cluster IP allocated in the super master. This, however, would significantly complicate the syncer 
+implementation and be error prone. By closely investigating all possible solutions, we found the
+simplest workaround is to introduce a trivial change to the `coredns` Kubernetes plugin. The idea
+is that the syncer can back populate the cluster IP used in the super master to tenant service
+annotation instead of recreating a new service object and let `coredns` record the
+super master cluster IP in its internal structures. The modification to `coredns` is literally one
+line change:
+``` bash
+diff --git a/plugin/kubernetes/object/service.go b/plugin/kubernetes/object/service.go
+index 295715e2..155944e8 100644
+--- a/plugin/kubernetes/object/service.go
++++ b/plugin/kubernetes/object/service.go
+@@ -44,7 +44,7 @@ func toService(skipCleanup bool, obj interface{}) interface{} {
+                Name:         svc.GetName(),
+                Namespace:    svc.GetNamespace(),
+                Index:        ServiceKey(svc.GetName(), svc.GetNamespace()),
+-               ClusterIP:    svc.Spec.ClusterIP,
++               ClusterIP:    svc.Annotations["transparency.tenancy.x-k8s.io/clusterIP"],
+                Type:         svc.Spec.Type,
+                ExternalName: svc.Spec.ExternalName,
+
+```
+
+Let us describe the steps to create a customized `coredns` container image with above change.
+They are simple.
+1. Get the `coredns` source code with desired version (e.g., v1.6.8).
+```
+git clone https://github.com/coredns/coredns.git
+git checkout tags/v1.6.8 
+```
+
+2. In the source code root directory, use the following cmd to change the code. Note that
+the syncer has populated the super master cluster IP in the tenant master service annotation using
+the key `transparency.tenancy.x-k8s.io/clusterIP`.
+```
+sed -i'' -e 's/svc.Spec.ClusterIP/svc.Annotations["transparency.tenancy.x-k8s.io\/clusterIP"]/g' plugin/kubernetes/object/service.go
+```
+
+3. Compile and build the new image.
+```
+make -f Makefile.release DOCKER=virtualcluster LINUX_ARCH=amd64 release
+make -f Makefile.release DOCKER=virtualcluster LINUX_ARCH=amd64 docker
+```
+
+Now the customized `coredns` image is ready. We have also prepared a few images for different `coredns`
+versions in the virtualcluster docker hub repo.
+
+## Installation
+
+Assuming is a virtualcluster has been installed (e.g., using the instructions in the [demo](demo.md)),
+one can use the provided sample coredns [yaml](../config/sampleswithspec/coredns.yaml) to install the customized
+coredns v1.6.8 in the virtualcluster.
+```
+# kubectl apply --kubeconfig vc-1.kubeconfig -f config/sampleswithspec/coredns.yaml
+```
+
+## Testing
+
+First, create a normal nginx Pod and a service `my-nginx` using the nginx Pod as the
+endpoint in the virtualcluster. Then you can access `my-nginx`
+service from any other tenant Pods in the same namespace using DNS. For example:
+```
+# kubectl exec $TEST_POD -n $SERVICE_NAMESPACE_IN_SUPER -it /bin/sh
+
+sh-4.4# curl my-nginx.default.svc.cluster.local
+<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome to nginx!</title>
+<style>
+    body {
+        width: 35em;
+        margin: 0 auto;
+        font-family: Tahoma, Verdana, Arial, sans-serif;
+    }
+</style>
+</head>
+<body>
+<h1>Welcome to nginx!</h1>
+<p>If you see this page, the nginx web server is successfully installed and
+working. Further configuration is required.</p>
+
+<p>For online documentation and support please refer to
+<a href="http://nginx.org/">nginx.org</a>.<br/>
+Commercial support is available at
+<a href="http://nginx.com/">nginx.com</a>.</p>
+
+<p><em>Thank you for using nginx.</em></p>
+</body>
+</html>
+
+```
+
+You can observe that the `my_nginx` service has different cluster IPs in tenant master and super master respectively
+and the tenant coredns uses the super master cluster ip for service FQDN translation.

--- a/incubator/virtualcluster/pkg/syncer/conversion/mutate.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/mutate.go
@@ -277,8 +277,6 @@ func mutateDNSConfig(p *podMutateCtx, vPod *v1.Pod, clusterDomain, nameServer st
 		// Fallback to DNSDefault for pod on hostnetwork.
 		fallthrough
 	case v1.DNSDefault:
-		// FIXME(zhuangqh): allow host dns or not.
-		p.pPod.Spec.DNSPolicy = v1.DNSNone
 		return
 	}
 }


### PR DESCRIPTION
This change adds document to explain how to customize coredns to provide super master cluster IP translation for tenant service domain name.