### PR TITLE
Update v1alpha2 HNCConfig modes to camel case

### DIFF
--- a/incubator/hnc/api/v1alpha2/hnc_config.go
+++ b/incubator/hnc/api/v1alpha2/hnc_config.go
@@ -26,21 +26,21 @@ const (
 )
 
 // SynchronizationMode describes propagation mode of objects of the same kind.
-// The only three modes currently supported are "propagate", "ignore", and "remove".
+// The only three modes currently supported are "Propagate", "Ignore", and "Remove".
 // See detailed definition below. An unsupported mode will be treated as "ignore".
 type SynchronizationMode string
 
 const (
 	// Propagate objects from ancestors to descendants and deletes obsolete descendants.
-	Propagate SynchronizationMode = "propagate"
+	Propagate SynchronizationMode = "Propagate"
 
 	// Ignore the modification of this type. New or changed objects will not be propagated,
 	// and obsolete objects will not be deleted. The inheritedFrom label is not removed.
-	// Any unknown mode is treated as ignore.
-	Ignore SynchronizationMode = "ignore"
+	// Any unknown mode is treated as Ignore.
+	Ignore SynchronizationMode = "Ignore"
 
 	// Remove all existing propagated copies.
-	Remove SynchronizationMode = "remove"
+	Remove SynchronizationMode = "Remove"
 )
 
 // HNCConfigurationCondition codes. *All* codes must also be documented in the
@@ -57,9 +57,9 @@ type TypeSynchronizationSpec struct {
 	// Kind to be configured.
 	Kind string `json:"kind"`
 	// Synchronization mode of the kind. If the field is empty, it will be treated
-	// as "propagate".
+	// as "Propagate".
 	// +optional
-	// +kubebuilder:validation:Enum=propagate;ignore;remove
+	// +kubebuilder:validation:Enum=Propagate;Ignore;Remove
 	Mode SynchronizationMode `json:"mode,omitempty"`
 }
 

--- a/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
+++ b/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
@@ -42,11 +42,11 @@ spec:
                     description: Kind to be configured.
                     type: string
                   mode:
-                    description: Synchronization mode of the kind. If the field is empty, it will be treated as "propagate".
+                    description: Synchronization mode of the kind. If the field is empty, it will be treated as "Propagate".
                     enum:
-                    - propagate
-                    - ignore
-                    - remove
+                    - Propagate
+                    - Ignore
+                    - Remove
                     type: string
                 required:
                 - apiVersion

--- a/incubator/hnc/internal/validators/hncconfig_test.go
+++ b/incubator/hnc/internal/validators/hncconfig_test.go
@@ -56,10 +56,10 @@ func TestRBACTypes(t *testing.T) {
 		allow   bool
 	}{
 		{
-			name: "Correct RBAC config with propagate mode",
+			name: "Correct RBAC config with Propagate mode",
 			configs: []api.TypeSynchronizationSpec{
-				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
-				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "Propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "Propagate"},
 			},
 			allow: true,
 		},
@@ -74,44 +74,44 @@ func TestRBACTypes(t *testing.T) {
 		{
 			name: "Missing Role",
 			configs: []api.TypeSynchronizationSpec{
-				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "Propagate"},
 			},
 			allow: false,
 		}, {
 			name: "Missing RoleBinding",
 			configs: []api.TypeSynchronizationSpec{
-				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "Propagate"},
 			},
 			allow: false,
 		}, {
 			name: "Incorrect Role mode",
 			configs: []api.TypeSynchronizationSpec{
-				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "ignore"},
-				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "Ignore"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "Propagate"},
 			},
 			allow: false,
 		}, {
 			name: "Incorrect RoleBinding mode",
 			configs: []api.TypeSynchronizationSpec{
-				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
-				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "ignore"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "Propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "Ignore"},
 			},
 			allow: false,
 		}, {
 			name: "Duplicate RBAC types with different modes",
 			configs: []api.TypeSynchronizationSpec{
-				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "Propagate"},
 				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
-				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "Propagate"},
 			},
 			allow: false,
 		},
 		{
 			name: "Duplicate RBAC types with the same mode",
 			configs: []api.TypeSynchronizationSpec{
-				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
-				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
-				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "Propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "Propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "Propagate"},
 			},
 			allow: false,
 		},
@@ -142,9 +142,9 @@ func TestNonRBACTypes(t *testing.T) {
 		{
 			name: "Correct Non-RBAC types config",
 			configs: []api.TypeSynchronizationSpec{
-				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
-				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "propagate"},
-				{APIVersion: "v1", Kind: "Secret", Mode: "ignore"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "Propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "Propagate"},
+				{APIVersion: "v1", Kind: "Secret", Mode: "Ignore"},
 				{APIVersion: "v1", Kind: "ResourceQuota"},
 			},
 			validator: f,
@@ -153,30 +153,30 @@ func TestNonRBACTypes(t *testing.T) {
 		{
 			name: "Resource does not exist",
 			configs: []api.TypeSynchronizationSpec{
-				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
-				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "Propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "Propagate"},
 				// "CronTab" kind does not exist in "v1"
-				{APIVersion: "v1", Kind: "CronTab", Mode: "ignore"},
+				{APIVersion: "v1", Kind: "CronTab", Mode: "Ignore"},
 			},
 			validator: f,
 			allow:     false,
 		}, {
 			name: "Duplicate types with different modes",
 			configs: []api.TypeSynchronizationSpec{
-				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
-				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "propagate"},
-				{APIVersion: "v1", Kind: "Secret", Mode: "ignore"},
-				{APIVersion: "v1", Kind: "Secret", Mode: "propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "Propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "Propagate"},
+				{APIVersion: "v1", Kind: "Secret", Mode: "Ignore"},
+				{APIVersion: "v1", Kind: "Secret", Mode: "Propagate"},
 			},
 			validator: f,
 			allow:     false,
 		}, {
 			name: "Duplicate types with the same mode",
 			configs: []api.TypeSynchronizationSpec{
-				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "propagate"},
-				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "propagate"},
-				{APIVersion: "v1", Kind: "Secret", Mode: "ignore"},
-				{APIVersion: "v1", Kind: "Secret", Mode: "ignore"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "Propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "Propagate"},
+				{APIVersion: "v1", Kind: "Secret", Mode: "Ignore"},
+				{APIVersion: "v1", Kind: "Secret", Mode: "Ignore"},
 			},
 			validator: f,
 			allow:     false,

--- a/incubator/hnc/test/e2e/demo_test.go
+++ b/incubator/hnc/test/e2e/demo_test.go
@@ -70,8 +70,8 @@ var _ = Describe("Demo", func() {
 	})
 
 	It("Should propagate different types", func() {
-		// ignore Secret in case this demo is run twice and the secret has been set to propagate
-		MustRun("kubectl hns config set-type --apiVersion v1 --kind Secret ignore")
+		// ignore Secret in case this demo is run twice and the secret has been set to 'Propagate'
+		MustRun("kubectl hns config set-type --apiVersion v1 --kind Secret Ignore")
 		MustRun("kubectl create ns", nsOrg)
 		MustRun("kubectl hns create", nsTeamA, "-n", nsOrg)
 		MustRun("kubectl hns create", nsTeamB, "-n", nsOrg)
@@ -82,7 +82,7 @@ var _ = Describe("Demo", func() {
 		time.Sleep(2 * time.Second)
 		// secret does not show up in service-1 because we haven’t configured HNC to propagate secrets in HNCConfiguration.
 		RunShouldNotContain("my-creds", 2, "kubectl -n", nsService1, "get secrets")
-		MustRun("kubectl hns config set-type --apiVersion v1 --kind Secret propagate")
+		MustRun("kubectl hns config set-type --apiVersion v1 --kind Secret Propagate")
 		// this command is not needed here, just to check that user can run it without error
 		MustRun("kubectl get hncconfiguration config -oyaml")
 		RunShouldContain("my-creds", 2, "kubectl -n", nsService1, "get secrets")
@@ -129,7 +129,7 @@ spec:
 		defer RemoveFile(filename)
 		MustRun("kubectl apply -f", filename)
 		// ensure this policy can be propagated to its descendants
-		MustRun("kubectl hns config set-type --apiVersion networking.k8s.io/v1 --kind NetworkPolicy propagate")
+		MustRun("kubectl hns config set-type --apiVersion networking.k8s.io/v1 --kind NetworkPolicy Propagate")
 		expected := "deny-from-other-namespaces"
 		RunShouldContain(expected, 2, "kubectl get netpol -n", nsOrg)
 		RunShouldContain(expected, 2, "kubectl get netpol -n", nsTeamA)
@@ -138,7 +138,7 @@ spec:
 		RunShouldContain(expected, 2, "kubectl get netpol -n", nsService2)
 
 		// Now we’ll see that we can no longer access service-2 from the client in service-1:
-		RunErrorShouldContain("wget: download timed out", 10, 
+		RunErrorShouldContain("wget: download timed out", 10,
 			"kubectl run client -n", nsService1, clientArgs, cmdln)
 		
 		// create a second network policy that will allow all namespaces within team-a to be able to communicate with each other


### PR DESCRIPTION
Update v1alpha2 HNCConfig sync modes to camel case, e.g. 'propagate' to
'Propagate'.

In addition, add e2e test case to make sure v1alpha2 HNCConfig
reconciler is working as expected. Verify v1alpha1 'propagate' is not
treated as unknown and converted to v1alpha2 'Ignore'. Verify object
propagation is still working after conversion. Verify all modes are
converted correctly.

Update 2 HNC e2e test cases in demo_test to use the new camel-case
modes.

Tested by 'make test-conversion'. When the old cached image was used,
v1alpha1 'propagate' was converted to v1alpha2 'Ignore'. After the image
was re-pulled, it was converted to v1alpha2 'Propagate' correctly.

Also passed the focused tests on the 2 HNC e2e test cases.

See #1025 about the cached image issue.
Part of #868 
