### PR TITLE
Fix the error in e2e test due to the prefix change

### DIFF
--- a/incubator/hnc/e2e/tests/namespace_test.go
+++ b/incubator/hnc/e2e/tests/namespace_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Namespace", func() {
 		Expect(cmd.Run()).Should(BeNil())
 
 		// Set "b" as a child of "a"
-		cmd = exec.Command("kubectl", "hns", "set", "b", "--parent", "a")
+		cmd = exec.Command("kubectl", "hns", "set", prefix+"b", "--parent", prefix+"a")
 		Expect(cmd.Run()).Should(BeNil())
 
 		// Delete the created namespace "a"
@@ -53,7 +53,7 @@ var _ = Describe("Namespace", func() {
 
 		// "b" should have 'CritParentMissing' condition. The command to use:
 		// kubectl get hierarchyconfigurations.hnc.x-k8s.io hierarchy -n b -o jsonpath='{.status.conditions..code}'
-		out, err := exec.Command("kubectl","get","hierarchyconfigurations.hnc.x-k8s.io","hierarchy","-n","b","-o", "jsonpath='{.status.conditions..code}'").Output()
+		out, err := exec.Command("kubectl","get","hierarchyconfigurations.hnc.x-k8s.io","hierarchy","-n",prefix+"b","-o", "jsonpath='{.status.conditions..code}'").Output()
 		// Convert []byte to string and remove the quotes to get the condition value.
 		condition := string(out)[1:len(out)-1]
 		Expect(err).Should(BeNil())


### PR DESCRIPTION
The prefix on test namespace was missing so the test was failing.

Tested by running:
     make kind-reset
     make kind-deploy
     k delete validatingwebhookconfigurations.admissionregistration.k8s.io hnc-validating-webhook-configuration
     go test ./e2e/...
All the e2e test passed now. 
Part of #785 