### PR TITLE
[VC] Feature: implement the webhook framework for VC

### DIFF
--- a/incubator/virtualcluster/config/sampleswithspec/clusterversion_v1_nodeport.yaml
+++ b/incubator/virtualcluster/config/sampleswithspec/clusterversion_v1_nodeport.yaml
@@ -10,6 +10,8 @@ spec:
     metadata:
       name: etcd 
     statefulset:
+      apiVersion: apps/v1
+      kind: StatefulSet
       metadata:
         name: etcd
       spec:
@@ -97,6 +99,8 @@ spec:
     # etcd will be accessed only by apiserver from inside the cluster, so we use a headless service to 
     # encapsulate it
     service:
+      apiVersion: v1
+      kind: Service
       metadata:
         name: etcd
         annotations:
@@ -111,6 +115,8 @@ spec:
     metadata:
       name: apiserver
     statefulset:
+      apiVersion: apps/v1
+      kind: StatefulSet
       metadata:
         name: apiserver
       spec:
@@ -209,6 +215,8 @@ spec:
                 defaultMode: 420
                 secretName: serviceaccount-rsa
     service:
+      apiVersion: apps/v1
+      kind: Service
       metadata:
         name: apiserver-svc
       spec:
@@ -221,10 +229,14 @@ spec:
           targetPort: api
   # a statefulset and service bundle for controller-manager
   controllerManager:
+    apiVersion: apps/v1
+    kind: StatefulSet
     metadata:
       name: controller-manager
     # statefuleset template for controller-manager
     statefulset:  
+      apiVersion: apps/v1
+      kind: StatefulSet
       metadata:
         name: controller-manager
       spec:

--- a/incubator/virtualcluster/config/setup/all_in_one.yaml
+++ b/incubator/virtualcluster/config/setup/all_in_one.yaml
@@ -10,6 +10,19 @@ metadata:
   name: vc-manager-role
 rules:
 - apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  - certificatesigningrequests/approval
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
   - tenancy.x-k8s.io
   resources:
   - clusterversions
@@ -205,6 +218,7 @@ spec:
       creationTimestamp: null
       labels:
         app: vc-manager
+        virtualcluster-webhook: "true"
     spec:
       serviceAccountName: vc-manager
       containers:
@@ -213,6 +227,9 @@ spec:
         image: virtualcluster/manager-amd64
         imagePullPolicy: Always
         name: vc-manager
+        env:
+        - name: ENABLE_WEBHOOKS
+          value: "true"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/incubator/virtualcluster/go.sum
+++ b/incubator/virtualcluster/go.sum
@@ -838,6 +838,7 @@ mvdan.cc/unparam v0.0.0-20190209190245-fbb59629db34/go.mod h1:H6SUd1XjIs+qQCyskX
 sigs.k8s.io/controller-runtime v0.4.0 h1:wATM6/m+3w8lj8FXNaO6Fs/rq/vqoOjO1Q116Z9NPsg=
 sigs.k8s.io/controller-runtime v0.4.0/go.mod h1:ApC79lpY3PHW9xj/w9pj+lYkLgwAAUZwfXkME1Lajns=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
+sigs.k8s.io/multi-tenancy v0.0.0-20200722202140-18a0d59c1f7d h1:QRCXwXPcH2Ycmwn53njQToREoBUoFXCpS+DKC0OyruE=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff v1.0.1 h1:LOs1LZWMsz1xs77Phr/pkB4LFaavH7IVq/3+WTN9XTA=
 sigs.k8s.io/structured-merge-diff v1.0.1/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=

--- a/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1/virtualcluster_webhook.go
+++ b/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1/virtualcluster_webhook.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"errors"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+var vclog = logf.Log.WithName("virtualcluster-webhook")
+
+func (vc *VirtualCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	vclog.Info("setup virtualcluster validation webhook")
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(vc).
+		Complete()
+}
+
+var _ webhook.Validator = &VirtualCluster{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (vc *VirtualCluster) ValidateCreate() error {
+	vclog.Info("validate create", "vc-name", vc.Name)
+	// do nothing for delete request
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (new *VirtualCluster) ValidateUpdate(old runtime.Object) error {
+	vclog.Info("validate update", "vc-name", new.Name)
+	return new.validateVirtualClusterUpdate(old)
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (vc *VirtualCluster) ValidateDelete() error {
+	vclog.Info("validate delete", "vc-name", vc.Name)
+	// do nothing for delete request
+	return nil
+}
+
+func (vc *VirtualCluster) validateVirtualClusterUpdate(old runtime.Object) error {
+	var allErrs field.ErrorList
+	oldVC, ok := old.(*VirtualCluster)
+	if !ok {
+		return errors.New("fail to assert runtime.Object to tenancyv1alpha1.VirtualCluster")
+	}
+	// once the VC.Status.Phase is set, it can't be set to empty again
+	if oldVC.Status.Phase != "" && vc.Status.Phase == "" {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("status").Child("phase"),
+				vc.Name, "cannot set virtualcluster.Status.Phase to empty"))
+		return apierrors.NewInvalid(
+			schema.GroupKind{Group: "tenancy.x-k8s.io", Kind: "VirtualCluster"},
+			vc.Name, allErrs)
+	}
+	return nil
+}

--- a/incubator/virtualcluster/pkg/controller/constants/constants.go
+++ b/incubator/virtualcluster/pkg/controller/constants/constants.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+const (
+	VirtualClusterWebhookCertDir = "/tmp/k8s-webhook-server/serving-certs"
+	VirtualClusterWebhookPort    = 9443
+)

--- a/incubator/virtualcluster/pkg/webhook/add_virtualcluster.go
+++ b/incubator/virtualcluster/pkg/webhook/add_virtualcluster.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/webhook/virtualcluster"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create webhook and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, virtualcluster.Add)
+}

--- a/incubator/virtualcluster/pkg/webhook/virtualcluster/virtualcluster_webhook.go
+++ b/incubator/virtualcluster/pkg/webhook/virtualcluster/virtualcluster_webhook.go
@@ -1,0 +1,445 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package virtualcluster
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	cryptorand "crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+
+	admv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	certapi "k8s.io/api/certificates/v1beta1"
+	certificates "k8s.io/api/certificates/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	certificatesclient "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
+	"k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/certificate/csr"
+	"k8s.io/client-go/util/keyutil"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	tenancyv1alpha1 "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/controller/constants"
+)
+
+const (
+	VCWebhookCertCommonName = "virtualcluster-webhook"
+	VCWebhookCertOrg        = "virtualcluster"
+	VCWebhookCertFileName   = "tls.crt"
+	VCWebhookKeyFileName    = "tls.key"
+	VCWebhookServiceName    = "virtualcluster-webhook-service"
+	VCWebhookServiceNs      = "vc-manager"
+	VCWebhookCfgName        = "virtualcluster-validating-webhook-configuration"
+	VCWebhookCfgNs          = "vc-manager"
+	VCWebhookCAFile         = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	VCWebhookCSRName        = "virtualcluster-webhook-csr"
+)
+
+var log = logf.Log.WithName("virtualcluster-webhook")
+
+// Add adds the webhook server to the manager as a runnable
+func Add(mgr manager.Manager, certDir string) error {
+	// 1. create the webhook service
+	if err := createVirtualClusterWebhookService(mgr.GetClient()); err != nil {
+		return err
+	}
+
+	// 2. generate the serving certificate for the webhook server
+	if err := genCertificate(mgr, certDir); err != nil {
+		return err
+	}
+
+	// 3. create the ValidatingWebhookConfiguration
+	log.Info(fmt.Sprintf("will create validatingwebhookconfiguration/%s", VCWebhookCfgName))
+	if err := createValidatingWebhookConfiguration(mgr.GetClient()); err != nil {
+		return err
+	}
+	log.Info(fmt.Sprintf("successfully created validatingwebhookconfiguration/%s", VCWebhookCfgName))
+
+	// 4. register the validating webhook
+	return (&tenancyv1alpha1.VirtualCluster{}).SetupWebhookWithManager(mgr)
+}
+
+// createVirtualClusterWebhookService creates the service for exposing the webhook server
+func createVirtualClusterWebhookService(client client.Client) error {
+	whSvc := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      VCWebhookServiceName,
+			Namespace: VCWebhookServiceNs,
+			Labels: map[string]string{
+				"virtualcluster-webhook": "true",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Port:       constants.VirtualClusterWebhookPort,
+					TargetPort: intstr.FromInt(constants.VirtualClusterWebhookPort),
+				},
+			},
+			Selector: map[string]string{
+				"virtualcluster-webhook": "true",
+			},
+		},
+	}
+	if err := client.Create(context.TODO(), &whSvc); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+		log.Info(fmt.Sprintf("service/%s already exist", VCWebhookServiceName))
+		return nil
+	}
+	log.Info(fmt.Sprintf("successfully created service/%s", VCWebhookServiceName))
+	return nil
+}
+
+// createValidatingWebhookConfiguration creates the validatingwebhookconfiguration for the webhook
+func createValidatingWebhookConfiguration(client client.Client) error {
+	validatePath := "/validate-tenancy-x-k8s-io-v1alpha1-virtualcluster"
+	svcPort := int32(constants.VirtualClusterWebhookPort)
+	// reject request if the webhook doesn't work
+	failPolicy := admv1beta1.Fail
+	// use the serviceaccount ca file as the authority
+	CAPemByts, err := ioutil.ReadFile(VCWebhookCAFile)
+	if err != nil {
+		return err
+	}
+	vwhCfg := admv1beta1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: VCWebhookCfgName,
+			Labels: map[string]string{
+				"virtualcluster-webhook": "true",
+			},
+		},
+		Webhooks: []admv1beta1.ValidatingWebhook{
+			{
+				Name: "virtualcluster.validating.webhook",
+				ClientConfig: admv1beta1.WebhookClientConfig{
+					Service: &admv1beta1.ServiceReference{
+						Name:      VCWebhookServiceName,
+						Namespace: VCWebhookServiceNs,
+						Path:      &validatePath,
+						Port:      &svcPort,
+					},
+					CABundle: CAPemByts,
+				},
+				FailurePolicy: &failPolicy,
+				Rules: []admv1beta1.RuleWithOperations{
+					{
+						Operations: []admv1beta1.OperationType{
+							admv1beta1.OperationAll,
+						},
+						Rule: admv1beta1.Rule{
+							APIGroups:   []string{"tenancy.x-k8s.io"},
+							APIVersions: []string{"v1alpha1"},
+							Resources:   []string{"virtualclusters"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := client.Create(context.TODO(), &vwhCfg); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+		log.Info(fmt.Sprintf("validatingwebhookconfiguration/%s already exist", VCWebhookCfgName))
+		return nil
+	}
+	log.Info(fmt.Sprintf("successfully created validatingwebhookconfiguration/%s", VCWebhookCfgName))
+	return nil
+}
+
+// genCertificate generates the serving cerficiate for the webhook server
+func genCertificate(mgr manager.Manager, certDir string) error {
+	// client-go client for generating certificate
+	clientSet, err := kubernetes.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		return err
+	}
+	csrClient := clientSet.CertificatesV1beta1().CertificateSigningRequests()
+
+	// 1. delete the VC CSR if exist
+	if err := delVCWebhookCSRIfExist(csrClient); err != nil {
+		return err
+	}
+	// 2. generate csr
+	csrPEM, keyPEM, privateKey, err := generateCSR(clientSet)
+	if err != nil {
+		return err
+	}
+
+	// 3. approve the csr
+	go approveVCWebhookCSR(csrClient)
+
+	// 4. submit csr and wait for it to be signed
+	// NOTE this step will block until the CSR is issued
+	csrPEM, err = submitCSRAndWait(csrClient, csrPEM, privateKey)
+	if err != nil {
+		return err
+	}
+
+	// 5. generate certificate files (i.e., tls.crt and tls.key)
+	if err := genCertAndKeyFile(csrPEM, keyPEM, certDir); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// delVCWebhookCSRIfExist deletes the validatingwebhookconfiguration/<VCWebhookCfgName> if exist
+func delVCWebhookCSRIfExist(csrClient certificatesclient.CertificateSigningRequestInterface) error {
+	if err := csrClient.Delete(VCWebhookCSRName, &metav1.DeleteOptions{}); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		log.Info("there is no legacy virtualcluster-webhook CSR")
+	}
+	return nil
+}
+
+// approveVCWebhookCSR approves the first observered CSR whose name is <VCWebhookCSRName>,
+// CommonName is <VCWebhookCertCommonName>, and Organization is <VCWebhookCertOrg>
+func approveVCWebhookCSR(csrClient certificatesclient.CertificateSigningRequestInterface) {
+	_, _ = watchtools.ListWatchUntil(
+		context.Background(),
+		&cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return csrClient.List(options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return csrClient.Watch(options)
+			},
+		},
+		func(event watch.Event) (bool, error) {
+			switch event.Type {
+			// only react to Modified and Added event
+			case watch.Modified, watch.Added:
+			case watch.Deleted:
+				return false, nil
+			default:
+				return false, nil
+			}
+			csr := event.Object.(*certificates.CertificateSigningRequest)
+			if !isVCWebhookCSR(csr) {
+				return false, nil
+			}
+
+			approved, denied := getCertCondition(&csr.Status)
+			// return if the CSR has already been approved or denied
+			if approved || denied {
+				return true, nil
+			}
+
+			log.Info("will try to approve the CSR", "CSR", csr.GetName())
+			// approve the virtualcluster webhook csr
+			csr.Status.Conditions = append(csr.Status.Conditions,
+				certapi.CertificateSigningRequestCondition{
+					Type:    certapi.CertificateApproved,
+					Reason:  "AutoApproved",
+					Message: fmt.Sprintf("Approve the csr/%s", csr.GetName()),
+				})
+
+			result, err := csrClient.UpdateApproval(csr)
+			if err != nil {
+				if result == nil {
+					log.Error(err, fmt.Sprintf("failed to approve virtualcluster csr, %v", err))
+				} else {
+					log.Error(err, fmt.Sprintf("failed to approve virtualcluster csr(%s), %v", result.Name, err))
+				}
+				return false, err
+			}
+			log.Info("successfully approve virtualcluster csr", "csr", result.Name)
+			return true, nil
+		},
+	)
+}
+
+// isVCWebhookCSR check if the given csr is a VirtualCluster Webhook related csr
+func isVCWebhookCSR(csr *certificates.CertificateSigningRequest) bool {
+	pemBytes := csr.Spec.Request
+	block, _ := pem.Decode(pemBytes)
+	if block == nil || block.Type != "CERTIFICATE REQUEST" {
+		return false
+	}
+	x509cr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return false
+	}
+
+	if x509cr.Subject.CommonName != VCWebhookCertCommonName {
+		return false
+	}
+
+	if csr.GetName() != VCWebhookCSRName {
+		log.Info(fmt.Sprintf("will not approve CSR, only approve CSR with name %s", VCWebhookCSRName),
+			"CSR", csr.GetName())
+		return false
+	}
+
+	for _, org := range x509cr.Subject.Organization {
+		if org == VCWebhookCertOrg {
+			return true
+		}
+	}
+	return false
+}
+
+// getCertCondition checks if the given CSR status is approved or denied
+func getCertCondition(status *certificates.CertificateSigningRequestStatus) (bool, bool) {
+	var approved, denied bool
+	for _, c := range status.Conditions {
+		if c.Type == certificates.CertificateApproved {
+			approved = true
+		}
+		if c.Type == certificates.CertificateDenied {
+			denied = true
+		}
+	}
+	return approved, denied
+}
+
+// getSVCClusterIP returns the clusterIP of the webhook service, which will be written
+// into the certificate
+func getSVCClusterIP(clientSet kubernetes.Interface) (net.IP, error) {
+	whSvc, err := clientSet.CoreV1().Services(VCWebhookServiceNs).
+		Get(VCWebhookServiceName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if whSvc.Spec.ClusterIP == "" {
+		return nil, fmt.Errorf("ClusterIP of the service/%s is not set", VCWebhookServiceName)
+	}
+	return net.ParseIP(whSvc.Spec.ClusterIP), nil
+}
+
+// genCertAndKeyFile creates the serving certificate/key files for the webhook server
+func genCertAndKeyFile(certData, keyData []byte, certDir string) error {
+	// always remove first
+	if err := os.RemoveAll(certDir); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(certDir, 0755); err != nil {
+		return fmt.Errorf("could not create directory %q to store certificates: %v", certDir, err)
+	}
+	certPath := filepath.Join(certDir, VCWebhookCertFileName)
+	f, err := os.OpenFile(certPath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0600)
+	if err != nil {
+		return fmt.Errorf("could not open %q: %v", certPath, err)
+	}
+	defer f.Close()
+	certBlock, _ := pem.Decode(certData)
+	if certBlock == nil {
+		return fmt.Errorf("invalid certificate data")
+	}
+	pem.Encode(f, certBlock)
+
+	keyPath := filepath.Join(certDir, VCWebhookKeyFileName)
+	kf, err := os.OpenFile(keyPath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0600)
+	if err != nil {
+		return fmt.Errorf("could not open %q: %v", keyPath, err)
+	}
+
+	keyBlock, _ := pem.Decode(keyData)
+	if keyBlock == nil {
+		return fmt.Errorf("invalid key data")
+	}
+	pem.Encode(kf, keyBlock)
+	log.Info("successfully generate certificate and key file")
+	return nil
+}
+
+// submitCSRAndWait submits the CSR and wait for apiserver to signed it
+func submitCSRAndWait(csrClient certificatesclient.CertificateSigningRequestInterface,
+	csrPEM []byte,
+	privateKey interface{}) ([]byte, error) {
+	req, err := csr.RequestCertificate(
+		csrClient, csrPEM, VCWebhookCSRName,
+		[]certificates.KeyUsage{certificates.UsageServerAuth},
+		privateKey)
+	if err != nil {
+		return nil, err
+	}
+	log.Info("CSR request submitted", "CSR reqest", req.GetName())
+	crtPEM, err := csr.WaitForCertificate(context.TODO(), csrClient, req)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("Certificate request was not signed: %v", err))
+		return nil, nil
+	}
+	log.Info("CSR is signed", "CSR reqest", req.GetName())
+	return crtPEM, nil
+}
+
+// generateCSR generate the csrPEM and corresponding keyPEM
+func generateCSR(clientSet kubernetes.Interface) (csrPEM []byte, keyPEM []byte, key interface{}, err error) {
+	// Generate a new private key.
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), cryptorand.Reader)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("unable to generate a new private key: %v", err)
+	}
+	der, err := x509.MarshalECPrivateKey(privateKey)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("unable to marshal the new key to DER: %v", err)
+	}
+
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: keyutil.ECPrivateKeyBlockType, Bytes: der})
+
+	whSvcIP, err := getSVCClusterIP(clientSet)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	template := &x509.CertificateRequest{
+		Subject: pkix.Name{
+			CommonName:   VCWebhookCertCommonName,
+			Organization: []string{VCWebhookCertOrg},
+		},
+		DNSNames: []string{
+			VCWebhookServiceName,
+			VCWebhookServiceName + "." + VCWebhookServiceNs,
+			VCWebhookServiceName + "." + VCWebhookServiceNs + ".svc",
+		},
+		IPAddresses: []net.IP{whSvcIP},
+	}
+
+	csrPEM, err = cert.MakeCSRFromTemplate(privateKey, template)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("unable to create a csr from the private key: %v", err)
+	}
+	log.Info("CSR is generated")
+	return csrPEM, keyPEM, privateKey, nil
+}

--- a/incubator/virtualcluster/pkg/webhook/webhook.go
+++ b/incubator/virtualcluster/pkg/webhook/webhook.go
@@ -21,15 +21,15 @@ import (
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-var AddToManagerFuncs []func(manager.Manager) error
+var AddToManagerFuncs []func(manager.Manager, string) error
 
 // AddToManager adds all Controllers to the Manager
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
-func AddToManager(m manager.Manager) error {
+func AddToManager(m manager.Manager, certDir string) error {
 	for _, f := range AddToManagerFuncs {
-		if err := f(m); err != nil {
+		if err := f(m, certDir); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
1. add the webhook framework for virtualcluster based on the
   controller-runtime webhook library
2. implement the functionality of automatically generating the webhook
   service/validatingwebhookconfiguration
3. implement the functionality of automatically generating webhook serving
   certificate through the CSR
4. implement the validateUpdate function that forbids virtualcluster.status.phase to be set o empty
5. other minor changes:
   a. fix the clusterversion_v1_nodeport.yaml to adapt the new
      clusterversion crd generated by controller-runtime @v0.4.0
   b. to enable webhook server, add new rabc rules and env to all_in_one.yaml