### PR TITLE
Add test for deleting leaf namespace

### DIFF
--- a/incubator/hnc/e2e/tests/issues_test.go
+++ b/incubator/hnc/e2e/tests/issues_test.go
@@ -170,4 +170,20 @@ var _ = Describe("Issues", func() {
 		// test: delete namespace 
 		mustRun("kubectl delete ns", nsChild)
 	})
+
+	It("Should not delete a parent of a subnamespace if allowCascadingDelete is not set -issue #716", func(){
+		// Setting up a 2-level tree 
+		mustRun("kubectl create ns", nsParent)
+		mustRun("kubectl hns create", nsChild, "-n", nsParent)
+		// test
+		mustNotRun("kubectl delete ns", nsParent)
+	})
+
+	It("Should delete leaf subnamespace without setting allowCascadingDelete - issue #716", func(){
+		// Setting up a 2-level tree 
+		mustRun("kubectl create ns", nsParent)
+		mustRun("kubectl hns create", nsChild, "-n", nsParent)
+		// test
+		mustRun("kubectl delete subns", nsChild, "-n", nsParent)
+	})
 })


### PR DESCRIPTION
A parent namespace without allowCascadingDelete should not be deleted. A
leaf namespace without allowCascadingDelete should be able to be
deleted.

Tested: make e2e-test