### PR TITLE
Restart the pod if certs change

### DIFF
--- a/incubator/hnc/config/manager/manager.yaml
+++ b/incubator/hnc/config/manager/manager.yaml
@@ -42,7 +42,8 @@ spec:
         - "--metrics-addr=127.0.0.1:8080"
         - "--max-reconciles=10"
         - "--apiserver-qps-throttle=50"
-        - "--enable-internal-cert-management=true"
+        - "--enable-internal-cert-management"
+        - "--cert-restart-on-secret-refresh"
         image: controller:latest
         name: manager
         resources:


### PR DESCRIPTION
See #765. If a mounted secret changes _after_ a pod is started, it can
take a fairly long time (~60s) for the kubelet to notice the change and
project the new secret to the pod. Since our internal cert manager
writes a secret but then needs to wait for it to become available as a
file, this leads to a poor onboarding experience with HNC.

This change introduces a flag that exits the process as soon as the
internal cert manager changes a secret, which should only occur on
initial installation of HNC or every ten years (!). The restart time
takes <5s so this is overall a much better experience.

Tested: without changing the flags in the default manifest, observed no
change when HNC is installed for the first time (i.e. from the first log
message to when the HNCConfiguration is first reconciled takes 103s, and
there are no restarts). When the flag is added, the startup time
decreases to 10s with the one expected restart. Further restarts of HNC
(e.g. deleting and recreating the deployment but not the secret) does
not result in a restart and completes in 4s.

Fixes #765