### PR TITLE
Move manager args to config/manager

### DIFF
--- a/incubator/hnc/config/default/manager_auth_proxy_patch.yaml
+++ b/incubator/hnc/config/default/manager_auth_proxy_patch.yaml
@@ -1,5 +1,13 @@
 # This patch inject a sidecar container which is a HTTP proxy for the controller manager,
 # it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+#
+# Without this patch, as long as NetworkPolicies doesn't forbid access to the
+# manager, any service on the cluster could read its metrics. With this patch,
+# we verify that the caller has permission to access the /metrics endpoints,
+# using the Kubernetes Service Account token that should already be embedded in
+# the `Authorization` HTTP header. See
+# https://brancz.com/2018/02/27/using-kube-rbac-proxy-to-secure-kubernetes-workloads/
+# for more details.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8,28 +16,17 @@ metadata:
 spec:
   template:
     spec:
-      securityContext:
-        # Generally to run as non root, the GID and UID can be any number between
-        # 1 to 65535 except for root, which is 0. If PodSecurityPolicy (PSP) is
-        # enabled, adjust the GID and UID to meet the specific requirement in PSP.
-        fsGroup: 2000
-        runAsNonRoot: true
-        runAsUser: 1000
       containers:
       - name: kube-rbac-proxy
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.0
         args:
-        - "--secure-listen-address=0.0.0.0:8443"
+        # The value of --upstream must match the value of --metrics-addr passed
+        # to the manager binary in the base config in
+        # ./config/manager/manager.yaml.
         - "--upstream=http://127.0.0.1:8080/"
+        - "--secure-listen-address=0.0.0.0:8443"
         - "--logtostderr=true"
         - "--v=10"
         ports:
         - containerPort: 8443
           name: https
-      - name: manager
-        args:
-        - "--webhook-server-port=9443"
-        - "--metrics-addr=127.0.0.1:8080"
-        - "--max-reconciles=10"
-        - "--apiserver-qps-throttle=50"
-        - "--enable-internal-cert-management=true"

--- a/incubator/hnc/config/manager/manager.yaml
+++ b/incubator/hnc/config/manager/manager.yaml
@@ -22,10 +22,27 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      securityContext:
+        # Generally to run as non-root, the GID and UID can be any number
+        # between 1 to 65535 (root is 0). These numbers were chosen
+        # arbitrarily; HNC can work with any value of fsGroup and runAsUser, so
+        # if your pod security policies (PSPs) require something different,
+        # feel free to modify these numbers.
+        fsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
       - command:
         - /manager
-        args: {} # overridden if manager_auth_proxy_patch.yaml is used
+        args:
+        - "--webhook-server-port=9443"
+        # If /config/default/manager_auth_proxy_patch.yaml is used,
+        # --metrics-addr must match the value of --upstream passed to
+        # kube-rbac-proxy.
+        - "--metrics-addr=127.0.0.1:8080"
+        - "--max-reconciles=10"
+        - "--apiserver-qps-throttle=50"
+        - "--enable-internal-cert-management=true"
         image: controller:latest
         name: manager
         resources:


### PR DESCRIPTION
The auth proxy patch used to add the address for the metrics server,
which meant that the patch used to have to include _all_ the args
(kustomize can't modify a single item in a list, it can only replace the
entire list). However, it doesn't hurt us to pass the metrics address in
the base config for the manager (we're passing in the default value
anyway) and it makes the configs much nicer to _only_ have the auth
proxy config in the auth proxy patch.

Also added a variety of comments.

Tested: verified that other than reordering a few lines, the generated
hnc-manager.yaml manifest file is identical before and after this
change.