### PR TITLE
[VC] replace GOBIN with GOPATH/bin

### DIFF
--- a/incubator/virtualcluster/Makefile
+++ b/incubator/virtualcluster/Makefile
@@ -125,7 +125,7 @@ ifeq (, $(shell which controller-gen))
 	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
-CONTROLLER_GEN=$(GOBIN)/controller-gen
+CONTROLLER_GEN=$(GOPATH)/bin/controller-gen
 else
 CONTROLLER_GEN=$(shell which controller-gen)
 endif


### PR DESCRIPTION
As user may not set $GOBIN, `make manifests` may fail. This PR replaces $GOBIN with $GOPATH/bin in the Makefile.