### PR TITLE
Allow finalizers to be removed when deleting CRDs

### DIFF
--- a/incubator/hnc/api/v1alpha1/hierarchy_types.go
+++ b/incubator/hnc/api/v1alpha1/hierarchy_types.go
@@ -48,6 +48,7 @@ const (
 	CannotUpdate              Code = "CannotUpdateObject"
 	CritAncestor              Code = "CritAncestor"
 	CritCycle                 Code = "CritCycle"
+	CritDeletingCRD           Code = "CritDeletingCRD"
 	CritParentMissing         Code = "CritParentMissing"
 	SubnamespaceAnchorMissing Code = "SubnamespaceAnchorMissing"
 )
@@ -57,6 +58,7 @@ var AllCodes = []Code{
 	CannotUpdate,
 	CritAncestor,
 	CritCycle,
+	CritDeletingCRD,
 	CritParentMissing,
 	SubnamespaceAnchorMissing,
 }
@@ -165,6 +167,10 @@ type Condition struct {
 	// parent is namespace A, but namespace A says that its parent is namespace B, then A and B are in
 	// a cycle with each other and both of them will have the CritCycle condition.
 	//
+	// - "CritDeletingCRD": The HierarchyConfiguration CRD is being deleted. No more objects will be
+	// propagated into or out of this namespace. It is expected that the HNC controller will be
+	// stopped soon after the CRDs are fully deleted.
+	//
 	// - "CritAncestor": a critical error exists in an ancestor namespace, so this namespace is no
 	// longer being updated either.
 	//
@@ -269,9 +275,10 @@ func init() {
 	SchemeBuilder.Register(&HierarchyConfiguration{}, &HierarchyConfigurationList{})
 	ClearConditionCriteria = map[Code]ClearConditionCriterion{
 		// All conditions on namespaces are set/cleared manually by the HCR
-		CritParentMissing:         CCCManual,
-		CritCycle:                 CCCManual,
 		CritAncestor:              CCCManual,
+		CritCycle:                 CCCManual,
+		CritDeletingCRD:           CCCManual,
+		CritParentMissing:         CCCManual,
 		SubnamespaceAnchorMissing: CCCManual,
 
 		// A source object can cause the CannotPropagate condition in two ways: if it cannot be

--- a/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hierarchyconfigurations.yaml
+++ b/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hierarchyconfigurations.yaml
@@ -99,12 +99,15 @@ spec:
                       example, if namespace B says that its parent is namespace A,
                       but namespace A says that its parent is namespace B, then A
                       and B are in a cycle with each other and both of them will have
-                      the CritCycle condition. \n - \"CritAncestor\": a critical error
-                      exists in an ancestor namespace, so this namespace is no longer
-                      being updated either. \n - \"SubnamespaceAnchorMissing\": this
-                      namespace is a subnamespace, but the anchor referenced in its
-                      `subnamespaceOf` annotation does not exist in the parent. \n
-                      - \"CannotPropagateObject\": this namespace contains an object
+                      the CritCycle condition. \n - \"CritDeletingCRD\": The HierarchyConfiguration
+                      CRD is being deleted. No more objects will be propagated into
+                      or out of this namespace. It is expected that the HNC controller
+                      will be stopped soon after the CRDs are fully deleted. \n -
+                      \"CritAncestor\": a critical error exists in an ancestor namespace,
+                      so this namespace is no longer being updated either. \n - \"SubnamespaceAnchorMissing\":
+                      this namespace is a subnamespace, but the anchor referenced
+                      in its `subnamespaceOf` annotation does not exist in the parent.
+                      \n - \"CannotPropagateObject\": this namespace contains an object
                       that couldn't be propagated *out* of this namespace, to one
                       or more of this namespace's descendants. If the object couldn't
                       be propagated to *any* descendants - for example, because it

--- a/incubator/hnc/hack/test-delete-hc-and-anchor-crd.sh
+++ b/incubator/hnc/hack/test-delete-hc-and-anchor-crd.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# see https://github.com/kubernetes-sigs/multi-tenancy/issues/824
+
+echo "THIS TEST WILL DELETE CRITICAL PARTS OF HNC. DO NOT RUN UNLESS YOU KNOW WHAT YOU'RE DOING"
+echo "You have five seconds to turn back!"
+sleep 5
+
+
+echo "-------------------------------------------------------"
+echo "Cleaning up from the last run. This may cause errors"
+
+p=delete-hc-anchor-crd-parent
+c=delete-hc-anchor-crd-child
+
+kubectl hns set -a $p
+sleep 1
+kubectl delete ns $p
+
+# Fail on any error from here on in.
+set -e
+
+echo "-------------------------------------------------------"
+echo "Creating parent and child"
+
+p=delete-hc-anchor-crd-parent
+c=delete-hc-anchor-crd-child
+
+kubectl create ns $p
+kubectl hns create $c -n $p
+
+echo "-------------------------------------------------------"
+echo "Delete the HC CRD, then wait 1s, then delete the anchor CRD. HNC IS NOW IN A BAD STATE AND MUST BE REINSTALLED"
+
+kubectl delete crd hierarchyconfigurations.hnc.x-k8s.io &
+sleep 1
+kubectl delete crd subnamespaceanchors.hnc.x-k8s.io &
+kubectl delete crd hncconfigurations.hnc.x-k8s.io &
+
+echo "-------------------------------------------------------"
+echo "Sleeping for 10s to give HNC the chance to fully delete everything (5s wasn't enough)"
+
+sleep 10
+
+echo "-------------------------------------------------------"
+echo "Verify that the HNC CRDs are gone (if nothing's printed, then they are)"
+
+kubectl get crd | grep hnc


### PR DESCRIPTION
See #824. When the CRDs are being deleted, we need to continue
reconciling the CRs until they're gone in order to ensure that any
finalizers on the CRs are removed.

Tested: new test script usually fails without this fix, but reliably
passes with it. Observed the new log messages working as expected while
running the script. For subnamespace anchors, tried removing the
CRD-checking code entirely and verified that
hack/test-delete-anchor-crd.sh failed, and then replaced it with the
current code (the shared isDeletingCRD function) and verified that it
passed again.

Fixes #824 