### PR TITLE
Prevent deletion of propagated objects

### DIFF
--- a/incubator/hnc/config/webhook/manifests.yaml
+++ b/incubator/hnc/config/webhook/manifests.yaml
@@ -96,5 +96,6 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - '*'

--- a/incubator/hnc/internal/validators/object_test.go
+++ b/incubator/hnc/internal/validators/object_test.go
@@ -18,10 +18,10 @@ import (
 	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/reconcilers"
 )
 
-// TestType only tests the types from the admission requests. There is no object in the
-// admission requests for all the test cases. The requests are supposed to fail with
-// "BadRequest" since the object cannot be decoded. However, with early exit for
-// non-propagate-mode types, they should return "allow" before the object gets decoded.
+// TestEarlyExit tests requests that, without an early exit, would *definitely* be denied because
+// they don't include any actual objects to validate. The only way these tests can pass is if we
+// never actually try to decode the object - that is, we do a very early exit because HNC isn't
+// supposed to look at these objects in the first place.
 func TestType(t *testing.T) {
 	or := &reconcilers.ObjectReconciler{
 		GVK:  schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"},
@@ -36,6 +36,7 @@ func TestType(t *testing.T) {
 		name    string
 		version string
 		kind    string
+		ns      string
 		deny    bool
 	}{{
 		name:    "Deny request with GroupVersionKind in the propagate mode",
@@ -50,19 +51,32 @@ func TestType(t *testing.T) {
 	}, {
 		name: "Always allow request with GroupKind not in propagate mode",
 		kind: "Configmap",
+	}, {
+		name:    "Allow request in excluded namespace",
+		version: "v1",
+		kind:    "Secret",
+		ns:      "kube-system",
 	}}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup
 			g := NewGomegaWithT(t)
-			req := admission.Request{AdmissionRequest: admissionv1beta1.AdmissionRequest{Kind: metav1.GroupVersionKind{Group: "", Version: tc.version, Kind: tc.kind}}}
+			if tc.ns == "" {
+				tc.ns = "default"
+			}
+			req := admission.Request{AdmissionRequest: admissionv1beta1.AdmissionRequest{
+				Name:      "foo",
+				Namespace: tc.ns,
+				Kind:      metav1.GroupVersionKind{Version: tc.version, Kind: tc.kind},
+			}}
 			// Test
 			got := o.Handle(context.Background(), req)
 			// Report
-			reason := got.AdmissionResponse.Result.Reason
 			code := got.AdmissionResponse.Result.Code
-			t.Logf("Got reason %q, code %d", reason, code)
+			reason := got.AdmissionResponse.Result.Reason
+			msg := got.AdmissionResponse.Result.Message
+			t.Logf("Got code %d, reason %q, message %q", code, reason, msg)
 			g.Expect(got.AdmissionResponse.Allowed).ShouldNot(Equal(tc.deny))
 		})
 	}
@@ -102,13 +116,7 @@ func TestInheritedFromLabel(t *testing.T) {
 		name:     "Label is added",
 		newLabel: api.LabelInheritedFrom, newValue: "foo",
 		fail: true,
-	}, {
-		name:     "Objects in excluded namespace is ignored",
-		oldLabel: api.LabelInheritedFrom, oldValue: "foo",
-		newLabel: api.LabelInheritedFrom, newValue: "bar",
-		namespace: "hnc-system",
-	},
-	}
+	}}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -121,12 +129,13 @@ func TestInheritedFromLabel(t *testing.T) {
 			metadata.SetLabel(inst, tc.newLabel, tc.newValue)
 
 			// Test
-			got := o.handle(context.Background(), l, inst, oldInst)
+			got := o.handle(context.Background(), l, admissionv1beta1.Update, inst, oldInst)
 
 			// Report
-			reason := got.AdmissionResponse.Result.Reason
 			code := got.AdmissionResponse.Result.Code
-			t.Logf("Got reason %q, code %d", reason, code)
+			reason := got.AdmissionResponse.Result.Reason
+			msg := got.AdmissionResponse.Result.Message
+			t.Logf("Got code %d, reason %q, message %q", code, reason, msg)
 			g.Expect(got.AdmissionResponse.Allowed).ShouldNot(Equal(tc.fail))
 		})
 	}
@@ -254,18 +263,71 @@ func TestUserChanges(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		name: "Allow deletions of source objects",
+		oldInst: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+			},
+		},
+	}, {
+		name: "Deny deletions of propagated objects",
+		fail: true,
+		oldInst: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{
+						api.LabelInheritedFrom: "foo",
+					},
+				},
+			},
+		},
+	}, {
+		name: "Allow creation of source objects",
+		inst: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+			},
+		},
+	}, {
+		name: "Deny creation of object with inheritedFrom label",
+		fail: true,
+		inst: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{
+						api.LabelInheritedFrom: "foo",
+					},
+				},
+			},
+		},
 	}}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup
 			g := NewGomegaWithT(t)
+			op := admissionv1beta1.Update
+			if tc.inst == nil {
+				op = admissionv1beta1.Delete
+				tc.inst = &unstructured.Unstructured{}
+			} else if tc.oldInst == nil {
+				op = admissionv1beta1.Create
+				tc.oldInst = &unstructured.Unstructured{}
+			}
 			// Test
-			got := o.handle(context.Background(), l, tc.inst, tc.oldInst)
+			got := o.handle(context.Background(), l, op, tc.inst, tc.oldInst)
 			// Report
-			reason := got.AdmissionResponse.Result.Reason
 			code := got.AdmissionResponse.Result.Code
-			t.Logf("Got reason %q, code %d", reason, code)
+			reason := got.AdmissionResponse.Result.Reason
+			msg := got.AdmissionResponse.Result.Message
+			t.Logf("Got code %d, reason %q, message %q", code, reason, msg)
 			g.Expect(got.AdmissionResponse.Allowed).ShouldNot(Equal(tc.fail))
 		})
 	}


### PR DESCRIPTION
Restructures the object validation controller to prevent deletions. Also
simplifiest the logic by explicitly checking the operation
(create/update/delete) that we're trying to validated.

Tested: new unit tests; tried a variety of legal and illegal
modifications on GKE 1.16 and confirmed that everything passed or failed
as expected in included namespaces, and that every change (including
illegal ones) pass in the excluded namespace `kube-system`. Confirmed
log messages are always printed out on failure while successes are never
printed.

Fixes #845