### PR TITLE
[VC]: Adding ClusterNamespace to VC.Status

### DIFF
--- a/incubator/virtualcluster/config/crds/tenancy.x-k8s.io_virtualclusters.yaml
+++ b/incubator/virtualcluster/config/crds/tenancy.x-k8s.io_virtualclusters.yaml
@@ -50,6 +50,8 @@ spec:
           type: object
         status:
           properties:
+            clusterNamespace:
+              type: string
             conditions:
               items:
                 properties:

--- a/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1/virtualcluster_types.go
+++ b/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1/virtualcluster_types.go
@@ -58,6 +58,11 @@ type VirtualClusterStatus struct {
 	// cluster phase of the virtual cluster
 	Phase ClusterPhase `json:"phase"`
 
+	// ClusterNamespace defines the namespace where the control plane components
+	// are deployed into.
+	// +optional
+	ClusterNamespace string `json:"clusterNamespace,omitempty"`
+
 	// A human readable message indicating details about why the cluster is in
 	// this condition.
 	// +optional

--- a/incubator/virtualcluster/pkg/controller/util/kube/util.go
+++ b/incubator/virtualcluster/pkg/controller/util/kube/util.go
@@ -161,6 +161,8 @@ func RetryUpdateVCStatusOnConflict(ctx context.Context, cli client.Client, vc *t
 
 // SetVCStatus set the virtualcluster 'vc' status, and append the new status to conditions list
 func SetVCStatus(vc *tenancyv1alpha1.VirtualCluster, phase tenancyv1alpha1.ClusterPhase, message, reason string) {
+	nsName := conversion.ToClusterKey(vc)
+	vc.Status.ClusterNamespace = nsName
 	vc.Status.Phase = phase
 	vc.Status.Message = message
 	vc.Status.Reason = reason


### PR DESCRIPTION
Currently, to get the namespace for the control plane components you need to load all ns and either grep for the right one, pull this from the logs or load the conversion package and run the same code, this make VC's code base a dependency of any controller using the VC object.

This PR adds a typed `.status.clusterNamespace` to get the namespace where control planes are deployed into.

Signed-off-by: Chris Hein <me@chrishein.com>