### PR TITLE
[VC] add generic metric for syncer operations

### DIFF
--- a/incubator/virtualcluster/cmd/syncer/app/options/options.go
+++ b/incubator/virtualcluster/cmd/syncer/app/options/options.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 	clientgokubescheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	restclient "k8s.io/client-go/rest"
@@ -41,6 +42,7 @@ import (
 	"k8s.io/klog"
 
 	syncerappconfig "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/cmd/syncer/app/config"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/apis"
 	vcclient "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/client/clientset/versioned"
 	vcinformers "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/client/informers/externalversions"
 	syncerconfig "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
@@ -156,6 +158,11 @@ func (o *ResourceSyncerOptions) Config() (*syncerappconfig.Config, error) {
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	// Setup Scheme for all resources
+	if err := apis.AddToScheme(scheme.Scheme); err != nil {
+		return nil, err
 	}
 
 	c.SecretClient = superMasterClient.CoreV1()

--- a/incubator/virtualcluster/pkg/syncer/constants/constants.go
+++ b/incubator/virtualcluster/pkg/syncer/constants/constants.go
@@ -86,6 +86,12 @@ const (
 	// Override the client-go default 5 qps and 10 burst, which are too samll for syncer.
 	DefaultSyncerClientQPS   = 1000
 	DefaultSyncerClientBurst = 2000
+
+	// StatusCode represents the status of every syncer operations.
+	// TODO: more detailed error code
+	StatusCodeOK                     = "OK"
+	StatusCodeExceedMaxRetryAttempts = "ExceedMaxRetryAttempts"
+	StatusCodeError                  = "Error"
 )
 
 const (

--- a/incubator/virtualcluster/pkg/syncer/metrics/metrics.go
+++ b/incubator/virtualcluster/pkg/syncer/metrics/metrics.go
@@ -28,10 +28,12 @@ const (
 	ResourceSyncerSubsystem  = "syncer"
 	PodOperationsKey         = "pod_operations_total"
 	PodOperationsDurationKey = "pod_operations_duration_seconds"
-	PodOperationsErrorsKey   = "pod_operations_errors_total"
 	CheckerMissMatchKey      = "checker_missmatch_count"
 	CheckerRemedyKey         = "checker_remedy_count"
 	CheckerScanDurationKey   = "checker_scan_duaration_seconds"
+	DWSOperationCounterKey   = "dws_operations_total"
+	DWSOperationDurationKey  = "dws_operations_duration_seconds"
+	UWSOperationCounterKey   = "uws_operations_total"
 	UWSOperationDurationKey  = "uws_operations_duration_seconds"
 	ClusterHealthKey         = "virtual_cluster_health"
 )
@@ -43,7 +45,7 @@ var (
 			Name:      PodOperationsKey,
 			Help:      "Cumulative number of pod operations by operation type.",
 		},
-		[]string{"operation_type"},
+		[]string{"operation_type", "code"},
 	)
 	PodOperationsDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -51,14 +53,6 @@ var (
 			Name:      PodOperationsDurationKey,
 			Help:      "Duration in seconds of pod operations. Broken down by operation type.",
 			Buckets:   prometheus.DefBuckets,
-		},
-		[]string{"operation_type"},
-	)
-	PodOperationsErrors = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Subsystem: ResourceSyncerSubsystem,
-			Name:      PodOperationsErrorsKey,
-			Help:      "Cumulative number of pod operation errors by operation type.",
 		},
 		[]string{"operation_type"},
 	)
@@ -87,6 +81,21 @@ var (
 		},
 		[]string{"checker_target"},
 	)
+	DWSOperationDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: ResourceSyncerSubsystem,
+			Name:      DWSOperationDurationKey,
+			Help:      "Duration in seconds of each resource dws operation time.",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{"resource", "cluster"})
+	DWSOperationCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: ResourceSyncerSubsystem,
+			Name:      DWSOperationCounterKey,
+			Help:      "Cumulative number of downward resource operations.",
+		},
+		[]string{"resource", "cluster", "code"})
 	UWSOperationDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: ResourceSyncerSubsystem,
@@ -94,8 +103,15 @@ var (
 			Help:      "Duration in seconds of resource uws operation time.",
 			Buckets:   prometheus.DefBuckets,
 		},
-		[]string{"uws_resource"},
+		[]string{"resource"},
 	)
+	UWSOperationCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: ResourceSyncerSubsystem,
+			Name:      UWSOperationCounterKey,
+			Help:      "Cumulative number of upward resource operations.",
+		},
+		[]string{"resource", "code"})
 	ClusterHealthStats = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: ResourceSyncerSubsystem,
@@ -113,10 +129,11 @@ func Register() {
 	registerMetrics.Do(func() {
 		prometheus.MustRegister(PodOperations)
 		prometheus.MustRegister(PodOperationsDuration)
-		prometheus.MustRegister(PodOperationsErrors)
 		prometheus.MustRegister(CheckerMissMatchStats)
 		prometheus.MustRegister(CheckerRemedyStats)
 		prometheus.MustRegister(CheckerScanDuration)
+		prometheus.MustRegister(DWSOperationCounter)
+		prometheus.MustRegister(DWSOperationDuration)
 		prometheus.MustRegister(UWSOperationDuration)
 		prometheus.MustRegister(ClusterHealthStats)
 	})
@@ -137,5 +154,17 @@ func RecordCheckerScanDuration(checkerTarget string, start time.Time) {
 }
 
 func RecordUWSOperationDuration(resource string, start time.Time) {
-	UWSOperationDuration.WithLabelValues(resource).Observe(SinceInSeconds(start))
+	UWSOperationDuration.With(prometheus.Labels{"resource": resource}).Observe(SinceInSeconds(start))
+}
+
+func RecordUWSOperationStatus(resource, code string) {
+	UWSOperationCounter.With(prometheus.Labels{"resource": resource, "code": code}).Inc()
+}
+
+func RecordDWSOperationDuration(resource, cluster string, start time.Time) {
+	DWSOperationDuration.With(prometheus.Labels{"resource": resource, "cluster": cluster}).Observe(SinceInSeconds(start))
+}
+
+func RecordDWSOperationStatus(resource, cluster, code string) {
+	DWSOperationCounter.With(prometheus.Labels{"resource": resource, "cluster": cluster, "code": code}).Inc()
 }

--- a/incubator/virtualcluster/pkg/syncer/resources/node/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/node/uws.go
@@ -19,15 +19,12 @@ package node
 import (
 	"fmt"
 	"sync"
-	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
-
-	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/metrics"
 )
 
 // StartUWS starts the upward syncer
@@ -53,7 +50,6 @@ func (c *controller) BackPopulate(nodeName string) error {
 		}
 		return err
 	}
-	defer metrics.RecordUWSOperationDuration("node", time.Now())
 	klog.V(4).Infof("back populate node %s/%s", node.Namespace, node.Name)
 	c.Lock()
 	clusterList := c.nodeNameToCluster[node.Name]

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
@@ -18,8 +18,6 @@ package pod
 
 import (
 	"fmt"
-	"time"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -30,7 +28,6 @@ import (
 
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
-	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/metrics"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/resources/node"
 )
@@ -51,7 +48,6 @@ func (c *controller) BackPopulate(key string) error {
 		return nil
 	}
 
-	defer metrics.RecordUWSOperationDuration("pod", time.Now())
 	pPod, err := c.podLister.Pods(pNamespace).Get(pName)
 	if err != nil {
 		if errors.IsNotFound(err) {


### PR DESCRIPTION
Signed-off-by: zhuangqh <zhuangqhc@gmail.com>

```
syncer_dws_operations_total{cluster="tenant1admin-e1e3e5-vc-sample-1",code="Error",resource="ConfigMap"} 3
syncer_dws_operations_total{cluster="tenant1admin-e1e3e5-vc-sample-1",code="Error",resource="Endpoints"} 3
syncer_dws_operations_total{cluster="tenant1admin-e1e3e5-vc-sample-1",code="Error",resource="Namespace"} 3
syncer_dws_operations_total{cluster="tenant1admin-e1e3e5-vc-sample-1",code="Error",resource="Node"} 3
syncer_dws_operations_total{cluster="tenant1admin-e1e3e5-vc-sample-1",code="Error",resource="Pod"} 4
syncer_dws_operations_total{cluster="tenant1admin-e1e3e5-vc-sample-1",code="Error",resource="Secret"} 3
syncer_dws_operations_total{cluster="tenant1admin-e1e3e5-vc-sample-1",code="Error",resource="Service"} 3
syncer_dws_operations_total{cluster="tenant1admin-e1e3e5-vc-sample-1",code="Error",resource="ServiceAccount"} 3
syncer_dws_operations_total{cluster="tenant1admin-e1e3e5-vc-sample-1",code="OK",resource="ConfigMap"} 1
syncer_dws_operations_total{cluster="tenant1admin-e1e3e5-vc-sample-1",code="OK",resource="Endpoints"} 1
syncer_dws_operations_total{cluster="tenant1admin-e1e3e5-vc-sample-1",code="OK",resource="Namespace"} 4
syncer_dws_operations_total{cluster="tenant1admin-e1e3e5-vc-sample-1",code="OK",resource="Node"} 10
syncer_dws_operations_total{cluster="tenant1admin-e1e3e5-vc-sample-1",code="OK",resource="Pod"} 9
syncer_dws_operations_total{cluster="tenant1admin-e1e3e5-vc-sample-1",code="OK",resource="Secret"} 29
syncer_dws_operations_total{cluster="tenant1admin-e1e3e5-vc-sample-1",code="OK",resource="Service"} 1
syncer_dws_operations_total{cluster="tenant1admin-e1e3e5-vc-sample-1",code="OK",resource="ServiceAccount"} 29
```