### PR TITLE
Line up Cloud Build with makefile

### DIFF
--- a/incubator/hnc/Makefile
+++ b/incubator/hnc/Makefile
@@ -27,6 +27,8 @@ else
 endif
 endif
 
+# Override this to release from a different repo
+HNC_REPO_USER ?= "kubernetes-sigs"
 HNC_RELEASED_IMG ?= "gcr.io/k8s-staging-multitenancy/${HNC_IMG_NAME}:${HNC_IMG_TAG}"
 
 CONTROLLER_GEN ?= "./bin/controller-gen"
@@ -245,7 +247,7 @@ release: check-release-env test
 	@echo "Invoking Cloud Build"
 	@echo "*********************************************"
 	@echo "*********************************************"
-	@gcloud builds submit --config cloudbuild.yaml --no-source --substitutions=_HNC_IMG_TAG=${HNC_IMG_TAG},_HNC_USER=${HNC_USER},_HNC_PERSONAL_ACCESS_TOKEN=${HNC_PAT},_HNC_RELEASE_ID=${HNC_RELEASE_ID},_HNC_RELEASED_IMG=${HNC_RELEASED_IMG}
+	@gcloud builds submit --config cloudbuild.yaml --no-source --substitutions=_HNC_REPO_USER=${HNC_REPO_USER},_HNC_IMG_NAME=${HNC_IMG_NAME},_HNC_IMG_TAG=${HNC_IMG_TAG},_HNC_USER=${HNC_USER},_HNC_PERSONAL_ACCESS_TOKEN=${HNC_PAT},_HNC_RELEASE_ID=${HNC_RELEASE_ID},_HNC_RELEASED_IMG=${HNC_RELEASED_IMG}
 	@echo Pushing image to K8s staging
 	@docker pull ${HNC_IMG}
 	@docker tag ${HNC_IMG} ${HNC_RELEASED_IMG}

--- a/incubator/hnc/cloudbuild.yaml
+++ b/incubator/hnc/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
   args:
   - '-c'
   - |
-    git clone https://github.com/kubernetes-sigs/multi-tenancy
+    git clone https://github.com/$_HNC_REPO_USER/multi-tenancy
     cd multi-tenancy
     git checkout hnc-$_HNC_IMG_TAG
 # Build the manifests and the kubectl plugin
@@ -57,6 +57,6 @@ steps:
   - 'https://uploads.github.com/repos/kubernetes-sigs/multi-tenancy/releases/$_HNC_RELEASE_ID/assets?name=kubectl-hns'
 # Build Docker image
 - name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/hnc/controller:$_HNC_IMG_TAG', 'multi-tenancy/incubator/hnc']
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/$_HNC_IMG_NAME:$_HNC_IMG_TAG', 'multi-tenancy/incubator/hnc']
 
-images: ['gcr.io/$PROJECT_ID/hnc/controller:$_HNC_IMG_TAG']
+images: ['gcr.io/$PROJECT_ID/$_HNC_IMG_NAME:$_HNC_IMG_TAG']


### PR DESCRIPTION
The makefile recently changed the name of the released image, but we
didn't update Cloud Build to match; this commit fixes that. It also
allows CB to pull from a different repo to make testing release changes
easier.

Tested: created a fake release and built from
gihub.com/adrianludwin/multi-tenancy using the new override.