### PR TITLE
Add timer for webhook server to get ready before test

### DIFF
--- a/incubator/hnc/Makefile
+++ b/incubator/hnc/Makefile
@@ -182,13 +182,20 @@ kind-deploy:
 	CONFIG=kind $(MAKE) deploy
 
 ###################### E2E TEST #########################
-
+# Sleep time is added for the webhook to get ready before test. The time 
+# comes from watching the log as well as multiple experiments. 
 .PHONY: e2e-test
 e2e-test: deploy
+	go clean -testcache
+	sleep 15
 	go test ./e2e/...
 
+# The sleep time needed for kind cluster is longer than that for a real 
+# cluster, from the experiments. I don't know why - @GinnyJI, July 2020
 .PHONY: local-e2e-test
 local-e2e-test: kind-deploy
+	go clean -testcache
+	sleep 20
 	go test ./e2e/...
 
 ###################### RELEASE ACTIONS #########################


### PR DESCRIPTION
Add a timer between deploy and go test to give webhook server enough
time to get ready. This change also invalidates the cached test results
before running the e2e test. Without 'go clean -testcache' it will always 
output the cached test result instead of the real one.

Tested:
On a real cluster, run:
    kubectl delete -f manifests/hnc-manager.yaml
    make e2e-test
On kind, run:
    make kind-reset
    make local-e2e-test

Fix #825