### PR TITLE
add vcname to metadata

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/resources/configmap/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/configmap/dws.go
@@ -86,7 +86,11 @@ func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, e
 }
 
 func (c *controller) reconcileConfigMapCreate(clusterName, targetNamespace, requestUID string, configMap *v1.ConfigMap) error {
-	newObj, err := conversion.BuildMetadata(clusterName, targetNamespace, configMap)
+	vcName, _, _, err := c.multiClusterConfigMapController.GetOwnerInfo(clusterName)
+	if err != nil {
+		return err
+	}
+	newObj, err := conversion.BuildMetadata(clusterName, vcName, targetNamespace, configMap)
 	if err != nil {
 		return err
 	}

--- a/incubator/virtualcluster/pkg/syncer/resources/endpoints/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/endpoints/dws.go
@@ -96,7 +96,11 @@ func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, e
 }
 
 func (c *controller) reconcileEndpointsCreate(clusterName, targetNamespace, requestUID string, ep *v1.Endpoints) error {
-	newObj, err := conversion.BuildMetadata(clusterName, targetNamespace, ep)
+	vcName, _, _, err := c.multiClusterEndpointsController.GetOwnerInfo(clusterName)
+	if err != nil {
+		return err
+	}
+	newObj, err := conversion.BuildMetadata(clusterName, vcName, targetNamespace, ep)
 	if err != nil {
 		return err
 	}

--- a/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/persistentvolume/uws.go
@@ -82,8 +82,11 @@ func (c *controller) BackPopulate(key string) error {
 				klog.Errorf("Cannot find the bound pvc %s/%s in tenant cluster %s for pv %v", vNamespace, pPVC.Name, clusterName, pPV)
 				return nil
 			}
-
-			vPV := conversion.BuildVirtualPersistentVolume(clusterName, pPV, vPVC)
+			vcName, _, _, err := c.multiClusterPersistentVolumeController.GetOwnerInfo(clusterName)
+			if err != nil {
+				return err
+			}
+			vPV := conversion.BuildVirtualPersistentVolume(clusterName, vcName, pPV, vPVC)
 			_, err = tenantClient.CoreV1().PersistentVolumes().Create(vPV)
 			if err != nil {
 				return err

--- a/incubator/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/dws.go
@@ -86,7 +86,11 @@ func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, e
 }
 
 func (c *controller) reconcilePVCCreate(clusterName, targetNamespace, requestUID string, pvc *v1.PersistentVolumeClaim) error {
-	newObj, err := conversion.BuildMetadata(clusterName, targetNamespace, pvc)
+	vcName, _, _, err := c.multiClusterPersistentVolumeClaimController.GetOwnerInfo(clusterName)
+	if err != nil {
+		return err
+	}
+	newObj, err := conversion.BuildMetadata(clusterName, vcName, targetNamespace, pvc)
 	if err != nil {
 		return err
 	}

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/dws.go
@@ -149,7 +149,11 @@ func (c *controller) reconcilePodCreate(clusterName, targetNamespace, requestUID
 		return err
 	}
 
-	newObj, err := conversion.BuildMetadata(clusterName, targetNamespace, vPod)
+	vcName, _, _, err := c.multiClusterPodController.GetOwnerInfo(clusterName)
+	if err != nil {
+		return err
+	}
+	newObj, err := conversion.BuildMetadata(clusterName, vcName, targetNamespace, vPod)
 	if err != nil {
 		return err
 	}

--- a/incubator/virtualcluster/pkg/syncer/resources/secret/checker_test.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/secret/checker_test.go
@@ -49,6 +49,7 @@ func TestSecretPatrol(t *testing.T) {
 	}
 
 	defaultClusterKey := conversion.ToClusterKey(testTenant)
+	defaultVCName := testTenant.Name
 	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
 
 	testcases := map[string]struct {
@@ -69,13 +70,13 @@ func TestSecretPatrol(t *testing.T) {
 		},
 		"pSecret with service account type created by token controller": {
 			ExistingObjectInSuper: []runtime.Object{
-				superSecret("secret", superDefaultNSName, "12345", defaultClusterKey, v1.SecretTypeServiceAccountToken),
+				superSecret(defaultVCName, "secret", superDefaultNSName, "12345", defaultClusterKey, v1.SecretTypeServiceAccountToken),
 			},
 			ExpectedNoOperation: true,
 		},
 		"pSecret exists, vSecret does not exists": {
 			ExistingObjectInSuper: []runtime.Object{
-				superSecret("normal-secret", superDefaultNSName, "12345", defaultClusterKey, v1.SecretTypeOpaque),
+				superSecret(defaultVCName, "normal-secret", superDefaultNSName, "12345", defaultClusterKey, v1.SecretTypeOpaque),
 			},
 			ExpectedDeletedPObject: []string{
 				superDefaultNSName + "/normal-secret",
@@ -83,7 +84,7 @@ func TestSecretPatrol(t *testing.T) {
 		},
 		"pSecret exists, vSecret exists with different uid": {
 			ExistingObjectInSuper: []runtime.Object{
-				superSecret("normal-secret", superDefaultNSName, "12345", defaultClusterKey, v1.SecretTypeOpaque),
+				superSecret(defaultVCName, "normal-secret", superDefaultNSName, "12345", defaultClusterKey, v1.SecretTypeOpaque),
 			},
 			ExistingObjectInTenant: []runtime.Object{
 				tenantSecret("normal-secret", "default", "123456", v1.SecretTypeOpaque),
@@ -94,7 +95,7 @@ func TestSecretPatrol(t *testing.T) {
 		},
 		"pSecret exists, vSecret exists with no diff": {
 			ExistingObjectInSuper: []runtime.Object{
-				superSecret("normal-secret", superDefaultNSName, "12345", defaultClusterKey, v1.SecretTypeOpaque),
+				superSecret(defaultVCName, "normal-secret", superDefaultNSName, "12345", defaultClusterKey, v1.SecretTypeOpaque),
 			},
 			ExistingObjectInTenant: []runtime.Object{
 				tenantSecret("normal-secret", "default", "12345", v1.SecretTypeOpaque),
@@ -103,7 +104,7 @@ func TestSecretPatrol(t *testing.T) {
 		},
 		"pSecret exists, vSecret exists but different in data": {
 			ExistingObjectInSuper: []runtime.Object{
-				applyDataToSecret(superSecret("normal-secret", superDefaultNSName, "12345", defaultClusterKey, v1.SecretTypeOpaque), "data1"),
+				applyDataToSecret(superSecret(defaultVCName, "normal-secret", superDefaultNSName, "12345", defaultClusterKey, v1.SecretTypeOpaque), "data1"),
 			},
 			ExistingObjectInTenant: []runtime.Object{
 				applyDataToSecret(tenantSecret("normal-secret", "default", "12345", v1.SecretTypeOpaque), "data2"),
@@ -115,13 +116,13 @@ func TestSecretPatrol(t *testing.T) {
 				tenantSecret("normal-secret", "default", "12345", v1.SecretTypeOpaque),
 			},
 			ExpectedCreatedPObject: []runtime.Object{
-				superSecret("normal-secret", superDefaultNSName, "12345", defaultClusterKey, v1.SecretTypeOpaque),
+				superSecret(defaultVCName, "normal-secret", superDefaultNSName, "12345", defaultClusterKey, v1.SecretTypeOpaque),
 			},
 			WaitDWS: true,
 		},
 		"pSecret exists, vSecret does not exists, service account token type": {
 			ExistingObjectInSuper: []runtime.Object{
-				applyGeneratedNameToSecret(superServiceAccountSecret("sa-secret", superDefaultNSName, "12345", defaultClusterKey), "sa-secret-token-xxx"),
+				applyGeneratedNameToSecret(superServiceAccountSecret(defaultVCName, "sa-secret", superDefaultNSName, "12345", defaultClusterKey), "sa-secret-token-xxx"),
 			},
 			ExpectedDeletedPObject: []string{
 				superDefaultNSName + "/sa-secret-token-xxx",
@@ -132,13 +133,13 @@ func TestSecretPatrol(t *testing.T) {
 				tenantSecret("sa-secret", "default", "12345", v1.SecretTypeServiceAccountToken),
 			},
 			ExpectedCreatedPObject: []runtime.Object{
-				superServiceAccountSecret("sa-secret", superDefaultNSName, "12345", defaultClusterKey),
+				superServiceAccountSecret(defaultVCName, "sa-secret", superDefaultNSName, "12345", defaultClusterKey),
 			},
 			WaitDWS: true,
 		},
 		"vSecret exists, pSecret exists with different data, service account token type": {
 			ExistingObjectInSuper: []runtime.Object{
-				applyDataToSecret(superServiceAccountSecret("sa-secret", superDefaultNSName, "12345", defaultClusterKey), "data1"),
+				applyDataToSecret(superServiceAccountSecret(defaultVCName, "sa-secret", superDefaultNSName, "12345", defaultClusterKey), "data1"),
 			},
 			ExistingObjectInTenant: []runtime.Object{
 				applyDataToSecret(tenantSecret("sa-secret", "default", "12345", v1.SecretTypeServiceAccountToken), "data2"),

--- a/incubator/virtualcluster/pkg/syncer/resources/secret/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/secret/dws.go
@@ -114,7 +114,11 @@ func (c *controller) reconcileSecretCreate(clusterName, targetNamespace, request
 }
 
 func (c *controller) reconcileServiceAccountSecretCreate(clusterName, targetNamespace string, vSecret *v1.Secret) error {
-	newObj, err := conversion.BuildMetadata(clusterName, targetNamespace, vSecret)
+	vcName, _, _, err := c.multiClusterSecretController.GetOwnerInfo(clusterName)
+	if err != nil {
+		return err
+	}
+	newObj, err := conversion.BuildMetadata(clusterName, vcName, targetNamespace, vSecret)
 	if err != nil {
 		return err
 	}
@@ -148,7 +152,11 @@ func (c *controller) reconcileServiceAccountSecretUpdate(clusterName, targetName
 }
 
 func (c *controller) reconcileNormalSecretCreate(clusterName, targetNamespace, requestUID string, secret *v1.Secret) error {
-	newObj, err := conversion.BuildMetadata(clusterName, targetNamespace, secret)
+	vcName, _, _, err := c.multiClusterSecretController.GetOwnerInfo(clusterName)
+	if err != nil {
+		return err
+	}
+	newObj, err := conversion.BuildMetadata(clusterName, vcName, targetNamespace, secret)
 	if err != nil {
 		return err
 	}

--- a/incubator/virtualcluster/pkg/syncer/resources/service/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/service/dws.go
@@ -84,7 +84,11 @@ func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, e
 }
 
 func (c *controller) reconcileServiceCreate(clusterName, targetNamespace, requestUID string, service *v1.Service) error {
-	newObj, err := conversion.BuildMetadata(clusterName, targetNamespace, service)
+	vcName, _, _, err := c.multiClusterServiceController.GetOwnerInfo(clusterName)
+	if err != nil {
+		return err
+	}
+	newObj, err := conversion.BuildMetadata(clusterName, vcName, targetNamespace, service)
 	if err != nil {
 		return err
 	}

--- a/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/dws.go
@@ -85,7 +85,11 @@ func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, e
 }
 
 func (c *controller) reconcileServiceAccountCreate(clusterName, targetNamespace, requestUID string, vSa *v1.ServiceAccount) error {
-	newObj, err := conversion.BuildMetadata(clusterName, targetNamespace, vSa)
+	vcName, _, _, err := c.multiClusterServiceAccountController.GetOwnerInfo(clusterName)
+	if err != nil {
+		return err
+	}
+	newObj, err := conversion.BuildMetadata(clusterName, vcName, targetNamespace, vSa)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Nowadays, syncer will add tenancy.x-k8s.io/cluster to object annotations to distinguish which vc this object belongs to. But the annotation is not convenient in real product because the cluster id is generated by vc-manager. The cluster id's format is ${namespace}-${uuid}-${vc-name}, where user can't get uuid without access k8s super master. 

In real product system, there are always many modules and not all modules need to access k8s. For example, module A deals with users order and pass a vcname to the k8s; module B collects pods information and module C get order information from module A and pods information from module B. Without vcname in pod metadata, module C can't match module A's information with module B unless module C get the vcname and cluster id mapping from super k8s.

In this issue, I changes the build metadata method to add tenancy.x-k8s.io/vcname to object annotation and label. In this way, module C can match module A and B's information by vc name. I aims to let all module's to use vcname as unified id in the whole system and do not need to convert vcname to cluster id.

