### PR TITLE
HNC: Add support for plugin build for darwin amd64

### DIFF
--- a/incubator/hnc/cloudbuild.yaml
+++ b/incubator/hnc/cloudbuild.yaml
@@ -30,7 +30,8 @@ steps:
     kustomize build . -o ./hnc-manager.yaml
 
     # Build plugin
-    go build -o kubectl-hns ../cmd/kubectl/main.go
+    GOOS=linux GOARCH=amd64 go build -o kubectl-hns_linux_amd64 ../cmd/kubectl/main.go
+    GOOS=darwin GOARCH=amd64 go build -o kubectl-hns_darwin_amd64 ../cmd/kubectl/main.go
 # Upload manifest
 - name: gcr.io/cloud-builders/curl
   args:
@@ -43,7 +44,7 @@ steps:
   - '-u'
   - '$_HNC_USER:$_HNC_PERSONAL_ACCESS_TOKEN'
   - 'https://uploads.github.com/repos/kubernetes-sigs/multi-tenancy/releases/$_HNC_RELEASE_ID/assets?name=hnc-manager.yaml'
-# Upload plugin
+# Upload plugin (Linux)
 - name: gcr.io/cloud-builders/curl
   args:
   - '-X'
@@ -51,10 +52,22 @@ steps:
   - '-H'
   - 'Content-Type: application/x-application'
   - '--data-binary'
-  - '@multi-tenancy/incubator/hnc/out/kubectl-hns'
+  - '@multi-tenancy/incubator/hnc/out/kubectl-hns_linux_amd64'
   - '-u'
   - '$_HNC_USER:$_HNC_PERSONAL_ACCESS_TOKEN'
-  - 'https://uploads.github.com/repos/kubernetes-sigs/multi-tenancy/releases/$_HNC_RELEASE_ID/assets?name=kubectl-hns'
+  - 'https://uploads.github.com/repos/kubernetes-sigs/multi-tenancy/releases/$_HNC_RELEASE_ID/assets?name=kubectl-hns_linux_amd64'
+# Upload plugin (Darwin)
+- name: gcr.io/cloud-builders/curl
+  args:
+  - '-X'
+  - 'POST'
+  - '-H'
+  - 'Content-Type: application/x-application'
+  - '--data-binary'
+  - '@multi-tenancy/incubator/hnc/out/kubectl-hns_darwin_amd64'
+  - '-u'
+  - '$_HNC_USER:$_HNC_PERSONAL_ACCESS_TOKEN'
+  - 'https://uploads.github.com/repos/kubernetes-sigs/multi-tenancy/releases/$_HNC_RELEASE_ID/assets?name=kubectl-hns_darwin_amd64'
 # Build Docker image
 - name: gcr.io/cloud-builders/docker
   args: ['build', '-t', 'gcr.io/$PROJECT_ID/$_HNC_IMG_NAME:$_HNC_IMG_TAG', 'multi-tenancy/incubator/hnc']


### PR DESCRIPTION
Related issue: https://github.com/kubernetes-sigs/multi-tenancy/issues/1029

This PR adds support for building and uploading the plugin for the darwin (Mac) environment. I just follow the current way which is done by Linux build. This changes binary name of release so we need to update the guide as well. If the current way is ok then let me update the guide as well. 