### PR TITLE
Fix the flaky test for #716

### DIFF
--- a/incubator/hnc/test/e2e/e2e_test.go
+++ b/incubator/hnc/test/e2e/e2e_test.go
@@ -13,7 +13,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 )
 
-const namspacePrefix = "e2e-test-"
+const (
+	namspacePrefix = "e2e-test-"
+	// The time that Eventually() will keep retrying until timeout
+	// we use 5 seconds here because some tests require deleting a namespace, and shorter time period might not be enough
+	eventuallyTimeout = 5
+)
 
 var hncRecoverPath = os.Getenv("HNC_REPAIR")
 
@@ -29,12 +34,13 @@ func TestE2e(t *testing.T) {
 func mustRun(cmdln ...string) {
 	Eventually(func() error {
 		return tryRun(cmdln...)
-	}, 2).Should(BeNil())
+	}, eventuallyTimeout).Should(BeNil())
 }
 
 func mustNotRun(cmdln ...string) {
-	err := tryRun(cmdln...)
-	Expect(err).Should(Not(BeNil()))
+	Eventually(func() error {
+		return tryRun(cmdln...)
+	}, eventuallyTimeout).Should(Not(BeNil()))
 }
 
 func tryRun(cmdln ...string) error {

--- a/incubator/hnc/test/e2e/issues_test.go
+++ b/incubator/hnc/test/e2e/issues_test.go
@@ -175,6 +175,8 @@ var _ = Describe("Issues", func() {
 		// Setting up a 2-level tree 
 		mustRun("kubectl create ns", nsParent)
 		mustRun("kubectl hns create", nsChild, "-n", nsParent)
+		// verify that the namespace has been created 
+		mustRun("kubectl get ns", nsChild)
 		// test
 		mustNotRun("kubectl delete ns", nsParent)
 	})
@@ -183,6 +185,8 @@ var _ = Describe("Issues", func() {
 		// Setting up a 2-level tree 
 		mustRun("kubectl create ns", nsParent)
 		mustRun("kubectl hns create", nsChild, "-n", nsParent)
+		// verify that the namespace has been created 
+		mustRun("kubectl get ns", nsChild)
 		// test
 		mustRun("kubectl delete subns", nsChild, "-n", nsParent)
 	})
@@ -192,6 +196,8 @@ var _ = Describe("Issues", func() {
 		mustRun("kubectl create ns", nsParent)
 		mustRun("kubectl hns create", nsChild, "-n", nsParent)
 		mustRun("kubectl hns create", nsSubChild, "-n", nsChild)
+		// verify that the namespace has been created 
+		mustRun("kubectl get ns", nsSubChild)
 		// Test: remove non-leaf subnamespace with 'allowCascadingDelete' unset.
 		// Expected: forbidden because 'allowCascadingDelete'flag is not set
 		mustNotRun("kubectl delete subns", nsChild, "-n", nsParent)
@@ -202,6 +208,8 @@ var _ = Describe("Issues", func() {
 		mustRun("kubectl create ns", nsParent)
 		mustRun("kubectl hns create", nsChild, "-n", nsParent)
 		mustRun("kubectl hns create", nsSubChild, "-n", nsChild)
+		// verify that the namespace has been created 
+		mustRun("kubectl get ns", nsSubChild)
 		// Test: remove leaf subnamespaces with 'allowCascadingDelete' unset.
 		// Expected: delete successfully
 		mustRun("kubectl delete subns", nsSubChild, "-n", nsChild)


### PR DESCRIPTION
Change the mustNotRun() function to use Eventually() so that we get
stable test result. Add sleep time after create subnamespace so that the
anchor is ready before test. Change the default wait time in mustRun()
and mustNotRun() to 5 seconds because deleting a subnamespace takes a
while.

Tested: make e2e-test

Fix #950 