### PR TITLE
[VC] setup e2e testing framework

### DIFF
--- a/incubator/virtualcluster/go.mod
+++ b/incubator/virtualcluster/go.mod
@@ -19,6 +19,7 @@ require (
 	golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 // indirect
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9
 	k8s.io/api v0.16.6
+	k8s.io/apiextensions-apiserver v0.16.6
 	k8s.io/apimachinery v0.16.6
 	k8s.io/apiserver v0.16.6
 	k8s.io/client-go v0.16.6

--- a/incubator/virtualcluster/go.mod
+++ b/incubator/virtualcluster/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.0
 	github.com/google/cadvisor v0.34.0
+	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.2

--- a/incubator/virtualcluster/go.sum
+++ b/incubator/virtualcluster/go.sum
@@ -316,6 +316,7 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
+github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible/go.mod h1:bB9ly3RchcQqsQ9CpyaQwvva7RS5ytVoSoholZQON6o=
 github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6/go.mod h1:xGMAM8JLi7UkZt1i4FQeQy0R2T8GLUwQhOP5M1gBhy4=
@@ -372,6 +373,7 @@ github.com/lucas-clemente/quic-go v0.10.2/go.mod h1:hvaRS9IHjFLMq76puFJeWNfmn+H7
 github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced/go.mod h1:NCcRLrOTZbzhZvixZLlERbJtDtYsmMw8Jc4vS8Z0g58=
 github.com/magiconair/properties v1.7.6/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329 h1:2gxZ0XQIU/5z3Z3bUBu+FXuk2pFbkN6tcwi/pjyaDic=
@@ -404,6 +406,7 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/go-ps v0.0.0-20170309133038-4fdf99ab2936/go.mod h1:r1VsdOzOPt1ZSrGZWFoNhsAedKnEd6r9Np1+5blZCWk=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/mapstructure v0.0.0-20180220230111-00c29f56e238/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
@@ -454,6 +457,7 @@ github.com/opencontainers/selinux v1.2.2/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOl
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.1.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -506,6 +510,7 @@ github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.2.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=
+github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.0-20180319062004-c439c4fa0937 h1:+ryWjMVzFAkEz5zT+Ms49aROZwxlJce3x3zLTFpkz3Y=
 github.com/spf13/cobra v0.0.0-20180319062004-c439c4fa0937/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
@@ -514,6 +519,7 @@ github.com/spf13/cobra v0.0.5 h1:f0B+LkLX6DtmRH1isoNA9VTtNUK9K8xYd28JNNfOv/s=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/jwalterweatherman v0.0.0-20180109140146-7c0cea34c8ec/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
+github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -522,6 +528,7 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.0.2/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
+github.com/spf13/viper v1.3.2 h1:VUFqw5KcqRf7i70GOzW7N+Q7+gxVBkSSqiXB12+JQ4M=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc/go.mod h1:ZrLn+e0ZuF3Y65PNF6dIwbJPZqfmtCXxFm9ckv0agOY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -807,6 +814,7 @@ k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf h1:EYm5AW/UUDbnmnI+gK0TJD
 k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
 k8s.io/kube-proxy v0.16.6/go.mod h1:l7jgZcYyjERYxALU/EizkMx/JmIhN2Ff/f/aR/azFKg=
 k8s.io/kube-scheduler v0.16.6/go.mod h1:ohT2kmuQnNex0cDUYvXBAdMKHlneruoD4KOacEDpPq4=
+k8s.io/kubectl v0.16.6 h1:u7bQl9F78+7wYcvBSX7JfnIotLIQfAVpN1E11m2s+3w=
 k8s.io/kubectl v0.16.6/go.mod h1:ybKdxxoYuQLRqsmBFylvgyFPeVmmRYUbxk134JCiNoM=
 k8s.io/kubelet v0.0.0-20200117002354-7275ea7ddf81/go.mod h1:brxzZtWMpAJyMQudCFd2v3go3zxOR5uztEojpwMgvcs=
 k8s.io/kubernetes v1.16.6 h1:ZWSNwxZ1w/IPV7pYH9gohR7AhKmn1VoJ9fEKxmkkeh8=

--- a/incubator/virtualcluster/pkg/syncer/constants/constants.go
+++ b/incubator/virtualcluster/pkg/syncer/constants/constants.go
@@ -96,6 +96,8 @@ const (
 	StatusCodeOK                     = "OK"
 	StatusCodeExceedMaxRetryAttempts = "ExceedMaxRetryAttempts"
 	StatusCodeError                  = "Error"
+
+	KubeconfigAdminSecretName = "admin-kubeconfig"
 )
 
 const (

--- a/incubator/virtualcluster/test/e2e/e2e.go
+++ b/incubator/virtualcluster/test/e2e/e2e.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog"
+	"k8s.io/kubernetes/test/e2e/framework/ginkgowrapper"
+
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/test/e2e/framework"
+)
+
+// Similar to SynchronizedBeforeSuite, we want to run some operations only once (such as collecting cluster logs).
+// Here, the order of functions is reversed; first, the function which runs everywhere,
+// and then the function that only runs on the first Ginkgo node.
+var _ = ginkgo.SynchronizedAfterSuite(func() {
+	// Run on all Ginkgo nodes
+	framework.Logf("Running AfterSuite actions on all nodes")
+	framework.RunCleanupActions()
+}, func() {
+	// Run only Ginkgo on node 1
+	framework.Logf("Running AfterSuite actions on node 1")
+})
+
+// RunE2ETests checks configuration parameters (specified through flags) and then runs
+// E2E tests using the Ginkgo runner.
+// If a "report directory" is specified, one or more JUnit test reports will be
+// generated in this directory, and cluster logs will also be saved.
+// This function is called on each Ginkgo node in parallel mode.
+func RunE2ETests(t *testing.T) {
+	runtime.ReallyCrash = true
+	//logs.InitLogs()
+	//defer logs.FlushLogs()
+
+	gomega.RegisterFailHandler(ginkgowrapper.Fail)
+	// Disable skipped tests unless they are explicitly requested.
+	if config.GinkgoConfig.FocusString == "" && config.GinkgoConfig.SkipString == "" {
+		config.GinkgoConfig.SkipString = `\[Flaky\]|\[Feature:.+\]`
+	}
+
+	// Run tests through the Ginkgo runner with output to console + JUnit for Jenkins
+	var r []ginkgo.Reporter
+	klog.Infof("Starting e2e run %q on Ginkgo node %d", framework.RunID, config.GinkgoConfig.ParallelNode)
+
+	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "Kubernetes e2e suite", r)
+}

--- a/incubator/virtualcluster/test/e2e/e2e_test.go
+++ b/incubator/virtualcluster/test/e2e/e2e_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"flag"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/kubernetes/scheme"
+
+	vcapis "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/apis"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/test/e2e/framework"
+)
+
+func TestMain(m *testing.M) {
+	// Register test flags, then parse flags.
+	framework.HandleFlags()
+
+	framework.AfterReadingAllFlags(&framework.TestContext)
+
+	rand.Seed(time.Now().UnixNano())
+	os.Exit(m.Run())
+}
+
+func TestE2E(t *testing.T) {
+	flag.Parse()
+	err := vcapis.AddToScheme(scheme.Scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	RunE2ETests(t)
+}

--- a/incubator/virtualcluster/test/e2e/e2e_test.go
+++ b/incubator/virtualcluster/test/e2e/e2e_test.go
@@ -24,6 +24,9 @@ import (
 
 	vcapis "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/apis"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/test/e2e/framework"
+
+	// test sources
+	_ "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/test/e2e/multi-tenancy"
 )
 
 func TestMain(m *testing.M) {

--- a/incubator/virtualcluster/test/e2e/framework/cleanup.go
+++ b/incubator/virtualcluster/test/e2e/framework/cleanup.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import "sync"
+
+// CleanupActionHandle is an integer pointer type for handling cleanup action
+type CleanupActionHandle *int
+
+var cleanupActionsLock sync.Mutex
+var cleanupActions = map[CleanupActionHandle]func(){}
+
+// AddCleanupAction installs a function that will be called in the event of the
+// whole test being terminated.  This allows arbitrary pieces of the overall
+// test to hook into SynchronizedAfterSuite().
+func AddCleanupAction(fn func()) CleanupActionHandle {
+	p := CleanupActionHandle(new(int))
+	cleanupActionsLock.Lock()
+	defer cleanupActionsLock.Unlock()
+	cleanupActions[p] = fn
+	return p
+}
+
+// RemoveCleanupAction removes a function that was installed by
+// AddCleanupAction.
+func RemoveCleanupAction(p CleanupActionHandle) {
+	cleanupActionsLock.Lock()
+	defer cleanupActionsLock.Unlock()
+	delete(cleanupActions, p)
+}
+
+// RunCleanupActions runs all functions installed by AddCleanupAction.  It does
+// not remove them (see RemoveCleanupAction) but it does run unlocked, so they
+// may remove themselves.
+func RunCleanupActions() {
+	list := []func(){}
+	func() {
+		cleanupActionsLock.Lock()
+		defer cleanupActionsLock.Unlock()
+		for _, fn := range cleanupActions {
+			list = append(list, fn)
+		}
+	}()
+	// Run unlocked.
+	for _, fn := range list {
+		fn()
+	}
+}

--- a/incubator/virtualcluster/test/e2e/framework/clusterversion/create.go
+++ b/incubator/virtualcluster/test/e2e/framework/clusterversion/create.go
@@ -1,0 +1,524 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterversion
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	vcclient "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/client/clientset/versioned"
+)
+
+var defaultClusterVersion = &v1alpha1.ClusterVersionSpec{
+	ETCD: &v1alpha1.StatefulSetSvcBundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "etcd",
+		},
+		StatefulSet: &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "etcd",
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas:             pointer.Int32Ptr(1),
+				RevisionHistoryLimit: pointer.Int32Ptr(10),
+				ServiceName:          "etcd",
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"component-name": "etcd",
+					},
+				},
+				UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+					Type: appsv1.OnDeleteStatefulSetStrategyType,
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"component-name": "etcd",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Subdomain: "etcd",
+						Containers: []corev1.Container{
+							{
+								Name:            "etcd",
+								Image:           "virtualcluster/etcd-v3.4.0",
+								ImagePullPolicy: corev1.PullAlways,
+								Command:         []string{"etcd"},
+								Env: []corev1.EnvVar{
+									{
+										Name: "HOSTNAME",
+										ValueFrom: &corev1.EnvVarSource{
+											FieldRef: &corev1.ObjectFieldSelector{
+												FieldPath: "metadata.name",
+											},
+										},
+									},
+								},
+								Args: []string{
+									"--name=$(HOSTNAME)",
+									"--trusted-ca-file=/etc/kubernetes/pki/root/tls.crt",
+									"--client-cert-auth",
+									"--cert-file=/etc/kubernetes/pki/etcd/tls.crt",
+									"--key-file=/etc/kubernetes/pki/etcd/tls.key",
+									"--peer-client-cert-auth",
+									"--peer-trusted-ca-file=/etc/kubernetes/pki/root/tls.crt",
+									"--peer-cert-file=/etc/kubernetes/pki/etcd/tls.crt",
+									"--peer-key-file=/etc/kubernetes/pki/etcd/tls.key",
+									"--listen-peer-urls=https://0.0.0.0:2380",
+									"--listen-client-urls=https://0.0.0.0:2379",
+									"--initial-advertise-peer-urls=https://$(HOSTNAME).etcd:2380",
+									"--advertise-client-urls=https://$(HOSTNAME).etcd:2379",
+									"--initial-cluster-state=new",
+									"--initial-cluster-token=vc-etcd",
+									"--data-dir=/var/lib/etcd/data",
+								},
+								LivenessProbe: &corev1.Probe{
+									Handler: corev1.Handler{
+										Exec: &corev1.ExecAction{
+											Command: []string{
+												"sh",
+												"-c",
+												"ETCDCTL_API=3 etcdctl --endpoints=https://etcd:2379 --cacert=/etc/kubernetes/pki/root/tls.crt --cert=/etc/kubernetes/pki/etcd/tls.crt --key=/etc/kubernetes/pki/etcd/tls.key endpoint health",
+											},
+										},
+									},
+									FailureThreshold:    8,
+									InitialDelaySeconds: 60,
+									TimeoutSeconds:      15,
+								},
+								ReadinessProbe: &corev1.Probe{
+									Handler: corev1.Handler{
+										Exec: &corev1.ExecAction{
+											Command: []string{
+												"sh",
+												"-c",
+												"ETCDCTL_API=3 etcdctl --endpoints=https://etcd:2379 --cacert=/etc/kubernetes/pki/root/tls.crt --cert=/etc/kubernetes/pki/etcd/tls.crt --key=/etc/kubernetes/pki/etcd/tls.key endpoint health",
+											},
+										},
+									},
+									FailureThreshold:    8,
+									InitialDelaySeconds: 15,
+									PeriodSeconds:       2,
+									TimeoutSeconds:      15,
+								},
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										MountPath: "/etc/kubernetes/pki/etcd",
+										Name:      "etcd-ca",
+										ReadOnly:  true,
+									},
+									{
+										MountPath: "/etc/kubernetes/pki/root",
+										Name:      "root-ca",
+										ReadOnly:  true,
+									},
+								},
+							},
+						},
+						Volumes: []corev1.Volume{
+							{
+								Name: "etcd-ca",
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										DefaultMode: pointer.Int32Ptr(420),
+										SecretName:  "etcd-ca",
+									},
+								},
+							},
+							{
+								Name: "root-ca",
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										DefaultMode: pointer.Int32Ptr(420),
+										SecretName:  "root-ca",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Status: appsv1.StatefulSetStatus{},
+		},
+		Service: &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "etcd",
+				Annotations: map[string]string{
+					"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Type:      corev1.ServiceTypeClusterIP,
+				ClusterIP: corev1.ClusterIPNone,
+				Selector: map[string]string{
+					"component-name": "etcd",
+				},
+			},
+		},
+	},
+	APIServer: &v1alpha1.StatefulSetSvcBundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "apiserver",
+		},
+		StatefulSet: &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "apiserver",
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas:             pointer.Int32Ptr(1),
+				RevisionHistoryLimit: pointer.Int32Ptr(10),
+				ServiceName:          "apiserver-svc",
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"component-name": "apiserver",
+					},
+				},
+				UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+					Type: appsv1.OnDeleteStatefulSetStrategyType,
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"component-name": "apiserver",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Hostname:  "apiserver",
+						Subdomain: "apiserver-svc",
+						Containers: []corev1.Container{
+							{
+								Name:            "apiserver",
+								Image:           "virtualcluster/apiserver-v1.16.2",
+								ImagePullPolicy: corev1.PullAlways,
+								Command: []string{
+									"kube-apiserver",
+								},
+								Args: []string{
+									"--bind-address=0.0.0.0",
+									"--allow-privileged=true",
+									"--anonymous-auth=true",
+									"--client-ca-file=/etc/kubernetes/pki/root/tls.crt",
+									"--tls-cert-file=/etc/kubernetes/pki/apiserver/tls.crt",
+									"--tls-private-key-file=/etc/kubernetes/pki/apiserver/tls.key",
+									"--kubelet-https=true",
+									"--kubelet-client-certificate=/etc/kubernetes/pki/apiserver/tls.crt",
+									"--kubelet-client-key=/etc/kubernetes/pki/apiserver/tls.key",
+									"--enable-bootstrap-token-auth=true",
+									"--etcd-servers=https://etcd-0.etcd:2379",
+									"--etcd-cafile=/etc/kubernetes/pki/root/tls.crt",
+									"--etcd-certfile=/etc/kubernetes/pki/apiserver/tls.crt",
+									"--etcd-keyfile=/etc/kubernetes/pki/apiserver/tls.key",
+									"--service-account-key-file=/etc/kubernetes/pki/service-account/tls.key",
+									"--service-cluster-ip-range=10.32.0.0/16",
+									"--service-node-port-range=30000-32767",
+									"--authorization-mode=Node,RBAC",
+									"--runtime-config=api/all",
+									"--enable-admission-plugins=NamespaceLifecycle,NodeRestriction,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota",
+									"--apiserver-count=1",
+									"--endpoint-reconciler-type=master-count",
+									"--v=2",
+								},
+								Ports: []corev1.ContainerPort{
+									{
+										ContainerPort: 6443,
+										Name:          "api",
+									},
+								},
+								LivenessProbe: &corev1.Probe{
+									Handler: corev1.Handler{
+										TCPSocket: &corev1.TCPSocketAction{
+											Port: intstr.IntOrString{
+												Type:   intstr.Int,
+												IntVal: 6443,
+											},
+										},
+									},
+									FailureThreshold:    8,
+									InitialDelaySeconds: 15,
+									PeriodSeconds:       10,
+									TimeoutSeconds:      15,
+								},
+								ReadinessProbe: &corev1.Probe{
+									Handler: corev1.Handler{
+										HTTPGet: &corev1.HTTPGetAction{
+											Port: intstr.IntOrString{
+												Type:   intstr.Int,
+												IntVal: 6443,
+											},
+											Path:   "/healthz",
+											Scheme: "HTTPS",
+										},
+									},
+									FailureThreshold:    8,
+									InitialDelaySeconds: 5,
+									PeriodSeconds:       2,
+									TimeoutSeconds:      30,
+								},
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										MountPath: "/etc/kubernetes/pki/apiserver",
+										Name:      "apiserver-ca",
+										ReadOnly:  true,
+									},
+									{
+										MountPath: "/etc/kubernetes/pki/root",
+										Name:      "root-ca",
+										ReadOnly:  true,
+									},
+									{
+										MountPath: "/etc/kubernetes/pki/service-account",
+										Name:      "serviceaccount-rsa",
+										ReadOnly:  true,
+									},
+								},
+							},
+						},
+						DNSConfig: &corev1.PodDNSConfig{
+							Searches: []string{
+								"cluster.local",
+							},
+						},
+						Volumes: []corev1.Volume{
+							{
+								Name: "apiserver-ca",
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										DefaultMode: pointer.Int32Ptr(420),
+										SecretName:  "apiserver-ca",
+									},
+								},
+							},
+							{
+								Name: "root-ca",
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										DefaultMode: pointer.Int32Ptr(420),
+										SecretName:  "root-ca",
+									},
+								},
+							},
+							{
+								Name: "serviceaccount-rsa",
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										DefaultMode: pointer.Int32Ptr(420),
+										SecretName:  "serviceaccount-rsa",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Status: appsv1.StatefulSetStatus{},
+		},
+		Service: &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "apiserver-svc",
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: map[string]string{
+					"component-name": "apiserver",
+				},
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
+					{
+						Port:     6443,
+						Protocol: corev1.ProtocolTCP,
+						TargetPort: intstr.IntOrString{
+							Type:   intstr.String,
+							StrVal: "api",
+						},
+					},
+				},
+			},
+		},
+	},
+	ControllerManager: &v1alpha1.StatefulSetSvcBundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "controller-manager",
+		},
+		StatefulSet: &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "controller-manager",
+			},
+			Spec: appsv1.StatefulSetSpec{
+				ServiceName: "controller-manager-svc",
+				Replicas:    pointer.Int32Ptr(1),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"component-name": "controller-manager",
+					},
+				},
+				UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+					Type: appsv1.OnDeleteStatefulSetStrategyType,
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"component-name": "controller-manager",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:            "controller-manager",
+								Image:           "virtualcluster/controller-manager-v1.16.2",
+								ImagePullPolicy: corev1.PullAlways,
+								Command: []string{
+									"kube-controller-manager",
+								},
+								Args: []string{
+									"--bind-address=0.0.0.0",
+									"--cluster-cidr=10.200.0.0/16",
+									"--cluster-signing-cert-file=/etc/kubernetes/pki/root/tls.crt",
+									"--cluster-signing-key-file=/etc/kubernetes/pki/root/tls.key",
+									"--kubeconfig=/etc/kubernetes/kubeconfig/controller-manager-kubeconfig",
+									"--authorization-kubeconfig=/etc/kubernetes/kubeconfig/controller-manager-kubeconfig",
+									"--authentication-kubeconfig=/etc/kubernetes/kubeconfig/controller-manager-kubeconfig",
+									"--leader-elect=false",
+									"--root-ca-file=/etc/kubernetes/pki/root/tls.crt",
+									"--service-account-private-key-file=/etc/kubernetes/pki/service-account/tls.key",
+									"--service-cluster-ip-range=10.32.0.0/24",
+									"--use-service-account-credentials=true",
+									"--experimental-cluster-signing-duration=87600h",
+									"--node-monitor-grace-period=200s",
+									"--v=2",
+								},
+								LivenessProbe: &corev1.Probe{
+									Handler: corev1.Handler{
+										HTTPGet: &corev1.HTTPGetAction{
+											Path: "/healthz",
+											Port: intstr.IntOrString{
+												Type:   intstr.Int,
+												IntVal: 10252,
+											},
+											Scheme: "HTTP",
+										},
+									},
+									FailureThreshold:    8,
+									InitialDelaySeconds: 15,
+									PeriodSeconds:       10,
+									TimeoutSeconds:      15,
+								},
+								ReadinessProbe: &corev1.Probe{
+									Handler: corev1.Handler{
+										HTTPGet: &corev1.HTTPGetAction{
+											Port: intstr.IntOrString{
+												Type:   intstr.Int,
+												IntVal: 10252,
+											},
+											Path:   "/healthz",
+											Scheme: "HTTP",
+										},
+									},
+									FailureThreshold:    8,
+									InitialDelaySeconds: 15,
+									PeriodSeconds:       2,
+									TimeoutSeconds:      15,
+								},
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										MountPath: "/etc/kubernetes/pki/root",
+										Name:      "root-ca",
+										ReadOnly:  true,
+									},
+									{
+										MountPath: "/etc/kubernetes/pki/service-account",
+										Name:      "serviceaccount-rsa",
+										ReadOnly:  true,
+									},
+									{
+										MountPath: "/etc/kubernetes/kubeconfig",
+										Name:      "kubeconfig",
+										ReadOnly:  true,
+									},
+								},
+							},
+						},
+						Volumes: []corev1.Volume{
+							{
+								Name: "root-ca",
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										DefaultMode: pointer.Int32Ptr(420),
+										SecretName:  "root-ca",
+									},
+								},
+							},
+							{
+								Name: "serviceaccount-rsa",
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										DefaultMode: pointer.Int32Ptr(420),
+										SecretName:  "serviceaccount-rsa",
+									},
+								},
+							},
+							{
+								Name: "kubeconfig",
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										DefaultMode: pointer.Int32Ptr(420),
+										SecretName:  "controller-manager-kubeconfig",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Status: appsv1.StatefulSetStatus{},
+		},
+	},
+}
+
+func CreateDefaultClusterVersion(client vcclient.Interface, name string) (*v1alpha1.ClusterVersion, error) {
+	return CreateClusterVersion(client, name, nil)
+}
+
+func CreateClusterVersion(client vcclient.Interface, name string, spec *v1alpha1.ClusterVersionSpec) (*v1alpha1.ClusterVersion, error) {
+	if spec == nil {
+		spec = defaultClusterVersion
+	}
+	cv := MakeClusterVersion(name, *spec)
+	cv, err := client.TenancyV1alpha1().ClusterVersions().Create(cv)
+	if err != nil {
+		return nil, fmt.Errorf("clusterVersion create API error: %v", err)
+	}
+	// get fresh cv info.
+	cv, err = client.TenancyV1alpha1().ClusterVersions().Get(cv.Name, metav1.GetOptions{})
+	if err != nil {
+		return cv, fmt.Errorf("clusterVersion get API error: %v", err)
+	}
+	return cv, nil
+}
+
+func MakeClusterVersion(name string, spec v1alpha1.ClusterVersionSpec) *v1alpha1.ClusterVersion {
+	return &v1alpha1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: spec,
+	}
+}

--- a/incubator/virtualcluster/test/e2e/framework/clusterversion/delete.go
+++ b/incubator/virtualcluster/test/e2e/framework/clusterversion/delete.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterversion
+
+import (
+	"fmt"
+
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	vcclient "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/client/clientset/versioned"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/test/e2e/framework"
+)
+
+func DeleteCV(client vcclient.Interface, cv *v1alpha1.ClusterVersion) error {
+	if cv == nil {
+		return nil
+	}
+	return DeleteCVByName(client, cv.GetName())
+}
+
+func DeleteCVByName(client vcclient.Interface, name string) error {
+	framework.Logf("Deleting cv %q", name)
+	err := client.TenancyV1alpha1().ClusterVersions().Delete(name, nil)
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("clusterVersion delete API error: %v", err)
+	}
+	return nil
+}

--- a/incubator/virtualcluster/test/e2e/framework/framework.go
+++ b/incubator/virtualcluster/test/e2e/framework/framework.go
@@ -33,6 +33,7 @@ import (
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 
 	vcclient "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/client/clientset/versioned"
+	e2evc "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/test/e2e/framework/virtualcluster"
 )
 
 const (
@@ -418,6 +419,16 @@ func (f *Framework) AddNamespacesToDelete(namespaces ...*v1.Namespace) {
 		}
 		f.namespacesToDelete = append(f.namespacesToDelete, ns)
 	}
+}
+
+// WaitForVCRunning waits for the vc to run in the namespace.
+func (f *Framework) WaitForVCRunning(vcName string) error {
+	return e2evc.WaitForVCRunningInNamespace(f.VCClientSet, vcName, f.Namespace.Name)
+}
+
+// WaitForVCRunning waits for the vc to be deleted in the namespace.
+func (f *Framework) WaitForVCNotFound(vcName string) error {
+	return e2evc.WaitForVCNotFoundInNamespace(f.VCClientSet, vcName, f.Namespace.Name)
 }
 
 // VCDescribe is wrapper function for ginkgo describe.  Adds namespacing.

--- a/incubator/virtualcluster/test/e2e/framework/framework.go
+++ b/incubator/virtualcluster/test/e2e/framework/framework.go
@@ -21,6 +21,7 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	crdclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -129,6 +130,13 @@ func (f *Framework) BeforeEach() {
 		ExpectNoError(err)
 		f.DynamicClient, err = dynamic.NewForConfig(config)
 		ExpectNoError(err)
+
+		crdClient, err := crdclient.NewForConfig(config)
+		ExpectNoError(err)
+		_, err = crdClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get("clusterversions.tenancy.x-k8s.io", metav1.GetOptions{})
+		ExpectNoError(err, "clusterversions crd not installed")
+		_, err = crdClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get("virtualclusters.tenancy.x-k8s.io", metav1.GetOptions{})
+		ExpectNoError(err, "virtualclusters crd not installed")
 	}
 
 	ginkgo.By(fmt.Sprintf("Building a namespace api object, basename %s", f.BaseName))

--- a/incubator/virtualcluster/test/e2e/framework/framework.go
+++ b/incubator/virtualcluster/test/e2e/framework/framework.go
@@ -1,0 +1,426 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+
+	vcclient "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/client/clientset/versioned"
+)
+
+const (
+	// DefaultNamespaceDeletionTimeout is timeout duration for waiting for a namespace deletion.
+	DefaultNamespaceDeletionTimeout = 10 * time.Minute
+)
+
+// Framework supports common operations used by e2e tests; it will keep a client & a namespace for you.
+// Eventual goal is to merge this with integration test framework.
+type Framework struct {
+	BaseName string
+
+	// Set together with creating the ClientSet and the namespace.
+	// Guaranteed to be unique in the cluster even when running the same
+	// test multiple times in parallel.
+	UniqueName string
+
+	ClientSet   clientset.Interface
+	VCClientSet vcclient.Interface
+
+	DynamicClient dynamic.Interface
+
+	Namespace                *v1.Namespace   // Every test has at least one namespace.
+	namespacesToDelete       []*v1.Namespace // Some tests have more than one.
+	NamespaceDeletionTimeout time.Duration
+
+	// To make sure that this framework cleans up after itself, no matter what,
+	// we install a Cleanup action before each test and clear it after.  If we
+	// should abort, the AfterSuite hook should run all Cleanup actions.
+	cleanupHandle CleanupActionHandle
+
+	// configuration for framework's client
+	Options Options
+}
+
+// Options is a struct for managing test framework options.
+type Options struct {
+	ClientQPS    float32
+	ClientBurst  int
+	GroupVersion *schema.GroupVersion
+}
+
+// NewDefaultFramework makes a new framework and sets up a BeforeEach/AfterEach for
+// you (you can write additional before/after each functions).
+func NewDefaultFramework(baseName string) *Framework {
+	options := Options{
+		ClientQPS:   20,
+		ClientBurst: 50,
+	}
+	return NewFramework(baseName, options, nil)
+}
+
+// NewFramework creates a test framework.
+func NewFramework(baseName string, options Options, client clientset.Interface) *Framework {
+	f := &Framework{
+		BaseName:  baseName,
+		Options:   options,
+		ClientSet: client,
+	}
+
+	ginkgo.BeforeEach(f.BeforeEach)
+	ginkgo.AfterEach(f.AfterEach)
+
+	return f
+}
+
+// BeforeEach gets a client and makes a namespace.
+func (f *Framework) BeforeEach() {
+	// The fact that we need this feels like a bug in ginkgo.
+	// https://github.com/onsi/ginkgo/issues/222
+	f.cleanupHandle = AddCleanupAction(f.AfterEach)
+	if f.ClientSet == nil {
+		ginkgo.By("Creating a kubernetes client")
+		config, err := LoadConfig()
+		ExpectNoError(err)
+		testDesc := ginkgo.CurrentGinkgoTestDescription()
+		if len(testDesc.ComponentTexts) > 0 {
+			componentTexts := strings.Join(testDesc.ComponentTexts, " ")
+			config.UserAgent = fmt.Sprintf(
+				"%v -- %v",
+				rest.DefaultKubernetesUserAgent(),
+				componentTexts)
+		}
+
+		config.QPS = f.Options.ClientQPS
+		config.Burst = f.Options.ClientBurst
+		if f.Options.GroupVersion != nil {
+			config.GroupVersion = f.Options.GroupVersion
+		}
+		f.VCClientSet, err = vcclient.NewForConfig(config)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		f.ClientSet, err = clientset.NewForConfig(config)
+		ExpectNoError(err)
+		f.DynamicClient, err = dynamic.NewForConfig(config)
+		ExpectNoError(err)
+	}
+
+	ginkgo.By(fmt.Sprintf("Building a namespace api object, basename %s", f.BaseName))
+	namespace, err := f.CreateNamespace(f.BaseName, map[string]string{
+		"e2e-framework": f.BaseName,
+	})
+	ExpectNoError(err)
+
+	f.Namespace = namespace
+	f.UniqueName = f.Namespace.GetName()
+}
+
+// AfterEach deletes the namespace, after reading its events.
+func (f *Framework) AfterEach() {
+	RemoveCleanupAction(f.cleanupHandle)
+
+	// DeleteNamespace at the very end in defer, to avoid any
+	// expectation failures preventing deleting the namespace.
+	defer func() {
+		nsDeletionErrors := map[string]error{}
+		// Whether to delete namespace is determined by 3 factors: delete-namespace flag, delete-namespace-on-failure flag and the test result
+		// if delete-namespace set to false, namespace will always be preserved.
+		// if delete-namespace is true and delete-namespace-on-failure is false, namespace will be preserved if test failed.
+		if TestContext.DeleteNamespace && (TestContext.DeleteNamespaceOnFailure || !ginkgo.CurrentGinkgoTestDescription().Failed) {
+			for _, ns := range f.namespacesToDelete {
+				ginkgo.By(fmt.Sprintf("Destroying namespace %q for this suite.", ns.Name))
+				timeout := DefaultNamespaceDeletionTimeout
+				if f.NamespaceDeletionTimeout != 0 {
+					timeout = f.NamespaceDeletionTimeout
+				}
+				if err := deleteNS(f.ClientSet, f.DynamicClient, ns.Name, timeout); err != nil {
+					if !apierrs.IsNotFound(err) {
+						nsDeletionErrors[ns.Name] = err
+					} else {
+						Logf("Namespace %v was already deleted", ns.Name)
+					}
+				}
+			}
+		} else {
+			if !TestContext.DeleteNamespace {
+				Logf("Found DeleteNamespace=false, skipping namespace deletion!")
+			} else {
+				Logf("Found DeleteNamespaceOnFailure=false and current test failed, skipping namespace deletion!")
+			}
+		}
+
+		// Paranoia-- prevent reuse!
+		f.Namespace = nil
+		f.ClientSet = nil
+		f.namespacesToDelete = nil
+
+		// if we had errors deleting, report them now.
+		if len(nsDeletionErrors) != 0 {
+			messages := []string{}
+			for namespaceKey, namespaceErr := range nsDeletionErrors {
+				messages = append(messages, fmt.Sprintf("Couldn't delete ns: %q: %s (%#v)", namespaceKey, namespaceErr, namespaceErr))
+			}
+			Failf(strings.Join(messages, ","))
+		}
+	}()
+
+	// Print events if the test failed.
+	if ginkgo.CurrentGinkgoTestDescription().Failed && TestContext.DumpLogsOnFailure {
+		// Pass both unversioned client and versioned clientset, till we have removed all uses of the unversioned client.
+		DumpAllNamespaceInfo(f.ClientSet, f.Namespace.Name)
+	}
+}
+
+// deleteNS deletes the provided namespace, waits for it to be completely deleted, and then checks
+// whether there are any pods remaining in a non-terminating state.
+func deleteNS(c clientset.Interface, dynamicClient dynamic.Interface, namespace string, timeout time.Duration) error {
+	startTime := time.Now()
+	if err := c.CoreV1().Namespaces().Delete(namespace, nil); err != nil {
+		return err
+	}
+
+	// wait for namespace to delete or timeout.
+	err := wait.PollImmediate(2*time.Second, timeout, func() (bool, error) {
+		if _, err := c.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{}); err != nil {
+			if apierrs.IsNotFound(err) {
+				return true, nil
+			}
+			Logf("Error while waiting for namespace to be terminated: %v", err)
+			return false, nil
+		}
+		return false, nil
+	})
+
+	// verify there is no more remaining content in the namespace
+	remainingContent, cerr := hasRemainingContent(c, dynamicClient, namespace)
+	if cerr != nil {
+		return cerr
+	}
+
+	// if content remains, let's dump information about the namespace, and system for flake debugging.
+	remainingPods := 0
+	missingTimestamp := 0
+	if remainingContent {
+		// log information about namespace, and set of namespaces in api server to help flake detection
+		logNamespace(c, namespace)
+		logNamespaces(c, namespace)
+
+		// if we can, check if there were pods remaining with no timestamp.
+		remainingPods, missingTimestamp, _ = e2epod.CountRemainingPods(c, namespace)
+	}
+
+	// a timeout waiting for namespace deletion happened!
+	if err != nil {
+		// some content remains in the namespace
+		if remainingContent {
+			// pods remain
+			if remainingPods > 0 {
+				if missingTimestamp != 0 {
+					// pods remained, but were not undergoing deletion (namespace controller is probably culprit)
+					return fmt.Errorf("namespace %v was not deleted with limit: %v, pods remaining: %v, pods missing deletion timestamp: %v", namespace, err, remainingPods, missingTimestamp)
+				}
+				// but they were all undergoing deletion (kubelet is probably culprit, check NodeLost)
+				return fmt.Errorf("namespace %v was not deleted with limit: %v, pods remaining: %v", namespace, err, remainingPods)
+			}
+			// other content remains (namespace controller is probably screwed up)
+			return fmt.Errorf("namespace %v was not deleted with limit: %v, namespaced content other than pods remain", namespace, err)
+		}
+		// no remaining content, but namespace was not deleted (namespace controller is probably wedged)
+		return fmt.Errorf("namespace %v was not deleted with limit: %v, namespace is empty but is not yet removed", namespace, err)
+	}
+	Logf("namespace %v deletion completed in %s", namespace, time.Since(startTime))
+	return nil
+}
+
+// logNamespaces logs the number of namespaces by phase
+// namespace is the namespace the test was operating against that failed to delete so it can be grepped in logs
+func logNamespaces(c clientset.Interface, namespace string) {
+	namespaceList, err := c.CoreV1().Namespaces().List(metav1.ListOptions{})
+	if err != nil {
+		Logf("namespace: %v, unable to list namespaces: %v", namespace, err)
+		return
+	}
+
+	numActive := 0
+	numTerminating := 0
+	for _, namespace := range namespaceList.Items {
+		if namespace.Status.Phase == v1.NamespaceActive {
+			numActive++
+		} else {
+			numTerminating++
+		}
+	}
+	Logf("namespace: %v, total namespaces: %v, active: %v, terminating: %v", namespace, len(namespaceList.Items), numActive, numTerminating)
+}
+
+// logNamespace logs detail about a namespace
+func logNamespace(c clientset.Interface, namespace string) {
+	ns, err := c.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			Logf("namespace: %v no longer exists", namespace)
+			return
+		}
+		Logf("namespace: %v, unable to get namespace due to error: %v", namespace, err)
+		return
+	}
+	Logf("namespace: %v, DeletionTimetamp: %v, Finalizers: %v, Phase: %v", ns.Name, ns.DeletionTimestamp, ns.Spec.Finalizers, ns.Status.Phase)
+}
+
+// isDynamicDiscoveryError returns true if the error is a group discovery error
+// only for groups expected to be created/deleted dynamically during e2e tests
+func isDynamicDiscoveryError(err error) bool {
+	if !discovery.IsGroupDiscoveryFailedError(err) {
+		return false
+	}
+	discoveryErr := err.(*discovery.ErrGroupDiscoveryFailed)
+	for gv := range discoveryErr.Groups {
+		switch gv.Group {
+		case "mygroup.example.com":
+			// custom_resource_definition
+			// garbage_collector
+		case "wardle.k8s.io":
+			// aggregator
+		case "metrics.k8s.io":
+			// aggregated metrics server add-on, no persisted resources
+		default:
+			Logf("discovery error for unexpected group: %#v", gv)
+			return false
+		}
+	}
+	return true
+}
+
+// hasRemainingContent checks if there is remaining content in the namespace via API discovery
+func hasRemainingContent(c clientset.Interface, dynamicClient dynamic.Interface, namespace string) (bool, error) {
+	// some tests generate their own framework.Client rather than the default
+	// TODO: ensure every test call has a configured dynamicClient
+	if dynamicClient == nil {
+		return false, nil
+	}
+
+	// find out what content is supported on the server
+	// Since extension apiserver is not always available, e.g. metrics server sometimes goes down,
+	// add retry here.
+	resources, err := waitForServerPreferredNamespacedResources(c.Discovery(), 30*time.Second)
+	if err != nil {
+		return false, err
+	}
+	resources = discovery.FilteredBy(discovery.SupportsAllVerbs{Verbs: []string{"list", "delete"}}, resources)
+	groupVersionResources, err := discovery.GroupVersionResources(resources)
+	if err != nil {
+		return false, err
+	}
+
+	// TODO: temporary hack for https://github.com/kubernetes/kubernetes/issues/31798
+	ignoredResources := sets.NewString("bindings")
+
+	contentRemaining := false
+
+	// dump how many of resource type is on the server in a log.
+	for gvr := range groupVersionResources {
+		// get a client for this group version...
+		dynamicClient := dynamicClient.Resource(gvr).Namespace(namespace)
+		if err != nil {
+			// not all resource types support list, so some errors here are normal depending on the resource type.
+			Logf("namespace: %s, unable to get client - gvr: %v, error: %v", namespace, gvr, err)
+			continue
+		}
+		// get the api resource
+		apiResource := metav1.APIResource{Name: gvr.Resource, Namespaced: true}
+		if ignoredResources.Has(gvr.Resource) {
+			Logf("namespace: %s, resource: %s, ignored listing per whitelist", namespace, apiResource.Name)
+			continue
+		}
+		unstructuredList, err := dynamicClient.List(metav1.ListOptions{})
+		if err != nil {
+			// not all resources support list, so we ignore those
+			if apierrs.IsMethodNotSupported(err) || apierrs.IsNotFound(err) || apierrs.IsForbidden(err) {
+				continue
+			}
+			// skip unavailable servers
+			if apierrs.IsServiceUnavailable(err) {
+				continue
+			}
+			return false, err
+		}
+		if len(unstructuredList.Items) > 0 {
+			Logf("namespace: %s, resource: %s, items remaining: %v", namespace, apiResource.Name, len(unstructuredList.Items))
+			contentRemaining = true
+		}
+	}
+	return contentRemaining, nil
+}
+
+// waitForServerPreferredNamespacedResources waits until server preferred namespaced resources could be successfully discovered.
+// TODO: Fix https://github.com/kubernetes/kubernetes/issues/55768 and remove the following retry.
+func waitForServerPreferredNamespacedResources(d discovery.DiscoveryInterface, timeout time.Duration) ([]*metav1.APIResourceList, error) {
+	Logf("Waiting up to %v for server preferred namespaced resources to be successfully discovered", timeout)
+	var resources []*metav1.APIResourceList
+	if err := wait.PollImmediate(Poll, timeout, func() (bool, error) {
+		var err error
+		resources, err = d.ServerPreferredNamespacedResources()
+		if err == nil || isDynamicDiscoveryError(err) {
+			return true, nil
+		}
+		if !discovery.IsGroupDiscoveryFailedError(err) {
+			return false, err
+		}
+		Logf("Error discoverying server preferred namespaced resources: %v, retrying in %v.", err, Poll)
+		return false, nil
+	}); err != nil {
+		return nil, err
+	}
+	return resources, nil
+}
+
+// CreateNamespace creates a namespace for e2e testing.
+func (f *Framework) CreateNamespace(baseName string, labels map[string]string) (*v1.Namespace, error) {
+	ns, err := CreateTestingNS(baseName, f.ClientSet, labels)
+	// check ns instead of err to see if it's nil as we may
+	// fail to create serviceAccount in it.
+	f.AddNamespacesToDelete(ns)
+
+	return ns, err
+}
+
+// AddNamespacesToDelete adds one or more namespaces to be deleted when the test
+// completes.
+func (f *Framework) AddNamespacesToDelete(namespaces ...*v1.Namespace) {
+	for _, ns := range namespaces {
+		if ns == nil {
+			continue
+		}
+		f.namespacesToDelete = append(f.namespacesToDelete, ns)
+	}
+}
+
+// VCDescribe is wrapper function for ginkgo describe.  Adds namespacing.
+func VCDescribe(text string, body func()) bool {
+	return ginkgo.Describe("[virtualcluster] "+text, body)
+}

--- a/incubator/virtualcluster/test/e2e/framework/text_context.go
+++ b/incubator/virtualcluster/test/e2e/framework/text_context.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/onsi/ginkgo/config"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/klog"
+)
+
+const (
+	defaultHost = "http://127.0.0.1:8080"
+)
+
+// TestContextType contains test settings and global state.
+type TestContextType struct {
+	KubeConfig  string
+	KubeContext string
+	Host        string
+
+	ReportDir    string
+	ReportPrefix string
+
+	DeleteNamespace          bool
+	DeleteNamespaceOnFailure bool
+
+	// If set to true test will dump data about the namespace in which test was running.
+	DumpLogsOnFailure bool
+}
+
+// TestContext should be used by all tests to access common context data.
+var TestContext TestContextType
+
+// RegisterCommonFlags registers flags common to all e2e test suites.
+// The flag set can be flag.CommandLine (if desired) or a custom
+// flag set that then gets passed to viperconfig.ViperizeFlags.
+//
+// The other Register*Flags methods below can be used to add more
+// test-specific flags. However, those settings then get added
+// regardless whether the test is actually in the test suite.
+func RegisterCommonFlags(flags *flag.FlagSet) {
+	// Turn on verbose by default to get spec names
+	config.DefaultReporterConfig.Verbose = true
+
+	// Turn on EmitSpecProgress to get spec progress (especially on interrupt)
+	config.GinkgoConfig.EmitSpecProgress = true
+
+	// Randomize specs as well as suites
+	config.GinkgoConfig.RandomizeAllSpecs = true
+
+	flags.BoolVar(&TestContext.DumpLogsOnFailure, "dump-logs-on-failure", true, "If set to true test will dump data about the namespace in which test was running.")
+	flags.BoolVar(&TestContext.DeleteNamespace, "delete-namespace", true, "If true tests will delete namespace after completion. It is only designed to make debugging easier, DO NOT turn it off by default.")
+	flags.BoolVar(&TestContext.DeleteNamespaceOnFailure, "delete-namespace-on-failure", true, "If true, framework will delete test namespace on failure. Used only during test debugging.")
+
+	flags.StringVar(&TestContext.Host, "host", "", fmt.Sprintf("The host, or apiserver, to connect to. Will default to %s if this argument and --kubeconfig are not set", defaultHost))
+	flags.StringVar(&TestContext.ReportPrefix, "report-prefix", "", "Optional prefix for JUnit XML reports. Default is empty, which doesn't prepend anything to the default name.")
+	flags.StringVar(&TestContext.ReportDir, "report-dir", "", "Path to the directory where the JUnit XML reports should be saved. Default is empty, which doesn't generate these reports.")
+}
+
+// RegisterClusterFlags registers flags specific to the cluster e2e test suite.
+func RegisterClusterFlags(flags *flag.FlagSet) {
+	flags.StringVar(&TestContext.KubeConfig, clientcmd.RecommendedConfigPathFlag, os.Getenv(clientcmd.RecommendedConfigPathEnvVar), "Path to kubeconfig containing embedded authinfo.")
+	flags.StringVar(&TestContext.KubeContext, clientcmd.FlagContext, "", "kubeconfig context to use/override. If unset, will use value from 'current-context'")
+}
+
+// HandleFlags sets up all flags and parses the command line.
+func HandleFlags() {
+	RegisterCommonFlags(flag.CommandLine)
+	RegisterClusterFlags(flag.CommandLine)
+	flag.Parse()
+}
+
+func createKubeConfig(clientCfg *restclient.Config) *clientcmdapi.Config {
+	clusterNick := "cluster"
+	userNick := "user"
+	contextNick := "context"
+
+	config := clientcmdapi.NewConfig()
+
+	credentials := clientcmdapi.NewAuthInfo()
+	credentials.Token = clientCfg.BearerToken
+	credentials.TokenFile = clientCfg.BearerTokenFile
+	credentials.ClientCertificate = clientCfg.TLSClientConfig.CertFile
+	if len(credentials.ClientCertificate) == 0 {
+		credentials.ClientCertificateData = clientCfg.TLSClientConfig.CertData
+	}
+	credentials.ClientKey = clientCfg.TLSClientConfig.KeyFile
+	if len(credentials.ClientKey) == 0 {
+		credentials.ClientKeyData = clientCfg.TLSClientConfig.KeyData
+	}
+	config.AuthInfos[userNick] = credentials
+
+	cluster := clientcmdapi.NewCluster()
+	cluster.Server = clientCfg.Host
+	cluster.CertificateAuthority = clientCfg.CAFile
+	if len(cluster.CertificateAuthority) == 0 {
+		cluster.CertificateAuthorityData = clientCfg.CAData
+	}
+	cluster.InsecureSkipTLSVerify = clientCfg.Insecure
+	config.Clusters[clusterNick] = cluster
+
+	context := clientcmdapi.NewContext()
+	context.Cluster = clusterNick
+	context.AuthInfo = userNick
+	config.Contexts[contextNick] = context
+	config.CurrentContext = contextNick
+
+	return config
+}
+
+// AfterReadingAllFlags makes changes to the context after all flags
+// have been read.
+func AfterReadingAllFlags(t *TestContextType) {
+	// Only set a default host if one won't be supplied via kubeconfig
+	if len(t.Host) == 0 && len(t.KubeConfig) == 0 {
+		// Check if we can use the in-cluster config
+		if clusterConfig, err := restclient.InClusterConfig(); err == nil {
+			if tempFile, err := ioutil.TempFile(os.TempDir(), "kubeconfig-"); err == nil {
+				kubeConfig := createKubeConfig(clusterConfig)
+				clientcmd.WriteToFile(*kubeConfig, tempFile.Name())
+				t.KubeConfig = tempFile.Name()
+				klog.Infof("Using a temporary kubeconfig file from in-cluster config : %s", tempFile.Name())
+			}
+		}
+		if len(t.KubeConfig) == 0 {
+			klog.Warningf("Unable to find in-cluster config, using default host : %s", defaultHost)
+			t.Host = defaultHost
+		}
+	}
+}

--- a/incubator/virtualcluster/test/e2e/framework/util.go
+++ b/incubator/virtualcluster/test/e2e/framework/util.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/kubernetes/test/e2e/framework/ginkgowrapper"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+)
+
+const (
+	// Poll is how often to Poll pods, nodes and claims.
+	Poll = 2 * time.Second
+)
+
+// RandomSuffix provides a random string to append to pods,services,rcs.
+func RandomSuffix() string {
+	return strconv.Itoa(rand.Intn(10000))
+}
+
+// ExpectNoError checks if "err" is set
+func ExpectNoError(err error, explain ...interface{}) {
+	ExpectNoErrorWithOffset(1, err, explain...)
+}
+
+// ExpectNoErrorWithOffset checks if "err" is set, and if so, fails assertion while logging the error at "offset" levels above its caller
+// (for example, for call chain f -> g -> ExpectNoErrorWithOffset(1, ...) error would be logged for "f").
+func ExpectNoErrorWithOffset(offset int, err error, explain ...interface{}) {
+	if err != nil {
+		Logf("Unexpected error occurred: %v", err)
+	}
+	gomega.ExpectWithOffset(1+offset, err).NotTo(gomega.HaveOccurred(), explain...)
+}
+
+// ExpectNoErrorWithRetries checks if "err" is set with retries
+func ExpectNoErrorWithRetries(fn func() error, maxRetries int, explain ...interface{}) {
+	var err error
+	for i := 0; i < maxRetries; i++ {
+		err = fn()
+		if err == nil {
+			return
+		}
+		Logf("(Attempt %d of %d) Unexpected error occurred: %v", i+1, maxRetries, err)
+	}
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred(), explain...)
+}
+
+// byFirstTimestamp sorts a slice of events by first timestamp, using their involvedObject's name as a tie breaker.
+type byFirstTimestamp []v1.Event
+
+func (o byFirstTimestamp) Len() int      { return len(o) }
+func (o byFirstTimestamp) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
+
+func (o byFirstTimestamp) Less(i, j int) bool {
+	if o[i].FirstTimestamp.Equal(&o[j].FirstTimestamp) {
+		return o[i].InvolvedObject.Name < o[j].InvolvedObject.Name
+	}
+	return o[i].FirstTimestamp.Before(&o[j].FirstTimestamp)
+}
+
+// EventsLister is a func that lists events.
+type EventsLister func(opts metav1.ListOptions, ns string) (*v1.EventList, error)
+
+// DumpEventsInNamespace dumps events in the given namespace.
+func DumpEventsInNamespace(eventsLister EventsLister, namespace string) {
+	ginkgo.By(fmt.Sprintf("Collecting events from namespace %q.", namespace))
+	events, err := eventsLister(metav1.ListOptions{}, namespace)
+	ExpectNoError(err, "failed to list events in namespace %q", namespace)
+
+	ginkgo.By(fmt.Sprintf("Found %d events.", len(events.Items)))
+	// Sort events by their first timestamp
+	sortedEvents := events.Items
+	if len(sortedEvents) > 1 {
+		sort.Sort(byFirstTimestamp(sortedEvents))
+	}
+	for _, e := range sortedEvents {
+		Logf("At %v - event for %v: %v %v: %v", e.FirstTimestamp, e.InvolvedObject.Name, e.Source, e.Reason, e.Message)
+	}
+	// Note that we don't wait for any Cleanup to propagate, which means
+	// that if you delete a bunch of pods right before ending your test,
+	// you may or may not see the killing/deletion/Cleanup events.
+}
+
+// DumpAllNamespaceInfo dumps events, pods and nodes information in the given namespace.
+func DumpAllNamespaceInfo(c clientset.Interface, namespace string) {
+	DumpEventsInNamespace(func(opts metav1.ListOptions, ns string) (*v1.EventList, error) {
+		return c.CoreV1().Events(ns).List(opts)
+	}, namespace)
+
+	e2epod.DumpAllPodInfoForNamespace(c, namespace)
+}
+
+// LoadConfig returns a config for a rest client.
+func LoadConfig() (*restclient.Config, error) {
+	c, err := RestclientConfig(TestContext.KubeContext)
+	if err != nil {
+		if TestContext.KubeConfig == "" {
+			return restclient.InClusterConfig()
+		}
+		return nil, err
+	}
+
+	return clientcmd.NewDefaultClientConfig(*c, &clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: TestContext.Host}}).ClientConfig()
+}
+
+// RestclientConfig returns a config holds the information needed to build connection to kubernetes clusters.
+func RestclientConfig(kubeContext string) (*clientcmdapi.Config, error) {
+	Logf(">>> kubeConfig: %s", TestContext.KubeConfig)
+	if TestContext.KubeConfig == "" {
+		return nil, fmt.Errorf("KubeConfig must be specified to load client config")
+	}
+	c, err := clientcmd.LoadFromFile(TestContext.KubeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error loading KubeConfig: %v", err.Error())
+	}
+	if kubeContext != "" {
+		Logf(">>> kubeContext: %s", kubeContext)
+		c.CurrentContext = kubeContext
+	}
+	return c, nil
+}
+
+// RunID is a unique identifier of the e2e run.
+// Beware that this ID is not the same for all tests in the e2e run, because each Ginkgo node creates it separately.
+var RunID = uuid.NewUUID()
+
+func nowStamp() string {
+	return time.Now().Format(time.StampMilli)
+}
+
+func log(level string, format string, args ...interface{}) {
+	fmt.Fprintf(ginkgo.GinkgoWriter, nowStamp()+": "+level+": "+format+"\n", args...)
+}
+
+// Logf logs the info.
+func Logf(format string, args ...interface{}) {
+	log("INFO", format, args...)
+}
+
+// Failf logs the fail info.
+func Failf(format string, args ...interface{}) {
+	FailfWithOffset(1, format, args...)
+}
+
+// FailfWithOffset calls "Fail" and logs the error at "offset" levels above its caller
+// (for example, for call chain f -> g -> FailfWithOffset(1, ...) error would be logged for "f").
+func FailfWithOffset(offset int, format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	log("FAIL", msg)
+	ginkgowrapper.Fail(nowStamp()+": "+msg, 1+offset)
+}
+
+// Fail is a replacement for ginkgo.Fail which logs the problem as it occurs
+// and then calls ginkgowrapper.Fail.
+func Fail(msg string, callerSkip ...int) {
+	skip := 1
+	if len(callerSkip) > 0 {
+		skip += callerSkip[0]
+	}
+	log("FAIL", msg)
+	ginkgowrapper.Fail(nowStamp()+": "+msg, skip)
+}
+
+// findAvailableNamespaceName random namespace name starting with baseName.
+func findAvailableNamespaceName(baseName string, c clientset.Interface) (string, error) {
+	var name string
+	err := wait.PollImmediate(Poll, 30*time.Second, func() (bool, error) {
+		name = fmt.Sprintf("%v-%v", baseName, RandomSuffix())
+		_, err := c.CoreV1().Namespaces().Get(name, metav1.GetOptions{})
+		if err == nil {
+			// Already taken
+			return false, nil
+		}
+		if apierrs.IsNotFound(err) {
+			return true, nil
+		}
+		Logf("Unexpected error while getting namespace: %v", err)
+		return false, nil
+	})
+	return name, err
+}
+
+// CreateTestingNS should be used by every test, note that we append a common prefix to the provided test name.
+// Please see NewFramework instead of using this directly.
+func CreateTestingNS(baseName string, c clientset.Interface, labels map[string]string) (*v1.Namespace, error) {
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels["e2e-run"] = string(RunID)
+
+	// We don't use ObjectMeta.GenerateName feature, as in case of API call
+	// failure we don't know whether the namespace was created and what is its
+	// name.
+	name, err := findAvailableNamespaceName(baseName, c)
+	if err != nil {
+		return nil, err
+	}
+
+	namespaceObj := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "",
+			Labels:    labels,
+		},
+		Status: v1.NamespaceStatus{},
+	}
+	// Be robust about making the namespace creation call.
+	var got *v1.Namespace
+	if err := wait.PollImmediate(Poll, 30*time.Second, func() (bool, error) {
+		var err error
+		got, err = c.CoreV1().Namespaces().Create(namespaceObj)
+		if err != nil {
+			Logf("Unexpected error while creating namespace: %v", err)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return got, nil
+}

--- a/incubator/virtualcluster/test/e2e/framework/vc.go
+++ b/incubator/virtualcluster/test/e2e/framework/vc.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	tenancyv1alpha1 "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/client/clientset/versioned/typed/tenancy/v1alpha1"
+)
+
+// VCClient is a struct for vc client.
+type VCClient struct {
+	f         *Framework
+	Interface clientset.Interface
+	tenancyv1alpha1.VirtualClusterInterface
+}
+
+// VCClient is a convenience method for getting a vc client interface in the framework's namespace,
+// possibly applying test-suite specific transformations to the vc spec.
+func (f *Framework) VCClient() *VCClient {
+	return &VCClient{
+		f:                       f,
+		Interface:               f.ClientSet,
+		VirtualClusterInterface: f.VCClientSet.TenancyV1alpha1().VirtualClusters(f.Namespace.Name),
+	}
+}
+
+// CreateSync creates a new vc according to the framework specifications, and wait for it to start.
+func (c *VCClient) CreateSync(vc *v1alpha1.VirtualCluster) *v1alpha1.VirtualCluster {
+	v, err := c.Create(vc)
+	ExpectNoError(err, "failed to create vc")
+	ExpectNoError(c.f.WaitForVCRunning(vc.Name))
+	v, err = c.Get(v.Name, metav1.GetOptions{})
+	ExpectNoError(err)
+	return v
+}
+
+// DeleteSync deletes the vc and wait for the vc to disappear.
+func (c *VCClient) DeleteSync(name string, options *metav1.DeleteOptions) {
+	err := c.Delete(name, options)
+	ExpectNoError(err, "failed to delete vc")
+	ExpectNoError(c.f.WaitForVCNotFound(name), "waiting virtualcluster to be completed deleted")
+}

--- a/incubator/virtualcluster/test/e2e/framework/virtualcluster/wait.go
+++ b/incubator/virtualcluster/test/e2e/framework/virtualcluster/wait.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package virtualcluster
+
+import (
+	"fmt"
+	"time"
+
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	vcclient "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/client/clientset/versioned"
+)
+
+const (
+	// vcStartTimeout is how long to wait for the vc to be started.
+	vcStartTimeout = 10 * time.Minute
+	// vcDeletionTimeout is how long to wait for the vc to be deleted.
+	vcDeletionTimeout = 5 * time.Minute
+	// poll is how often to poll vc.
+	poll = 2 * time.Second
+)
+
+// WaitForVCRunningInNamespace waits default amount of time (vcStartTimeout) for the specified vc to become running.
+// Returns an error if timeout occurs first, or vc goes in to failed state.
+func WaitForVCRunningInNamespace(c vcclient.Interface, vcName, namespace string) error {
+	return WaitTimeoutForVCRunningInNamespace(c, vcName, namespace, vcStartTimeout)
+}
+
+// WaitTimeoutForVCRunningInNamespace waits the given timeout duration for the specified vc to become running.
+func WaitTimeoutForVCRunningInNamespace(c vcclient.Interface, vcName, namespace string, timeout time.Duration) error {
+	return wait.PollImmediate(poll, timeout, vcRunning(c, vcName, namespace))
+}
+
+func vcRunning(c vcclient.Interface, vcName, namespace string) wait.ConditionFunc {
+	return func() (bool, error) {
+		pod, err := c.TenancyV1alpha1().VirtualClusters(namespace).Get(vcName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		switch pod.Status.Phase {
+		case v1alpha1.ClusterRunning:
+			return true, nil
+		case v1alpha1.ClusterError:
+			return false, fmt.Errorf("vc ran to error")
+		}
+		return false, nil
+	}
+}
+
+// WaitForVCNotFoundInNamespace waits default amount of time (vcStartTimeout) for the specified vc to become deleted.
+func WaitForVCNotFoundInNamespace(c vcclient.Interface, vcName, namespace string) error {
+	return WaitTimeoutForVCNotFoundInNamespace(c, vcName, namespace, vcDeletionTimeout)
+}
+
+// WaitTimeoutForVCRunningInNamespace waits the given timeout duration for the specified vc to become running.
+func WaitTimeoutForVCNotFoundInNamespace(c vcclient.Interface, vcName, namespace string, timeout time.Duration) error {
+	return wait.PollImmediate(poll, timeout, vcNotFound(c, vcName, namespace))
+}
+
+func vcNotFound(c vcclient.Interface, vcName, namespace string) wait.ConditionFunc {
+	return func() (bool, error) {
+		_, err := c.TenancyV1alpha1().VirtualClusters(namespace).Get(vcName, metav1.GetOptions{})
+		if apierrs.IsNotFound(err) {
+			return true, nil
+		}
+		if err != nil {
+			return true, err
+		}
+		return false, nil
+	}
+}

--- a/incubator/virtualcluster/test/e2e/multi-tenancy/framework.go
+++ b/incubator/virtualcluster/test/e2e/multi-tenancy/framework.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multi_tenancy
+
+import "github.com/onsi/ginkgo"
+
+// SIGDescribe describes SIG information
+func SIGDescribe(text string, body func()) bool {
+	return ginkgo.Describe("[sig-multi-tenancy] "+text, body)
+}

--- a/incubator/virtualcluster/test/e2e/multi-tenancy/virtual_cluster.go
+++ b/incubator/virtualcluster/test/e2e/multi-tenancy/virtual_cluster.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multi_tenancy
+
+import (
+	. "github.com/onsi/ginkgo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/test/e2e/framework"
+	e2ecv "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/test/e2e/framework/clusterversion"
+)
+
+var _ = SIGDescribe("VirtualCluster", func() {
+	f := framework.NewDefaultFramework("virtualcluster")
+	var (
+		ns       string
+		vcClient *framework.VCClient
+		cv       *v1alpha1.ClusterVersion
+		err      error
+	)
+
+	BeforeEach(func() {
+		vcClient = f.VCClient()
+		ns = f.Namespace.Name
+
+		By("Creating a ClusterVersion " + ns)
+		cv, err = e2ecv.CreateDefaultClusterVersion(f.VCClientSet, ns)
+		framework.ExpectNoError(err, "Error Creating ClusterVersion")
+	})
+
+	AfterEach(func() {
+		By("Deleting ClusterVersion " + ns)
+		e2ecv.DeleteCV(f.VCClientSet, cv)
+	})
+
+	framework.VCDescribe("VirtualCluster LifeCycle", func() {
+		It("should be created and removed", func() {
+			name := "create-remove-" + framework.RandomSuffix()
+			vc := &v1alpha1.VirtualCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Spec: v1alpha1.VirtualClusterSpec{
+					ClusterDomain:      "cluster.local",
+					ClusterVersionName: cv.GetName(),
+					PKIExpireDays:      365,
+				},
+			}
+
+			By("creating the virtualcluster " + vc.Name)
+			vc = vcClient.CreateSync(vc)
+
+			By("check if tenant master is healthy")
+			kubecfgBytes, err := conversion.GetKubeConfigOfVC(vcClient.Interface.CoreV1(), vc)
+			framework.ExpectNoError(err, "failed to get kubeconfig of vc")
+			clusterRestConfig, err := clientcmd.RESTConfigFromKubeConfig(kubecfgBytes)
+			framework.ExpectNoError(err, "failed to parse kubeconfig")
+			_, err = clientset.NewForConfig(clusterRestConfig)
+			framework.ExpectNoError(err, "failed to create clientset from rest config")
+			// TODO: we need convert tenant apiserver host for nodeport typed tenant.
+
+			By("deleting the virtualcluster " + vc.Name)
+			vcClient.DeleteSync(vc.Name, nil)
+		})
+	})
+})


### PR DESCRIPTION
1. setup e2e testing framework
2. e2e test case: create and remove vc

Signed-off-by: zhuangqh <zhuangqhc@gmail.com>

how to run 

```
[root@vm virtualcluster]# KUBECONFIG=/root/.kube/config  go test ./test/e2e/ -timeout 60m -v
=== RUN   TestE2E
I0713 06:36:30.133191   20074 e2e.go:59] Starting e2e run "8d1e8f15-f4e8-40c7-8b38-d63bfc6e41e8" on Ginkgo node 1
Running Suite: Kubernetes e2e suite
===================================
Random Seed: 1594622190 - Will randomize all specs
Will run 1 of 1 specs

[sig-multi-tenancy] VirtualCluster [virtualcluster] VirtualCluster LifeCycle
  should be created and removed
  /root/go/src/sigs.k8s.io/multi-tenancy/incubator/virtualcluster/test/e2e/multi-tenancy/virtual_cluster.go:55
[BeforeEach] [sig-multi-tenancy] VirtualCluster
  /root/go/src/sigs.k8s.io/multi-tenancy/incubator/virtualcluster/test/e2e/framework/framework.go:97
STEP: Creating a kubernetes client
Jul 13 06:36:30.134: INFO: >>> kubeConfig: /root/.kube/config
STEP: Building a namespace api object, basename virtualcluster
[BeforeEach] [sig-multi-tenancy] VirtualCluster
  /root/go/src/sigs.k8s.io/multi-tenancy/incubator/virtualcluster/test/e2e/multi-tenancy/virtual_cluster.go:40
STEP: Creating a ClusterVersion virtualcluster-253
[It] should be created and removed
  /root/go/src/sigs.k8s.io/multi-tenancy/incubator/virtualcluster/test/e2e/multi-tenancy/virtual_cluster.go:55
STEP: creating the virtualcluster create-remove-6683
STEP: check if tenant master is healthy
STEP: deleting the virtualcluster create-remove-6683
[AfterEach] [sig-multi-tenancy] VirtualCluster
  /root/go/src/sigs.k8s.io/multi-tenancy/incubator/virtualcluster/test/e2e/framework/framework.go:98
STEP: Destroying namespace "virtualcluster-253" for this suite.
Jul 13 06:37:24.575: INFO: Waiting up to 30s for server preferred namespaced resources to be successfully discovered
Jul 13 06:37:24.693: INFO: namespace virtualcluster-253 deletion completed in 6.149271658s
[AfterEach] [sig-multi-tenancy] VirtualCluster
  /root/go/src/sigs.k8s.io/multi-tenancy/incubator/virtualcluster/test/e2e/multi-tenancy/virtual_cluster.go:49
STEP: Deleting ClusterVersion virtualcluster-253
Jul 13 06:37:24.693: INFO: Deleting cv "virtualcluster-253"

• [SLOW TEST:54.567 seconds]
[sig-multi-tenancy] VirtualCluster
/root/go/src/sigs.k8s.io/multi-tenancy/incubator/virtualcluster/test/e2e/multi-tenancy/framework.go:23
  [virtualcluster] VirtualCluster LifeCycle
  /root/go/src/sigs.k8s.io/multi-tenancy/incubator/virtualcluster/test/e2e/framework/framework.go:436
    should be created and removed
    /root/go/src/sigs.k8s.io/multi-tenancy/incubator/virtualcluster/test/e2e/multi-tenancy/virtual_cluster.go:55
------------------------------
Jul 13 06:37:24.702: INFO: Running AfterSuite actions on all nodes
Jul 13 06:37:24.702: INFO: Running AfterSuite actions on node 1

Ran 1 of 1 Specs in 54.569 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestE2E (54.57s)
PASS
ok  	sigs.k8s.io/multi-tenancy/incubator/virtualcluster/test/e2e	54.613s
```