### PR TITLE
Reworked landing and docs pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,47 @@
-# Multi-tenancy
+# Kubernetes Working Group for Multi-Tenancy
 
-A working place for multi-tenancy related proposals and prototypes.
+This is a working place for multi-tenancy related proposals and prototypes. To
+join our biweekly meetings, Slack, mailing list, [please visit our community
+page](https://github.com/kubernetes/community/blob/master/wg-multitenancy/README.md).
 
-## Community, discussion, contribution, and support
+## Projects
 
-Learn how to engage with the Kubernetes community on the [community page](http://kubernetes.io/community/).
+This repo contains the following projects:
 
-You can reach the maintainers of this project at:
+* **[Benchmarks](benchmarks/):** a set of benchmarks (i.e., compliance
+  tests) to determine if your clusters are well-configured for multitenancy.
+* **[Hierararchical namespaces (aka HNC)](incubator/hnc/):** allows
+  namespaces to own each other, policy propagation between related namespaces,
+  and delegated namespace creation.
+* **[Tenant Operator](tenant/):** an opinionated solution to manage tenants
+  within a cluster.
+* **[Virtual clusters](incubator/virtualcluster):** run multiple virtualized
+  cluster on a single underlying cluster, allowing for hard(er) multitenancy.
 
-- [Slack channel](https://kubernetes.slack.com/messages/wg-multitenancy)
-- [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-multitenancy)
+As these projects mature, they may be adopted by a SIG and moved to their own
+repos.
 
-## Join this repo 
+## Resources
 
-File a request at https://github.com/kubernetes/org to be added to @kubernetes-sigs, using the [Template](https://github.com/kubernetes/org/issues/new?template=membership.md&title=REQUEST%3A%20New%20membership%20for%20%3Cyour-GH-handle%3E).
+The [docs](docs/)  directory contains any documents written in markdown. Some
+draft docs which need collaboration are Google docs for better collaboration
+experience. The [links](docs/links.md) file contains links to all presentations,
+wg-multitenancy minutes, and other docs not directly related to the projects
+above.
 
-Once you've been a member, when you are ready to become a reviewer of other people's code, file a PR on our [OWNERS file](https://github.com/kubernetes-sigs/multi-tenancy/blob/master/OWNERS) and an approver will need to approve you.
+## Join this repo
 
-Once you've been a reviewer, you can request to become an approver by filling a PR on our OWNERS file and another approver will need to approve you.
+File a request at https://github.com/kubernetes/org to be added to
+@kubernetes-sigs, using the
+[Template](https://github.com/kubernetes/org/issues/new?template=membership.md&title=REQUEST%3A%20New%20membership%20for%20%3Cyour-GH-handle%3E).
 
-### Docs directory
+Once you've been a member, when you are ready to become a reviewer of other
+people's code, file a PR on our [OWNERS
+file](https://github.com/kubernetes-sigs/multi-tenancy/blob/master/OWNERS) and
+an approver will need to approve you.
 
-The `docs` directory contains any documents written in markdown.
-Some draft docs which need collaboration are Google docs for better collaboration experience.
-The [Links](docs/links.md) file contains links to all relevant draft Google docs.
-
-### Incubator directory 
-
-The `incubator` directory includes several projects that are actively being incubated within the multi-tenancy working group. This includes the "Hierarchical Namespace" project and the "Virtual Cluster" Project. Additional projects may be added.
-
-- ["Hierarchical Namespace" project design doc](https://docs.google.com/document/d/10MZfFfbQMm33CBboMq2bfrEtXkJQQT4-UH4DDXZRrKY/edit)
-- ["Virtual Cluster" project design doc](https://docs.google.com/document/d/1QAWtYdRZGseSar_KgyfiIisL7JTGMHCfqB_Legfa39w/edit#)
+Once you've been a reviewer, you can request to become an approver by filling a
+PR on our OWNERS file and another approver will need to approve you.
 
 ### [Deprecated] PoC directory
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,0 @@
-# Release Process
-
-The Kubernetes Template Project is released on an as-needed basis. The process is as follows:
-
-1. An issue is proposing a new release with a changelog since the last release
-1. All [OWNERS](OWNERS) must LGTM this release
-1. An OWNER runs `git tag -s $VERSION` and inserts the changelog and pushes the tag with `git push $VERSION`
-1. The release issue is closed
-1. An announcement email is sent to `kubernetes-dev@googlegroups.com` with the subject `[ANNOUNCE] kubernetes-template-project $VERSION is released`

--- a/docs/links.md
+++ b/docs/links.md
@@ -1,15 +1,32 @@
 # Links
 
-This file contains links to files not stored in this repository.
-Many of them are drafts in Google docs for better collaboration experience.
+This file contains links to files **not stored in this repository**. See the
+individual [projects](../README.md#projects) for docs relevant to those
+projects.
 
-## Access to the docs
-
-Some documents listed are shared within limited google groups, 
-please at least join one of the following groups to access the docs:
+Many of files listed below are drafts in Google docs for better collaboration
+experience.  Some of these are shared within limited google groups, please at
+least join one of the following groups to access the docs:
 
 - [kubernetes-dev](https://groups.google.com/forum/#!forum/kubernetes-dev)
 - [kubernetes-wg-multitenancy](https://groups.google.com/forum/#!forum/kubernetes-wg-multitenancy)
+
+## Working Group Meeting Records
+
+- [YouTube Channel](https://www.youtube.com/playlist?list=PL69nYSiGNLP1tBA0W8zEe6UwPsabGQk-j&disable_polymer=true)
+- [Meeting Notes and Agenda](https://docs.google.com/document/d/1fj3yzmeU2eU8ZNBCUJG97dk_wC7228-e_MmdcmTNrZY/edit)
+
+## Presentations
+
+- Kubecon EU 2020 ("Amsterdam" or wherever COVID dropped you, August)
+  - Multi-tenant clusters with hierarchical namespaces (@adrianludwin, [Aug 19](https://sched.co/Zeuh))
+  - Virtual Cluster - A Practical Kubernetes Hard Multi-tenancy Solution (@Fei-Guo, [Aug 19](https://sched.co/Zek6))
+- Kubecon NA 2019 (San Diego, November)
+  - [Intro to wg-multitenancy (@tashimi)](https://www.youtube.com/watch?v=589ORHspowE)
+  - [Deep dive (@srampal and @adrianludwin)](https://www.youtube.com/watch?v=PA101KUDusY)
+  - [Panel: the tenets of multitenancy (tashimi@, @tashimi, @rjbez17, @Fei-Guo, @adrianludwin)](https://www.youtube.com/watch?v=WN8mmHU2HOU)
+- Kubecon EU 2019 (Barcelona)
+  - [Kubernetes Multitenancy WG Deep Dive](https://drive.google.com/open?id=1tYIjKga6zveyd5LnavbqS5tsxUplnZpL)
 
 ## WG Architecture Summaries & Presentations
 
@@ -17,15 +34,14 @@ please at least join one of the following groups to access the docs:
 - [Kubernetes Multitenancy WG Deep Dive KubeCon EU 2019 (last updated 5/22/2019)](https://drive.google.com/open?id=1tYIjKga6zveyd5LnavbqS5tsxUplnZpL)
 - [K8s Multi-tenancy WG Plan (last updated 3/1/2019)](https://docs.google.com/presentation/d/1dsAsVm8kCA9Dx9_gMEYeJL7pduAbnfnxT9lhbyCvHDg/edit#slide=id.p19)
 
-## Draft feature proposals  
+## Draft feature proposals
 
-- [Tenant Concept in Kubernetes](https://drive.google.com/open?id=1ddx7UAEPKFPldBh_diksYO4WZXSHDUhm-e6hyNNGYVU)
-- [Kubernetes Tenant CRD](https://drive.google.com/open?id=1hpJX5O_siMmNGMvIHvz8Pm7XOjJLz5g57XWrgwWarFw)
-- [A Virtual Cluster Based Multi-tenancy Solution](https://docs.google.com/document/d/1EELeVaduYZ65j4AXg9bp3Kyn38GKDU5fAJ5LFcxt2ZU)
+- [Tenant Concept in Kubernetes (Apr 2019)](https://drive.google.com/open?id=1ddx7UAEPKFPldBh_diksYO4WZXSHDUhm-e6hyNNGYVU)
+- [Kubernetes Tenant CRD (Mar 2019)](https://drive.google.com/open?id=1hpJX5O_siMmNGMvIHvz8Pm7XOjJLz5g57XWrgwWarFw)
+- [A Virtual Cluster Based Multi-tenancy Solution (Apr 2019)](https://docs.google.com/document/d/1EELeVaduYZ65j4AXg9bp3Kyn38GKDU5fAJ5LFcxt2ZU)
 
-## References
+## Other references
 
-- [Kubernetes Multitenancy WG Deep Dive KubeCon EU 2019](https://drive.google.com/open?id=1tYIjKga6zveyd5LnavbqS5tsxUplnZpL)
 - [Kubernetes Tenant Controller](https://docs.google.com/document/d/1auNOT2Hpguaxcqg8dX6JLLw5-RYQ0Abp6_-OcUP4pbI)
 - [Kubernetes Multi-Tenancy Design Scratch Space](https://docs.google.com/document/d/1PjlsBmZw6Jb3XZeVyZ0781m6PV7-nSUvQrwObkvz7jg/edit)
 - [Multi-tenancy Models for Kubernetes](https://docs.google.com/document/d/15w1_fesSUZHv-vwjiYa9vN_uyc--PySRoLKTuDhimjc/edit)
@@ -39,8 +55,3 @@ please at least join one of the following groups to access the docs:
 - [KEP: Security Profile](https://github.com/kubernetes/community/pull/2052)
 - [Multi-Tenancy in Kubernetes: Best Practices Today, and Future Directions](https://youtu.be/xygE8DbwJ7c)
 - [A Kubernetes Operator for managing multi-tenant workloads](https://github.com/lessor/lessor)
-
-## Working Group Meeting Records
-
-- [YouTube Channel](https://www.youtube.com/playlist?list=PL69nYSiGNLP1tBA0W8zEe6UwPsabGQk-j&disable_polymer=true)
-- [Meeting Notes and Agenda](https://docs.google.com/document/d/1fj3yzmeU2eU8ZNBCUJG97dk_wC7228-e_MmdcmTNrZY/edit)


### PR DESCRIPTION
Changes:
* Provide up-front links to our biweekly meetings (was missing before)
* Highlight the four active projects
* Clean up docs/links.md to highlight more recent content
* Removed redundant "releases" doc