### PR TITLE
Add delete-hc-crd test to e2e test suite

### DIFF
--- a/incubator/hnc/e2e/tests/delete_crd_test.go
+++ b/incubator/hnc/e2e/tests/delete_crd_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 )
@@ -15,16 +16,19 @@ var _ = Describe("Delete-anchor-crd", func() {
 		nsChild = "delete-crd-child"
 	)
 
+	BeforeEach(func() {
+		// we don't want to destroy the HNC without being able to repair it, so skip this test if recovery path not set
+		if hncRecoverPath == ""{
+			Skip("Environment variable HNC_REPAIR not set. Skipping reocovering HNC.")
+		}
+	})
+
 	AfterEach(func() {
 		cleanupNamespaces(nsParent, nsChild)
 		mustRun("kubectl apply -f", hncRecoverPath)
 	})
 
 	It("should create parent and deletable child, and delete the CRD", func() {
-		// we don't want to destroy the HNC without being able to repair it, so skip this test if recovery path not set
-		if hncRecoverPath == ""{
-			Skip("Environment variable HNC_REPAIR not set. Skipping reocovering HNC.")
-		}
 		// set up
 		mustRun("kubectl create ns", nsParent)
 		mustRun("kubectl hns create", nsChild, "-n", nsParent)
@@ -32,5 +36,23 @@ var _ = Describe("Delete-anchor-crd", func() {
 		mustRun("kubectl delete customresourcedefinition/subnamespaceanchors.hnc.x-k8s.io")
 		// verify
 		mustRun("kubectl get ns", nsChild)
+	})
+
+	It("should create a rolebinding in parent and propagate to child", func() {
+		// set up
+		mustRun("kubectl create ns", nsParent)
+		mustRun("kubectl create ns", nsChild)
+		mustRun("kubectl hns set", nsChild, "--parent", nsParent)
+		// test
+		mustRun("kubectl create rolebinding --clusterrole=view --serviceaccount=default:default -n", nsParent, "foo")
+		time.Sleep(1 * time.Second)
+		// verify
+		mustRun("kubectl get -oyaml rolebinding foo -n", nsChild)
+		// test - delete CRD
+		mustRun("kubectl delete customresourcedefinition/subnamespaceanchors.hnc.x-k8s.io")
+		// Sleeping for 5s to give HNC the chance to delete the RB (but it shouldn't)
+		time.Sleep(5 * time.Second)
+		// verify
+		mustRun("kubectl get -oyaml rolebinding foo -n", nsChild)
 	})
 })


### PR DESCRIPTION
Translate test-delete-hc-crd.sh to delete_crd_test.go. Move hnc path
check to BeforeEach() to avoid repeated checks in each It block.

Tested: 'make e2e-test' with and without HNC_REPAIR