### PR TITLE
Set apiVersion and kind as required fields in hncconfig.spec.types

### DIFF
--- a/incubator/hnc/api/v1alpha1/hnc_config.go
+++ b/incubator/hnc/api/v1alpha1/hnc_config.go
@@ -54,9 +54,9 @@ const (
 // TypeSynchronizationSpec defines the desired synchronization state of a specific kind.
 type TypeSynchronizationSpec struct {
 	// API version of the kind defined below. This is used to unambiguously identifies the kind.
-	APIVersion string `json:"apiVersion,omitempty"`
+	APIVersion string `json:"apiVersion"`
 	// Kind to be configured.
-	Kind string `json:"kind,omitempty"`
+	Kind string `json:"kind"`
 	// Synchronization mode of the kind. If the field is empty, it will be treated
 	// as "propagate". An unsupported mode will be treated as "ignore".
 	// +optional
@@ -66,9 +66,9 @@ type TypeSynchronizationSpec struct {
 // TypeSynchronizationStatus defines the observed synchronization state of a specific kind.
 type TypeSynchronizationStatus struct {
 	// API version of the kind defined below. This is used to unambiguously identifies the kind.
-	APIVersion string `json:"apiVersion,omitempty"`
+	APIVersion string `json:"apiVersion"`
 	// Kind to be configured.
-	Kind string `json:"kind,omitempty"`
+	Kind string `json:"kind"`
 	// Mode describes the synchronization mode of the kind. Typically, it will be the same as the mode
 	// in the spec, except when the reconciler has fallen behind or when the mode is omitted from the
 	// spec and the default is chosen.

--- a/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
+++ b/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
@@ -54,6 +54,9 @@ spec:
                       empty, it will be treated as "propagate". An unsupported mode
                       will be treated as "ignore".
                     type: string
+                required:
+                - apiVersion
+                - kind
                 type: object
               type: array
           type: object
@@ -149,6 +152,9 @@ spec:
                       users.
                     minimum: 0
                     type: integer
+                required:
+                - apiVersion
+                - kind
                 type: object
               type: array
           type: object


### PR DESCRIPTION
apiVersion and kind fields in hncconfig.spec.types should never be
empty. It was a mistake to leave them omitempty. The current validating
webhook ensures the type generated from these two fields are valid,
therefore, empty fields are not allowed. Still we need to fix it in the
CRD.

Tested with the webhook disabled and it was still not allowed.