### PR TITLE
[VC] Make sure VolumeMount is a secret volume before mutation

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/constants/constants.go
+++ b/incubator/virtualcluster/pkg/syncer/constants/constants.go
@@ -48,8 +48,6 @@ const (
 	// LabelVCRootNS means the namespace is the rootns created by vc-manager.
 	LabelVCRootNS = "tenancy.x-k8s.io/vcrootns"
 
-	// LabelServiceAccountUID is the tenant service account UID related to the secret.
-	LabelServiceAccountUID = "tenancy.x-k8s.io/service-account.UID"
 	// LabelSecretUID is the service account token secret UID in tenant namespace.
 	LabelSecretUID = "tenancy.x-k8s.io/secret.UID"
 

--- a/incubator/virtualcluster/pkg/syncer/conversion/helper_test.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/helper_test.go
@@ -124,9 +124,6 @@ func Test_mutateDownwardAPIField(t *testing.T) {
 }
 
 func Test_mutateContainerSecret(t *testing.T) {
-	saSecretMap := map[string]string{
-		"service-token-secret-tenant": "service-token-secret",
-	}
 	for _, tt := range []struct {
 		name              string
 		container         *v1.Container
@@ -150,7 +147,9 @@ func Test_mutateContainerSecret(t *testing.T) {
 					},
 				},
 			},
-			saSecretMap: saSecretMap,
+			saSecretMap: map[string]string{
+				"service-token-secret-tenant": "service-token-secret",
+			},
 			vPod: &v1.Pod{
 				Spec: v1.PodSpec{
 					Volumes: []v1.Volume{
@@ -174,6 +173,62 @@ func Test_mutateContainerSecret(t *testing.T) {
 					},
 					{
 						Name:      "service-token-secret",
+						MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
+						ReadOnly:  true,
+					},
+				},
+			},
+		},
+		{
+			name: "customized secret, no change",
+			container: &v1.Container{
+				VolumeMounts: []v1.VolumeMount{
+					{
+						Name:      "local-token",
+						MountPath: "/path/to/mount",
+						ReadOnly:  true,
+					},
+					{
+						Name:      "service-token-secret-tenant",
+						MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
+						ReadOnly:  true,
+					},
+				},
+			},
+			saSecretMap: map[string]string{
+				"local-token": "service-token-secret",
+			},
+			vPod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Volumes: []v1.Volume{
+						{
+							Name: "service-token-secret-tenant",
+							VolumeSource: v1.VolumeSource{
+								Secret: &v1.SecretVolumeSource{
+									SecretName: "local-token",
+								},
+							},
+						},
+						{
+							Name: "local-token",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{
+									Path: "/path/to/mount",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedContainer: &v1.Container{
+				VolumeMounts: []v1.VolumeMount{
+					{
+						Name:      "local-token",
+						MountPath: "/path/to/mount",
+						ReadOnly:  true,
+					},
+					{
+						Name:      "service-token-secret-tenant",
 						MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
 						ReadOnly:  true,
 					},

--- a/incubator/virtualcluster/pkg/syncer/conversion/helper_test.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/helper_test.go
@@ -131,6 +131,7 @@ func Test_mutateContainerSecret(t *testing.T) {
 		name              string
 		container         *v1.Container
 		saSecretMap       map[string]string
+		vPod              *v1.Pod
 		expectedContainer *v1.Container
 	}{
 		{
@@ -150,6 +151,20 @@ func Test_mutateContainerSecret(t *testing.T) {
 				},
 			},
 			saSecretMap: saSecretMap,
+			vPod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Volumes: []v1.Volume{
+						{
+							Name: "service-token-secret-tenant",
+							VolumeSource: v1.VolumeSource{
+								Secret: &v1.SecretVolumeSource{
+									SecretName: "service-token-secret-tenant",
+								},
+							},
+						},
+					},
+				},
+			},
 			expectedContainer: &v1.Container{
 				VolumeMounts: []v1.VolumeMount{
 					{
@@ -167,7 +182,7 @@ func Test_mutateContainerSecret(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(tc *testing.T) {
-			mutateContainerSecret(tt.container, tt.saSecretMap)
+			mutateContainerSecret(tt.container, tt.saSecretMap, tt.vPod)
 			if !equality.Semantic.DeepEqual(tt.container, tt.expectedContainer) {
 				tc.Errorf("expected container %+v, got %+v", tt.expectedContainer, tt.container)
 			}

--- a/incubator/virtualcluster/pkg/syncer/resources/secret/dws_test.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/secret/dws_test.go
@@ -76,8 +76,7 @@ func superServiceAccountSecret(name, namespace, uid, clusterKey string) *v1.Secr
 				constants.LabelSecretName:      name,
 			},
 			Labels: map[string]string{
-				constants.LabelServiceAccountUID: "",
-				constants.LabelSecretUID:         uid,
+				constants.LabelSecretUID: uid,
 			},
 		},
 		Type: v1.SecretTypeOpaque,


### PR DESCRIPTION
It is still possible that volumeMount name is duplicated with a secretName in the Volume while the Volume.Name does not match. This may happen if the Pod volume mount yaml is manually created. For example, 

```
volumeMounts:
      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
        name: token-B
      - mountPath: /var/run/foo
        name: token-A 
volumes:
    - name: token-B
      secret:
        defaultMode: 420
        secretName: token-A
   - name: token-A
      hostPath: /
```
This change makes sure the Pod volumeMount name is changed only when the corresponding volume is a secret volume whose name needs to be changed.

This change also removes the LabelServiceAccountUID constant which is not used any more. 

