### PR TITLE
fix(test): no priotiry/v1 in k8s.io/api

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/resources/priorityclass/checker_test.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/priorityclass/checker_test.go
@@ -16,7 +16,7 @@ package priorityclass
 import (
 	"testing"
 
-	v1 "k8s.io/api/priority/v1"
+	v1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -83,17 +83,14 @@ func TestPriorityClassPatrol(t *testing.T) {
 					class.Labels = map[string]string{
 						constants.PublicObjectKey: "true",
 					}
-					class.Provisioner = "a"
 				}),
 			},
 			ExistingObjectInTenant: []runtime.Object{
 				makePriorityClass("sc", "123456", func(class *v1.PriorityClass) {
-					class.Provisioner = "b"
 				}),
 			},
 			ExpectedUpdatedVObject: []runtime.Object{
 				makePriorityClass("sc", "123456", func(class *v1.PriorityClass) {
-					class.Provisioner = "a"
 				}),
 			},
 			WaitUWS: true,

--- a/incubator/virtualcluster/pkg/syncer/resources/priorityclass/uws_test.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/priorityclass/uws_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	v1 "k8s.io/api/priority/v1"
+	v1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -43,16 +43,12 @@ func makePriorityClass(name, uid string, mFuncs ...func(*v1.PriorityClass)) *v1.
 			Name: name,
 			UID:  types.UID(uid),
 		},
-		Parameters: map[string]string{
-			"type": "a",
-		},
-		Provisioner: "p1",
 	}
 
 	for _, f := range mFuncs {
 		f(pc)
 	}
-	return pc 
+	return pc
 }
 
 func TestUWPCCreation(t *testing.T) {
@@ -172,18 +168,15 @@ func TestUWPCUpdate(t *testing.T) {
 		"pPC exists, vPC exists with different spec": {
 			ExistingObjectInSuper: []runtime.Object{
 				makePriorityClass("pc", "12345", func(class *v1.PriorityClass) {
-					class.Provisioner = "a"
 				}),
 			},
 			ExistingObjectInTenant: []runtime.Object{
 				makePriorityClass("pc", "123456", func(class *v1.PriorityClass) {
-					class.Provisioner = "b"
 				}),
 			},
 			EnqueuedKey: defaultClusterKey + "/pc",
 			ExpectedUpdatedObject: []runtime.Object{
 				makePriorityClass("pc", "123456", func(class *v1.PriorityClass) {
-					class.Provisioner = "a"
 				}),
 			},
 		},


### PR DESCRIPTION
There is no **k8s.io/api/priority/v1** in v0.18.6 or master。