### PR TITLE
Restore webhook in e2e test from the current manifest

### DIFF
--- a/incubator/hnc/hack/test-issue-797-leaf.sh
+++ b/incubator/hnc/hack/test-issue-797-leaf.sh
@@ -11,6 +11,8 @@ kubectl create ns p1
 kubectl create ns p2
 sleep 1
 
+echo "${bold}Creating a copy of the webhook manifest at hnc_e2e_797_webhook.yaml...${normal}"
+kubectl get validatingwebhookconfigurations.admissionregistration.k8s.io hnc-validating-webhook-configuration -o yaml > hnc_e2e_797_webhook.yaml
 echo "${bold}Disabling webhook to generate the race condition...${normal}"
 kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io hnc-validating-webhook-configuration
 sleep 1
@@ -30,7 +32,9 @@ echo "${bold}subns (anchor) 'sub' in 'p2' should have 'status: conflict' because
 kubectl get subns sub -n p2 -o yaml
 
 echo "${bold}Enabling webhook again...${normal}"
-kubectl apply -f manifests/hnc-manager.yaml
+kubectl apply -f hnc_e2e_797_webhook.yaml
+echo "${bold}Deleting the webhook manifest hnc_e2e_797_webhook.yaml...${normal}"
+rm hnc_e2e_797_webhook.yaml
 
 echo "----------------------------------------------------"
 echo "${bold}Test-1:${normal} Remove subns (anchor) in the bad parent 'p2'"

--- a/incubator/hnc/hack/test-issue-797-non-leaf.sh
+++ b/incubator/hnc/hack/test-issue-797-non-leaf.sh
@@ -11,6 +11,8 @@ kubectl create ns p1
 kubectl create ns p2
 sleep 1
 
+echo "${bold}Creating a copy of the webhook manifest at hnc_e2e_797_webhook.yaml...${normal}"
+kubectl get validatingwebhookconfigurations.admissionregistration.k8s.io hnc-validating-webhook-configuration -o yaml > hnc_e2e_797_webhook.yaml
 echo "${bold}Disabling webhook to generate the race condition...${normal}"
 kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io hnc-validating-webhook-configuration
 sleep 1
@@ -34,7 +36,9 @@ kubectl hns create sub-sub -n sub
 sleep 1
 
 echo "${bold}Enabling webhook again...${normal}"
-kubectl apply -f manifests/hnc-manager.yaml
+kubectl apply -f hnc_e2e_797_webhook.yaml
+echo "${bold}Deleting the webhook manifest hnc_e2e_797_webhook.yaml...${normal}"
+rm hnc_e2e_797_webhook.yaml
 
 echo "----------------------------------------------------"
 echo "${bold}Test-1:${normal} Remove subns (anchor) in the bad parent 'p2'"


### PR DESCRIPTION
Remove the `kubectl apply -f manifests/hnc-manager.yaml` in the e2e
test as a way to restore webhook. Instead, output the webhook manifest
into a file and later apply this file to restore the webhook. This makes
sure the webhook is the one used in the current deployment when the e2e
test is run.

Tested by running the script and the generated yaml file is deleted
after each test.

Fixes #846 