### PR TITLE
Add nodes/proxy to vn-agent RBAC

### DIFF
--- a/incubator/virtualcluster/config/setup/all_in_one.yaml
+++ b/incubator/virtualcluster/config/setup/all_in_one.yaml
@@ -350,6 +350,7 @@ rules:
   - pods/log
   - pods/exec
   - pods/portforward
+  - nodes/proxy
   verbs:
   - get
   - list


### PR DESCRIPTION
Without adding nodes/proxy, vn-agent cannot get/create proxy requets to the kubelet:
Error from server (Forbidden): Forbidden (user=vn-agent, verb=get, resource=nodes, subresource=proxy) ( pods/log net-tools)