### PR TITLE
Unbreak object validator on 1.14

### DIFF
--- a/incubator/hnc/internal/validators/object.go
+++ b/incubator/hnc/internal/validators/object.go
@@ -70,6 +70,10 @@ func (o *Object) Handle(ctx context.Context, req admission.Request) admission.Re
 		}
 	}
 	if req.Operation != admissionv1beta1.Create {
+		// See issue #688 and #889
+		if req.Operation == admissionv1beta1.Delete && req.OldObject.Raw == nil {
+			return allow("cannot validate deletions in K8s 1.14")
+		}
 		if err := o.decoder.DecodeRaw(req.OldObject, oldInst); err != nil {
 			log.Error(err, "Couldn't decode req.OldObject", "raw", req.OldObject)
 			return deny(metav1.StatusReasonBadRequest, err.Error())


### PR DESCRIPTION
See #688 and #889 - validators need to be able to handle that OldObject
might not be populated in K8s 1.14

Tested: can delete an empty (!) subnamespace in 1.14 with this change,
while it hangs forever and prints out error messages from the object
validators without this change. See #889 for more information.

Fixes #889