### PR TITLE
Replace pattern with enum to enforce singleton

### DIFF
--- a/incubator/hnc/config/crd/patches/singleton_validation_hierarchyconfiguration.yaml
+++ b/incubator/hnc/config/crd/patches/singleton_validation_hierarchyconfiguration.yaml
@@ -12,4 +12,5 @@ spec:
           properties:
             name:
               type: string
-              pattern: '^hierarchy$'
+              enum:
+                - hierarchy

--- a/incubator/hnc/config/crd/patches/singleton_validation_hncconfiguration.yaml
+++ b/incubator/hnc/config/crd/patches/singleton_validation_hncconfiguration.yaml
@@ -12,4 +12,5 @@ spec:
           properties:
             name:
               type: string
-              pattern: '^config$'
+              enum:
+                - config


### PR DESCRIPTION
As suggested by API reviewers, the enum validation produces a nicer
error message than patterns.

Tested by applying wrong names and got nicer message:
Unsupported value: "wconfig": supported values: "hierarchy"

Part of #868 