### PR TITLE
Support using ClusterIP for the API Server service

### DIFF
--- a/incubator/virtualcluster/cmd/vcctl/subcmd/create.go
+++ b/incubator/virtualcluster/cmd/vcctl/subcmd/create.go
@@ -151,7 +151,8 @@ func createVirtualCluster(cli client.Client, vc *tenancyv1alpha1.VirtualCluster,
 	// fail early, if service type is not supported
 	svcType := cv.Spec.APIServer.Service.Spec.Type
 	if svcType != v1.ServiceTypeNodePort &&
-		svcType != v1.ServiceTypeLoadBalancer {
+		svcType != v1.ServiceTypeLoadBalancer &&
+		  svcType != v1.ServiceTypeClusterIP {
 		return fmt.Errorf("unsupported apiserver service type: %s", svcType)
 	}
 


### PR DESCRIPTION
Use ClusterIP in the kubeconfig if it exists
Allow ClusterIP service type in vcctl
Create the apiserver-svc ahead of time to add ClusterIP to PKI.