### PR TITLE
Use enum schema validation for HNCConfig spec modes

### DIFF
--- a/incubator/hnc/api/v1alpha1/hnc_config.go
+++ b/incubator/hnc/api/v1alpha1/hnc_config.go
@@ -57,8 +57,9 @@ type TypeSynchronizationSpec struct {
 	// Kind to be configured.
 	Kind string `json:"kind"`
 	// Synchronization mode of the kind. If the field is empty, it will be treated
-	// as "propagate". An unsupported mode will be treated as "ignore".
+	// as "propagate".
 	// +optional
+	// +kubebuilder:validation:Enum=propagate;ignore;remove
 	Mode SynchronizationMode `json:"mode,omitempty"`
 }
 

--- a/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
+++ b/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
@@ -42,7 +42,11 @@ spec:
                     description: Kind to be configured.
                     type: string
                   mode:
-                    description: Synchronization mode of the kind. If the field is empty, it will be treated as "propagate". An unsupported mode will be treated as "ignore".
+                    description: Synchronization mode of the kind. If the field is empty, it will be treated as "propagate".
+                    enum:
+                    - propagate
+                    - ignore
+                    - remove
                     type: string
                 required:
                 - apiVersion

--- a/incubator/hnc/internal/validators/hncconfig.go
+++ b/incubator/hnc/internal/validators/hncconfig.go
@@ -139,13 +139,7 @@ func (c *HNCConfig) validateType(ctx context.Context, t api.TypeSynchronizationS
 			fmt.Sprintf("Cannot find the %s in the apiserver with error: %s", gvk, err.Error()))
 	}
 
-	// The mode of a type should be either unset or set to one of the supported modes.
-	switch t.Mode {
-	case api.Propagate, api.Ignore, api.Remove, "":
-		return allow("")
-	default:
-		return deny(metav1.StatusReasonInvalid, fmt.Sprintf("Unrecognized mode '%s' for %s", t.Mode, gvk))
-	}
+	return allow("")
 }
 
 // realGVKValidator implements gvkValidator, and is not used during unit tests.

--- a/incubator/hnc/internal/validators/hncconfig_test.go
+++ b/incubator/hnc/internal/validators/hncconfig_test.go
@@ -160,17 +160,6 @@ func TestNonRBACTypes(t *testing.T) {
 			},
 			validator: f,
 			allow:     false,
-		},
-		{
-			name: "Unrecognized mode",
-			configs: []api.TypeSynchronizationSpec{
-				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
-				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "propagate"},
-				// "delete" mode is unsupported
-				{APIVersion: "v1", Kind: "Secret", Mode: "delete"},
-			},
-			validator: f,
-			allow:     false,
 		}, {
 			name: "Duplicate types with different modes",
 			configs: []api.TypeSynchronizationSpec{


### PR DESCRIPTION
Add schema validation and remove the mode validation in HNCConfig
validator.

Tested with an obsolete existing HNCConfig resource with unknown modes
in the spec. Changes to the config is not allowed until the unknown
modes are fixed.

The validator test was failed before removing the test case.

Fix #899 
Part of #868 