### PR TITLE
Allow subnamespace deletion if parent/anchor is missing

### DIFF
--- a/incubator/hnc/internal/forest/namespace.go
+++ b/incubator/hnc/internal/forest/namespace.go
@@ -142,6 +142,16 @@ func (ns *Namespace) SetAnchors(anchors []string) (diff []string) {
 	return
 }
 
+// HasAnchor returns true if the name exists in the anchor list.
+func (ns *Namespace) HasAnchor(n string) bool {
+	for _, a := range ns.Anchors {
+		if a == n {
+			return true
+		}
+	}
+	return false
+}
+
 // IsExternal returns true if the namespace is not managed by HNC.
 func (ns *Namespace) IsExternal() bool {
 	return len(ns.ExternalTreeLabels) > 0


### PR DESCRIPTION
Since we allow changes to the subnamespaceOf annotation on subnamespace
as an escape hatch and there's a scenario of recovering from CRD
deletion, this commit makes it easier to delete a subnamespace, but only
when the parent or the anchor is missing. If the anchor is ok (state),
we still don't allow direct deletion of a subnamespace and only allows
deletion from the anchor.

Tested with new unit test cases and manually before and after.

Fixes #847 