### PR TITLE
Use CRD validation to enforce singletons

### DIFF
--- a/incubator/hnc/api/v1alpha1/hnc_config.go
+++ b/incubator/hnc/api/v1alpha1/hnc_config.go
@@ -46,7 +46,6 @@ const (
 // HNCConfigurationCondition codes. *All* codes must also be documented in the
 // comment to HNCConfigurationCondition.Code.
 const (
-	CritSingletonNameInvalid         HNCConfigurationCode = "CritSingletonNameInvalid"
 	ObjectReconcilerCreationFailed   HNCConfigurationCode = "ObjectReconcilerCreationFailed"
 	MultipleConfigurationsForOneType HNCConfigurationCode = "MultipleConfigurationsForOneType"
 )
@@ -148,16 +147,10 @@ type HNCConfigurationCondition struct {
 	// shown below, but new values may be added over time. This field is always present in a
 	// condition.
 	//
-	// All codes that begin with the prefix `crit` indicate that reconciliation has
-	// been paused for this configuration. Future changes of the configuration will be
-	// ignored by HNC until the condition has been resolved. Non-critical conditions
-	// typically indicate some kinds of error that HNC itself can ignore. However,
+	// Conditions typically indicate some kinds of error that HNC itself can ignore. However,
 	// the behaviors of some types might be out-of-sync with the users' expectations.
 	//
 	// Currently, the supported values are:
-	//
-	// - "critSingletonNameInvalid": the specified singleton name is invalid. The name should be the
-	// same as HNCConfigSingleton.
 	//
 	// - "objectReconcilerCreationFailed": an error exists when creating the object
 	// reconciler for the type specified in Msg.

--- a/incubator/hnc/config/crd/kustomization.yaml
+++ b/incubator/hnc/config/crd/kustomization.yaml
@@ -18,6 +18,10 @@ patchesStrategicMerge:
 #- patches/cainjection_in_hierarchies.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
+# Add CRD validation to enforce singleton.
+- patches/singleton_validation_hncconfiguration.yaml
+- patches/singleton_validation_hierarchyconfiguration.yaml
+
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
 - kustomizeconfig.yaml

--- a/incubator/hnc/config/crd/patches/singleton_validation_hierarchyconfiguration.yaml
+++ b/incubator/hnc/config/crd/patches/singleton_validation_hierarchyconfiguration.yaml
@@ -1,0 +1,15 @@
+# The following patch adds a singleton name validation to the CRD.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: hierarchyconfigurations.hnc.x-k8s.io
+spec:
+  validation:
+    openAPIV3Schema:
+      properties:
+        metadata:
+          type: object
+          properties:
+            name:
+              type: string
+              pattern: '^hierarchy$'

--- a/incubator/hnc/config/crd/patches/singleton_validation_hncconfiguration.yaml
+++ b/incubator/hnc/config/crd/patches/singleton_validation_hncconfiguration.yaml
@@ -1,0 +1,15 @@
+# The following patch adds a singleton name validation to the CRD.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: hncconfigurations.hnc.x-k8s.io
+spec:
+  validation:
+    openAPIV3Schema:
+      properties:
+        metadata:
+          type: object
+          properties:
+            name:
+              type: string
+              pattern: '^config$'

--- a/incubator/hnc/internal/reconcilers/hnc_config.go
+++ b/incubator/hnc/internal/reconcilers/hnc_config.go
@@ -71,13 +71,6 @@ const checkPeriod = 3 * time.Second
 func (r *ConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
 
-	// Validate the singleton name, and early exit if we're not validating the real one (note that the
-	// bad singleton will have a condition set, but the main one will not be affected).
-	if ok, err := r.validateSingletonName(ctx, req.NamespacedName.Name); !ok || err != nil {
-		r.Log.Error(err, "An incorrectly-named HNC Config exists", "name", req.NamespacedName.Name)
-		return ctrl.Result{}, err
-	}
-
 	// Load the config and clear its conditions so they can be reset.
 	inst, err := r.getSingleton(ctx)
 	if err != nil {
@@ -364,33 +357,6 @@ func (r *ConfigReconciler) writeObjectReconcilerCreationFailedCondition(inst *ap
 		Msg:  fmt.Sprintf("Couldn't create ObjectReconciler for type %s: %s", gvk, err),
 	}
 	inst.Status.Conditions = append(inst.Status.Conditions, condition)
-}
-
-// validateSingletonName tries to ensure we only have a single HNC Config object in the cluster. It
-// returns true if the singleton name is correct, and false if there's a bad copy (in which case,
-// the rest of the reconciler is skipped).
-func (r *ConfigReconciler) validateSingletonName(ctx context.Context, nm string) (bool, error) {
-	// If the name is expected, no problem.
-	if nm == api.HNCConfigSingleton {
-		return true, nil
-	}
-
-	// Otherwise, let's update whatever's in this wayward copy by setting a critical condition on it.
-	nnm := types.NamespacedName{Name: nm}
-	inst := &api.HNCConfiguration{}
-	if err := r.Get(ctx, nnm, inst); err != nil {
-		return false, err
-	}
-
-	msg := "Singleton name is wrong. It should be 'config'"
-	condition := api.HNCConfigurationCondition{
-		Code: api.CritSingletonNameInvalid,
-		Msg:  msg,
-	}
-	inst.Status.Conditions = nil
-	inst.Status.Conditions = append(inst.Status.Conditions, condition)
-
-	return false, r.writeSingleton(ctx, inst)
 }
 
 // setTypeStatuses adds Status.Types for types configured in the spec. Only the status of

--- a/incubator/hnc/internal/reconcilers/hnc_config_test.go
+++ b/incubator/hnc/internal/reconcilers/hnc_config_test.go
@@ -111,17 +111,6 @@ var _ = Describe("HNCConfiguration", func() {
 		Eventually(typeSpecHasMode(ctx, rbacAV, "Role")).Should(Equal(api.Propagate))
 	})
 
-	It("should set CritSingletonNameInvalid condition if singleton name is wrong", func() {
-		nm := "wrong-config-1"
-		Eventually(func() error {
-			config := &api.HNCConfiguration{}
-			config.ObjectMeta.Name = nm
-			return updateHNCConfig(ctx, config)
-		}).Should(Succeed())
-
-		Eventually(hasHNCConfigurationConditionWithName(ctx, api.CritSingletonNameInvalid, nm)).Should(BeTrue())
-	})
-
 	It("should unset ObjectReconcilerCreationFailed condition if a bad type spec is removed", func() {
 		// API version of ConfigMap should be "v1"
 		addToHNCConfig(ctx, "v2", "ConfigMap", api.Propagate)

--- a/incubator/hnc/internal/validators/hncconfig_test.go
+++ b/incubator/hnc/internal/validators/hncconfig_test.go
@@ -19,7 +19,7 @@ func TestDeletingConfigObject(t *testing.T) {
 		req := admission.Request{
 			AdmissionRequest: v1beta1.AdmissionRequest{
 				Operation: v1beta1.Delete,
-				Name:      "config",
+				Name:      api.HNCConfigSingleton,
 			}}
 		config := &HNCConfig{}
 
@@ -44,24 +44,6 @@ func TestDeletingOtherObject(t *testing.T) {
 
 		logResult(t, got.AdmissionResponse.Result)
 		g.Expect(got.AdmissionResponse.Allowed).Should(BeTrue())
-	})
-}
-
-func TestInvalidName(t *testing.T) {
-	t.Run("Invalid config name", func(t *testing.T) {
-		g := NewGomegaWithT(t)
-		c := &api.HNCConfiguration{Spec: api.HNCConfigurationSpec{Types: []api.TypeSynchronizationSpec{
-			{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
-			{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "propagate"},
-		}}}
-		// Name should be "config"
-		c.Name = "invalid-name"
-		config := &HNCConfig{}
-
-		got := config.handle(context.Background(), c)
-
-		logResult(t, got.AdmissionResponse.Result)
-		g.Expect(got.AdmissionResponse.Allowed).Should(BeFalse())
 	})
 }
 
@@ -139,7 +121,7 @@ func TestRBACTypes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 			c := &api.HNCConfiguration{Spec: api.HNCConfigurationSpec{Types: tc.configs}}
-			c.Name = "config"
+			c.Name = api.HNCConfigSingleton
 
 			got := config.handle(context.Background(), c)
 
@@ -215,7 +197,7 @@ func TestNonRBACTypes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 			c := &api.HNCConfiguration{Spec: api.HNCConfigurationSpec{Types: tc.configs}}
-			c.Name = "config"
+			c.Name = api.HNCConfigSingleton
 			config := &HNCConfig{validator: tc.validator}
 
 			got := config.handle(context.Background(), c)


### PR DESCRIPTION
Add CRD validation kustomization patchs to HierarchyConfiguration and
HNCConfiguration CRDs to validate the metadata.name to be the singleton.

Remove the "CritSingletonNameInvalid" condition and remove the
validating and condition setting code in the HNCConfig reconciler.
HNCConfig reconiler only reconciles the 'config' singleton. The
validation here is only to set the condition so it's safe to remove.

Remove the validating webhook on HNCConfig resource name too. There's no
need to keep the validating webhook as a second layer of protection
because the server-side validation is more reliable than webhooks since
webhooks can be disabled or bypassed if not running.

This change is also backward compatible since the old bad HNCConfig
resource will still have the obsolete condition on it. HNCConfig
reconciler won't touch it.

Tested on kind and GKE 1.14 cluster. New HC or HNCConfig with bad
names cannot be created with the server-side validation. An old
HNCConfig with bad name created before introducing the CRD validation
when the webhook was also disabled can still be deleted now. There was
still an obsolete "CritSingletonNameInvalid" condition on it.

Fixes #831 