### PR TITLE
[VC] Remove tenant-controller from the demo, and use default NS

### DIFF
--- a/incubator/virtualcluster/config/sampleswithspec/virtualcluster_1_loadbalancer.yaml
+++ b/incubator/virtualcluster/config/sampleswithspec/virtualcluster_1_loadbalancer.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: vc-sample-1
-  namespace: tenant1admin
+  namespace: default
 spec:
   clusterDomain: cluster.local
   clusterVersionName: cv-sample-lb

--- a/incubator/virtualcluster/config/sampleswithspec/virtualcluster_1_nodeport.yaml
+++ b/incubator/virtualcluster/config/sampleswithspec/virtualcluster_1_nodeport.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: vc-sample-1
-  namespace: tenant1admin
+  namespace: default
 spec:
   clusterDomain: cluster.local
   clusterVersionName: cv-sample-np

--- a/incubator/virtualcluster/doc/demo.md
+++ b/incubator/virtualcluster/doc/demo.md
@@ -2,25 +2,8 @@
 
 This demo illustrates how to setup a virtualcluster in an existing `minikube` Kubernetes cluster.
 
-All virtualcluster related API resources (CRD, Secret, Configmap etc.) are created in a
-tenant admin namespace. The tenant admin namespace can be created using the
-[Tenant CRD](https://sigs.k8s.io/multi-tenancy/tenant/pkg/apis/tenancy/v1alpha1/tenant_types.go),
-or created manually.
-If the Tenant CRD is desired, one can follow the [instructions](https://sigs.k8s.io/multi-tenancy/tenant)
-to install it. We repeat some of the steps in this demo.
- 
-## Create tenant admin namespace
-First, we install all tenant CRDs and the tenant controller manager.
-```bash
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/tenant/config/crds/tenancy_v1alpha1_tenant.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/tenant/config/crds/tenancy_v1alpha1_tenantnamespace.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/tenant/config/manager/all_in_one.yaml
-```
-
-Then we create a tenant CR, a tenant admin namespace `tenant1admin` will be created.
-```bash
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/tenant/config/samples/tenancy_v1alpha1_tenant.yaml
-```
+All virtualcluster related API resources (CRD, Secret, Configmap etc.) are created in an
+"admin namespace" for the rest of this demo we'll use the `default` namespace.
 
 ## Build `vcctl`
 It is recommended to use `vcctl` cli tool to simplify some operations.


### PR DESCRIPTION
While the tenant controller is really useful it's an additional component that isn't technically necessary for using `virtualcluster`. This PR removes the steps to setup the `tenant1admin` namespace from the demo doc making it easier to get up and running.

Signed-off-by: Chris Hein <me@chrishein.com>