### PR TITLE
Make it work with Go 1.15

### DIFF
--- a/incubator/hnc/internal/reconcilers/hierarchy_config_test.go
+++ b/incubator/hnc/internal/reconcilers/hierarchy_config_test.go
@@ -2,6 +2,7 @@ package reconcilers_test
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -449,7 +450,7 @@ func hasChild(ctx context.Context, nm, cnm string) func() bool {
 func createNSes(ctx context.Context, num int) []string {
 	nms := []string{}
 	for i := 0; i < num; i++ {
-		nm := createNS(ctx, string('a'+i))
+		nm := createNS(ctx, fmt.Sprintf("%c", 'a'+i))
 		nms = append(nms, nm)
 	}
 	return nms


### PR DESCRIPTION
This bug is a warning of converting integer to a string of rune instead
of digits. This warning is introduced in Go 1.15. See https://blog.golang.org/go1.15-proposals
and specifically golang/go#32479.

Tested by make test and make deploy.

Fix #975 