### PR TITLE
Warn the testers if HNC cannot be repaired

### DIFF
--- a/incubator/hnc/e2e/tests/delete_crd_test.go
+++ b/incubator/hnc/e2e/tests/delete_crd_test.go
@@ -17,7 +17,14 @@ var _ = Describe("Delete-anchor-crd", func() {
 
 	AfterEach(func() {
 		cleanupNamespaces(nsParent, nsChild)
-		mustRun("kubectl apply -f", hncRecoverPath)
+		err := tryRun("kubectl apply -f", hncRecoverPath)
+		if err != nil {
+			GinkgoT().Log("-----------------------------WARNING------------------------------")
+			GinkgoT().Logf("WARNING: COULDN'T REPAIR HNC: %v", err)
+			GinkgoT().Log("ANY TEST AFTER THIS COULD FAIL BECAUSE WE COULDN'T REPAIR HNC HERE")
+			GinkgoT().Log("------------------------------------------------------------------")
+			GinkgoT().FailNow()
+		}
 	})
 
 	It("should create parent and deletable child, and delete the CRD", func() {


### PR DESCRIPTION
If HNC is broken and cannot be repaired, log loud warnings to the user that any test after this could fail because of broken hnc.

Tested: 'make e2e-test' with invalid HNC_REPAIR path

Fix #881 