### PR TITLE
Makefile change

### DIFF
--- a/incubator/hnc/Makefile
+++ b/incubator/hnc/Makefile
@@ -182,13 +182,20 @@ kind-deploy:
 	CONFIG=kind $(MAKE) deploy
 
 ###################### E2E TEST #########################
-
+# Sleep time is added for the webhook to get ready before test. The time 
+# comes from watching the log as well as multiple experiments. 
 .PHONY: e2e-test
 e2e-test: deploy
+	go clean -testcache
+	sleep 15
 	go test ./e2e/...
 
+# The sleep time needed for kind cluster is longer than that for a real 
+# cluster, from the experiments. I don't know why - @GinnyJI, July 2020
 .PHONY: local-e2e-test
 local-e2e-test: kind-deploy
+	go clean -testcache
+	sleep 20
 	go test ./e2e/...
 
 ###################### RELEASE ACTIONS #########################

--- a/incubator/hnc/Makefile
+++ b/incubator/hnc/Makefile
@@ -182,20 +182,16 @@ kind-deploy:
 	CONFIG=kind $(MAKE) deploy
 
 ###################### E2E TEST #########################
-# Sleep time is added for the webhook to get ready before test. The time 
-# comes from watching the log as well as multiple experiments. 
+# This test will run on the current cluster the user deployed (either kind or 
+# a kubernetes cluster). Please make sure to have the test cluster ready 
+# before running the test.
+
 .PHONY: e2e-test
-e2e-test: deploy
-	go clean -testcache
-	sleep 15
+e2e-test: 
 	go test ./e2e/...
 
-# The sleep time needed for kind cluster is longer than that for a real 
-# cluster, from the experiments. I don't know why - @GinnyJI, July 2020
 .PHONY: local-e2e-test
-local-e2e-test: kind-deploy
-	go clean -testcache
-	sleep 20
+local-e2e-test: 
 	go test ./e2e/...
 
 ###################### RELEASE ACTIONS #########################


### PR DESCRIPTION
The user should be responsible to have the test cluster ready before
running the E2E test. It could be either a kind cluster or a real k8s
cluster.

Tested:
    on a real cluster: make e2e-test
    on a kind cluster: make local-e2e-test