### PR TITLE
Update v1alpah2 SubnamespaceAnchor status to camel case

### DIFF
--- a/incubator/hnc/api/v1alpha2/subnamespace_anchor.go
+++ b/incubator/hnc/api/v1alpha2/subnamespace_anchor.go
@@ -28,15 +28,15 @@ const (
 )
 
 // SubnamespaceAnchorState describes the state of the subnamespace. The state could be
-// "missing", "ok", "conflict" or "forbidden". The definitions will be described below.
+// "Missing", "Ok", "Conflict" or "Forbidden". The definitions will be described below.
 type SubnamespaceAnchorState string
 
 // Anchor states, which are documented in the comment to SubnamespaceAnchorStatus.State.
 const (
-	Missing   SubnamespaceAnchorState = "missing"
-	Ok        SubnamespaceAnchorState = "ok"
-	Conflict  SubnamespaceAnchorState = "conflict"
-	Forbidden SubnamespaceAnchorState = "forbidden"
+	Missing   SubnamespaceAnchorState = "Missing"
+	Ok        SubnamespaceAnchorState = "Ok"
+	Conflict  SubnamespaceAnchorState = "Conflict"
+	Forbidden SubnamespaceAnchorState = "Forbidden"
 )
 
 // SubnamespaceAnchorStatus defines the observed state of SubnamespaceAnchor.
@@ -45,15 +45,15 @@ type SubnamespaceAnchorStatus struct {
 	//
 	// Currently, the supported values are:
 	//
-	// - "missing": the subnamespace has not been created yet. This should be the default state when
+	// - "Missing": the subnamespace has not been created yet. This should be the default state when
 	// the anchor is just created.
 	//
-	// - "ok": the subnamespace exists.
+	// - "Ok": the subnamespace exists.
 	//
-	// - "conflict": a namespace of the same name already exists. The admission controller will
+	// - "Conflict": a namespace of the same name already exists. The admission controller will
 	// attempt to prevent this.
 	//
-	// - "forbidden": the anchor was created in a namespace that doesn't allow children, such as
+	// - "Forbidden": the anchor was created in a namespace that doesn't allow children, such as
 	// kube-system or hnc-system. The admission controller will attempt to prevent this.
 	State SubnamespaceAnchorState `json:"status,omitempty"`
 }

--- a/incubator/hnc/config/crd/bases/hnc.x-k8s.io_subnamespaceanchors.yaml
+++ b/incubator/hnc/config/crd/bases/hnc.x-k8s.io_subnamespaceanchors.yaml
@@ -33,7 +33,7 @@ spec:
           description: SubnamespaceAnchorStatus defines the observed state of SubnamespaceAnchor.
           properties:
             status:
-              description: "Describes the state of the subnamespace anchor. \n Currently, the supported values are: \n - \"missing\": the subnamespace has not been created yet. This should be the default state when the anchor is just created. \n - \"ok\": the subnamespace exists. \n - \"conflict\": a namespace of the same name already exists. The admission controller will attempt to prevent this. \n - \"forbidden\": the anchor was created in a namespace that doesn't allow children, such as kube-system or hnc-system. The admission controller will attempt to prevent this."
+              description: "Describes the state of the subnamespace anchor. \n Currently, the supported values are: \n - \"Missing\": the subnamespace has not been created yet. This should be the default state when the anchor is just created. \n - \"Ok\": the subnamespace exists. \n - \"Conflict\": a namespace of the same name already exists. The admission controller will attempt to prevent this. \n - \"Forbidden\": the anchor was created in a namespace that doesn't allow children, such as kube-system or hnc-system. The admission controller will attempt to prevent this."
               type: string
           type: object
       type: object

--- a/incubator/hnc/test/conversion/conversion_test.go
+++ b/incubator/hnc/test/conversion/conversion_test.go
@@ -77,7 +77,7 @@ metadata:
 		verifyCRDConversion()
 		// Verify subnamespace anchor status in the new version.
 		FieldShouldContainWithTimeout(anchorCRD, nsA, nsB, ".apiVersion", "v1alpha2", crdConversionTime)
-		FieldShouldContain(anchorCRD, nsA, nsB, ".status.status", "ok")
+		FieldShouldContain(anchorCRD, nsA, nsB, ".status.status", "Ok")
 	})
 
 	It("should convert HCs with parent", func() {


### PR DESCRIPTION
Tested by 'make test-conversion'. It failed before and passed after
changing the v1alpha2 status check from 'ok' to 'Ok'.

Part of #868 