### PR TITLE
Rename the package name from 'test' to 'e2e' 

### DIFF
--- a/incubator/hnc/test/e2e/delete_crd_test.go
+++ b/incubator/hnc/test/e2e/delete_crd_test.go
@@ -1,4 +1,4 @@
-package test
+package e2e
 
 import (
 	"os"

--- a/incubator/hnc/test/e2e/e2e_test.go
+++ b/incubator/hnc/test/e2e/e2e_test.go
@@ -1,4 +1,4 @@
-package test
+package e2e
 
 import (
 	"errors"

--- a/incubator/hnc/test/e2e/issues_test.go
+++ b/incubator/hnc/test/e2e/issues_test.go
@@ -1,4 +1,4 @@
-package test
+package e2e
 
 import (
 	"time"

--- a/incubator/hnc/test/e2e/namespace_test.go
+++ b/incubator/hnc/test/e2e/namespace_test.go
@@ -1,4 +1,4 @@
-package test
+package e2e
 
 import (
 	"os/exec"

--- a/incubator/hnc/test/e2e/subnamespace_test.go
+++ b/incubator/hnc/test/e2e/subnamespace_test.go
@@ -1,4 +1,4 @@
-package test
+package e2e
 
 import (
 	"os/exec"


### PR DESCRIPTION
Rename the package name from 'test' to 'e2e' for better naming convention

Tested: make e2e-test