### PR TITLE
Update v1alpha2 HC schema with allowCascadingDeletion

### DIFF
--- a/incubator/hnc/api/v1alpha1/hierarchy_types_conversion.go
+++ b/incubator/hnc/api/v1alpha1/hierarchy_types_conversion.go
@@ -26,7 +26,7 @@ func (src *HierarchyConfiguration) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1a2.HierarchyConfiguration)
 
 	// Spec
-	dst.Spec.AllowCascadingDelete = src.Spec.AllowCascadingDelete
+	dst.Spec.AllowCascadingDeletion = src.Spec.AllowCascadingDelete
 	dst.Spec.Parent = src.Spec.Parent
 
 	// We don't need to convert status because controllers will update it.

--- a/incubator/hnc/api/v1alpha2/hierarchy_types.go
+++ b/incubator/hnc/api/v1alpha2/hierarchy_types.go
@@ -111,9 +111,9 @@ type HierarchyConfigurationSpec struct {
 	// Parent indicates the parent of this namespace, if any.
 	Parent string `json:"parent,omitempty"`
 
-	// AllowCascadingDelete indicates if the subnamespaces of this namespace are allowed to cascading
-	// delete. TODO update it to allowCascadingDeletion.
-	AllowCascadingDelete bool `json:"allowCascadingDelete,omitempty"`
+	// AllowCascadingDeletion indicates if the subnamespaces of this namespace are
+	// allowed to cascading delete.
+	AllowCascadingDeletion bool `json:"allowCascadingDeletion,omitempty"`
 }
 
 // HierarchyStatus defines the observed state of Hierarchy

--- a/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hierarchyconfigurations.yaml
+++ b/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hierarchyconfigurations.yaml
@@ -112,8 +112,8 @@ spec:
           spec:
             description: HierarchySpec defines the desired state of Hierarchy
             properties:
-              allowCascadingDelete:
-                description: AllowCascadingDelete indicates if the subnamespaces of this namespace are allowed to cascading delete. TODO update it to allowCascadingDeletion.
+              allowCascadingDeletion:
+                description: AllowCascadingDeletion indicates if the subnamespaces of this namespace are allowed to cascading delete.
                 type: boolean
               parent:
                 description: Parent indicates the parent of this namespace, if any.

--- a/incubator/hnc/docs/user-guide/how-to.md
+++ b/incubator/hnc/docs/user-guide/how-to.md
@@ -206,8 +206,8 @@ However, if you actually try this, you'll get an error:
 ```
 $ kubectl delete namespace parent
 # Output:
-Error from server (Forbidden): admission webhook "namespaces.hnc.x-k8s.io" denied the request: Please set allowCascadingDelete first either in the parent namespace or in all the subnamespaces.
- Subnamespace(s) without allowCascadingDelete set: [child].
+Error from server (Forbidden): admission webhook "namespaces.hnc.x-k8s.io" denied the request: Please set allowCascadingDeletion first either in the parent namespace or in all the subnamespaces.
+ Subnamespace(s) without allowCascadingDeletion set: [child].
 ```
 
 These errors are there for your protection. Deleting namespaces is very
@@ -215,10 +215,10 @@ dangerous, and deleting _subnamespaces_ can result in entire subtrees of
 namespaces being deleted as well. Therefore, if deleting a namespace (or
 subnamespace) would result in the deletion of any namespace _other than the one
 explicitly being deleted_, HNC requires that you must specify the
-`allowCascadingDelete` field on either all the namespaces that will be
+`allowCascadingDeletion` field on either all the namespaces that will be
 implicitly deleted, or any of their ancestors.
 
-The `allowCascadingDelete` field is a bit like `rm -rf` in a Linux shell.
+The `allowCascadingDeletion` field is a bit like `rm -rf` in a Linux shell.
 
 > **WARNING: this option is very dangerous, so you should only set it on the lowest
 possible level of the hierarchy.**
@@ -228,24 +228,13 @@ deleted, and so will any subnamespaces of those namespaces, and so on. However,
 any _full_ namespaces that are descendants of a subnamespace will not be
 deleted.**
 
-> _Note: In HNC v0.4.x and earlier, the inheritance of `allowCascadingDelete` is
-> actually a bit more restricted than what's sketched out above: its value is
-> only inherited through ancestor _subnamespaces_, or up to the _first_ full
-> namespace._
->
-> _For example, if subnamespace `child` has ancestors `parent` and `grandparent`,
-> both of which are full namespaces, we will only respect the
-> `allowCascadingDelete` field on `parent`, not on `grandparent`. This is
-> because if `grandparent` is deleted, `parent` will not be affected, and
-> therefore neither will `child`._
->
-> _This behaviour was simplified in HNC v0.5.x
-> ([#730](https://github.com/kubernetes-sigs/multi-tenancy/issues/730))._
+> _Note: In HNC v0.5.x and earlier, HNC uses v1alpha1 API and this field is
+> called `allowCascadingDelete`._
 
-To set the `allowCascadingDelete` field on a namespace using the plugin:
+To set the `allowCascadingDeletion` field on a namespace using the plugin:
 
 ```
-$ kubectl hns set parent --allowCascadingDelete
+$ kubectl hns set parent --allowCascadingDeletion
 # Output:
 Allowing cascading deletion on 'parent'
 Succesfully updated 1 property of the hierarchical configuration of parent
@@ -254,8 +243,8 @@ $ kubectl delete namespace parent
 # Should succeed
 ```
 
-To set the `allowCascadingDelete` field without the plugin, simply set the
-`spec.allowCascadingDelete field` to true in the namespace's
+To set the `allowCascadingDeletion` field without the plugin, simply set the
+`spec.allowCascadingDeletion field` to true in the namespace's
 `hierarchyconfiguration/hierarchy` object - for example, via:
 
 ```
@@ -491,7 +480,7 @@ does not make them an _administrator_ of that subnamespace. That requires
 someone to explicitly grant them the `update` permission for the
 `HierarchyConfiguration` object in that namespace. As a result, an unprivileged
 user who creates a subnamespace generally can’t delete it as well, since this
-would require them to set the `allowCascadingDelete` property of the child
+would require them to set the `allowCascadingDeletion` property of the child
 namespace.
 
 <a name="admin-types"/>

--- a/incubator/hnc/internal/forest/namespace.go
+++ b/incubator/hnc/internal/forest/namespace.go
@@ -20,12 +20,12 @@ type conditions map[api.AffectedObject]map[api.Code]string
 // Namespace represents a namespace in a forest. Other than its structure, it contains some
 // properties useful to the reconcilers.
 type Namespace struct {
-	forest               *Forest
-	name                 string
-	parent               *Namespace
-	children             namedNamespaces
-	exists               bool
-	allowCascadingDelete bool
+	forest                 *Forest
+	name                   string
+	parent                 *Namespace
+	children               namedNamespaces
+	exists                 bool
+	allowCascadingDeletion bool
 
 	// sourceObjects store the objects created by users, identified by GVK and name.
 	// It serves as the source of truth for object controllers to propagate objects.
@@ -99,15 +99,15 @@ func (ns *Namespace) clean() {
 	delete(ns.forest.namespaces, ns.name)
 }
 
-// UpdateAllowCascadingDelete updates if this namespace allows cascading deletion.
-func (ns *Namespace) UpdateAllowCascadingDelete(acd bool) {
-	ns.allowCascadingDelete = acd
+// UpdateAllowCascadingDeletion updates if this namespace allows cascading deletion.
+func (ns *Namespace) UpdateAllowCascadingDeletion(acd bool) {
+	ns.allowCascadingDeletion = acd
 }
 
-// AllowsCascadingDelete returns true if the namespace's or any of the ancestors'
-// allowCascadingDelete field is set to true.
-func (ns *Namespace) AllowsCascadingDelete() bool {
-	if ns.allowCascadingDelete == true {
+// AllowsCascadingDeletion returns true if the namespace's or any of the ancestors'
+// allowCascadingDeletion field is set to true.
+func (ns *Namespace) AllowsCascadingDeletion() bool {
+	if ns.allowCascadingDeletion == true {
 		return true
 	}
 	if ns.parent == nil || ns.CycleNames() != nil {
@@ -115,7 +115,7 @@ func (ns *Namespace) AllowsCascadingDelete() bool {
 	}
 
 	// This namespace is neither a root nor in a cycle, so this line can't cause a stack overflow.
-	return ns.parent.AllowsCascadingDelete()
+	return ns.parent.AllowsCascadingDeletion()
 }
 
 // SetAnchors updates the anchors and returns a difference between the new/old list.

--- a/incubator/hnc/internal/kubectl/set.go
+++ b/incubator/hnc/internal/kubectl/set.go
@@ -48,20 +48,20 @@ var setCmd = &cobra.Command{
 	kubectl hns set bar --root --parent foo # error
 
 	# Allow 'foo', or any of its descendants, to be cascading deleted
-	kubectl hns set foo --allowCascadingDelete
+	kubectl hns set foo --allowCascadingDeletion
 	kubectl hns set foo -a
 
 	# Forbids cascading deletion on 'foo' and its subtree (unless specifically
 	# allowed on any descendants).
-	kubectl hns set foo --forbidCascadingDelete
+	kubectl hns set foo --forbidCascadingDeletion
 	kubectl hns set foo -f`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		nnm := args[0]
 		flags := cmd.Flags()
 		parent, _ := flags.GetString("parent")
-		allowCD, _ := flags.GetBool("allowCascadingDelete")
-		forbidCD, _ := flags.GetBool("forbidCascadingDelete")
+		allowCD, _ := flags.GetBool("allowCascadingDeletion")
+		forbidCD, _ := flags.GetBool("forbidCascadingDeletion")
 
 		updates := hcUpdates{
 			root:     flags.Changed("root"),
@@ -92,7 +92,7 @@ func updateHC(cl Client, updates hcUpdates, nnm string) {
 		setParent(hc, oldpnm, updates.parent, nnm, &numChanges)
 	}
 
-	setAllowCascadingDelete(hc, nnm, updates.allowCD, updates.forbidCD, &numChanges)
+	setAllowCascadingDeletion(hc, nnm, updates.allowCD, updates.forbidCD, &numChanges)
 
 	if numChanges > 0 {
 		cl.updateHierarchy(hc, fmt.Sprintf("update the hierarchical configuration of %s", nnm))
@@ -130,9 +130,9 @@ func setParent(hc *api.HierarchyConfiguration, oldpnm, pnm, nnm string, numChang
 	}
 }
 
-func setAllowCascadingDelete(hc *api.HierarchyConfiguration, nnm string, allow, forbid bool, numChanges *int) {
+func setAllowCascadingDeletion(hc *api.HierarchyConfiguration, nnm string, allow, forbid bool, numChanges *int) {
 	if allow && forbid {
-		fmt.Printf("Cannot set both --allowCascadingDelete and --forbidCascadingDelete\n")
+		fmt.Printf("Cannot set both --allowCascadingDeletion and --forbidCascadingDeletion\n")
 		os.Exit(1)
 	}
 
@@ -142,10 +142,10 @@ func setAllowCascadingDelete(hc *api.HierarchyConfiguration, nnm string, allow, 
 	}
 
 	// We now know that allow != forbid, so we can just look at allow
-	if hc.Spec.AllowCascadingDelete == allow {
+	if hc.Spec.AllowCascadingDeletion == allow {
 		fmt.Printf("Cascading deletion for '%s' is already set to %t; unchanged\n", nnm, allow)
 	} else {
-		hc.Spec.AllowCascadingDelete = allow
+		hc.Spec.AllowCascadingDeletion = allow
 		if allow {
 			fmt.Printf("Allowing cascading deletion on '%s'\n", nnm)
 		} else {
@@ -168,7 +168,7 @@ func normalizeStringArray(in []string) []string {
 func newSetCmd() *cobra.Command {
 	setCmd.Flags().BoolP("root", "r", false, "Removes the current parent namespace, making this namespace a root")
 	setCmd.Flags().StringP("parent", "p", "", "Sets the parent namespace")
-	setCmd.Flags().BoolP("allowCascadingDelete", "a", false, "Allows cascading deletion of its subnamespaces.")
-	setCmd.Flags().BoolP("forbidCascadingDelete", "f", false, "Protects cascading deletion of its subnamespaces.")
+	setCmd.Flags().BoolP("allowCascadingDeletion", "a", false, "Allows cascading deletion of its subnamespaces.")
+	setCmd.Flags().BoolP("forbidCascadingDeletion", "f", false, "Protects cascading deletion of its subnamespaces.")
 	return setCmd
 }

--- a/incubator/hnc/internal/reconcilers/anchor.go
+++ b/incubator/hnc/internal/reconcilers/anchor.go
@@ -125,7 +125,7 @@ func (r *AnchorReconciler) onDeleting(ctx context.Context, log logr.Logger, inst
 		log.Info("Do nothing since the finalizers are already gone.")
 		return true, nil
 	case r.shouldDeleteSubns(inst, snsInst, deletingCRD):
-		// The subnamespace is not already being deleted but it allows cascadingDelete or it's a leaf.
+		// The subnamespace is not already being deleted but it allows cascadingDeletion or it's a leaf.
 		// Delete the subnamespace, unless the CRD is being deleted, in which case, we want to leave the
 		// namespaces alone.
 		log.Info("The subnamespace is not being deleted but it allows cascading deletion or it's a leaf.")
@@ -169,7 +169,7 @@ func (r *AnchorReconciler) shouldDeleteSubns(inst *api.SubnamespaceAnchor, nsIns
 
 	// The subnamespace exists and isn't being deleted. We should delete it if it
 	// doesn't have any children itself, or if cascading deletion is enabled.
-	return cns.ChildNames() == nil || cns.AllowsCascadingDelete()
+	return cns.ChildNames() == nil || cns.AllowsCascadingDeletion()
 }
 
 func (r *AnchorReconciler) removeFinalizers(log logr.Logger, inst *api.SubnamespaceAnchor, snsInst *corev1.Namespace) bool {

--- a/incubator/hnc/internal/reconcilers/anchor_test.go
+++ b/incubator/hnc/internal/reconcilers/anchor_test.go
@@ -74,18 +74,18 @@ var _ = Describe("Anchor", func() {
 		}).Should(Equal(fooName))
 
 		// Change the bar's parent. Additionally change another field to reflect the
-		// update of the HC instance (hc.Spec.AllowCascadingDelete).
+		// update of the HC instance (hc.Spec.AllowCascadingDeletion).
 		Eventually(func() error {
 			barHier := getHierarchy(ctx, barName)
 			barHier.Spec.Parent = "other"
-			barHier.Spec.AllowCascadingDelete = true
+			barHier.Spec.AllowCascadingDeletion = true
 			return tryUpdateHierarchy(ctx, barHier) // can fail if made too quickly
 		}).Should(Succeed())
 
 		// The parent of 'bar' should be set back to 'foo' after reconciliation.
 		Eventually(func() bool {
 			barHier := getHierarchy(ctx, barName)
-			return barHier.Spec.AllowCascadingDelete
+			return barHier.Spec.AllowCascadingDeletion
 		}).Should(Equal(true))
 		Eventually(func() string {
 			barHier := getHierarchy(ctx, barName)

--- a/incubator/hnc/internal/reconcilers/hierarchy_config.go
+++ b/incubator/hnc/internal/reconcilers/hierarchy_config.go
@@ -162,7 +162,7 @@ func (r *HierarchyConfigReconciler) onMissingNamespace(log logr.Logger, nm strin
 
 // updateFinalizers ensures that the HC can't be deleted if there are any subnamespace anchors in
 // the namespace (with some exceptions). The main reason is that the HC stores the
-// .spec.allowCascadingDelete field, so if we allowed this object to be deleted before all
+// .spec.allowCascadingDeletion field, so if we allowed this object to be deleted before all
 // descendants have been deleted, we would lose the knowledge that cascading deletion is enabled.
 func (r *HierarchyConfigReconciler) updateFinalizers(ctx context.Context, log logr.Logger, inst *api.HierarchyConfiguration, nsInst *corev1.Namespace, anms []string) {
 	// No-one should put a finalizer on a hierarchy config except us. See
@@ -218,7 +218,7 @@ func (r *HierarchyConfigReconciler) syncWithForest(log logr.Logger, nsInst *core
 
 	// Sync other spec and spec-like info
 	r.syncAnchors(log, ns, anms)
-	ns.UpdateAllowCascadingDelete(inst.Spec.AllowCascadingDelete)
+	ns.UpdateAllowCascadingDeletion(inst.Spec.AllowCascadingDeletion)
 
 	// Sync the status
 	inst.Status.Children = ns.ChildNames()

--- a/incubator/hnc/internal/validators/anchor.go
+++ b/incubator/hnc/internal/validators/anchor.go
@@ -94,8 +94,8 @@ func (v *Anchor) handle(req *anchorRequest) admission.Response {
 		if cns.Parent().Name() != pnm {
 			return allow("")
 		}
-		if cns.Exists() && cns.ChildNames() != nil && !cns.AllowsCascadingDelete() {
-			msg := fmt.Sprintf("The subnamespace %s is not a leaf and doesn't allow cascading deletion. Please set allowCascadingDelete flag or make it a leaf first.", cnm)
+		if cns.Exists() && cns.ChildNames() != nil && !cns.AllowsCascadingDeletion() {
+			msg := fmt.Sprintf("The subnamespace %s is not a leaf and doesn't allow cascading deletion. Please set allowCascadingDeletion flag or make it a leaf first.", cnm)
 			return deny(metav1.StatusReasonForbidden, msg)
 		}
 	}

--- a/incubator/hnc/internal/validators/anchor_test.go
+++ b/incubator/hnc/internal/validators/anchor_test.go
@@ -52,7 +52,7 @@ func TestCreateSubnamespaces(t *testing.T) {
 func TestAllowCascadingDeleteSubnamespaces(t *testing.T) {
 	// Create a chain of namespaces from "a" to "e", with "a" as the root. Among them,
 	// "b", "d" and "e" are subnamespaces. This is set up in a long chain to test that
-	// subnamespaces will look all the way up to get the 'allowCascadingDelete` value
+	// subnamespaces will look all the way up to get the 'allowCascadingDeletion` value
 	// and won't stop looking when the first full namespace ancestor is met.
 	f := foresttest.Create("-AbCD")
 	h := &Anchor{Forest: f}
@@ -74,8 +74,8 @@ func TestAllowCascadingDeleteSubnamespaces(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.acd != "" {
-				f.Get(tc.acd).UpdateAllowCascadingDelete(true)
-				defer f.Get(tc.acd).UpdateAllowCascadingDelete(false)
+				f.Get(tc.acd).UpdateAllowCascadingDeletion(true)
+				defer f.Get(tc.acd).UpdateAllowCascadingDeletion(false)
 			}
 
 			// Setup

--- a/incubator/hnc/internal/validators/namespace.go
+++ b/incubator/hnc/internal/validators/namespace.go
@@ -134,7 +134,7 @@ func (v *Namespace) cannotDeleteSubnamespace(req *nsRequest) admission.Response 
 
 func (v *Namespace) illegalCascadingDeletion(ns *forest.Namespace) admission.Response {
 	// Early exit if the namespace allows cascading deletion.
-	if ns.AllowsCascadingDelete() {
+	if ns.AllowsCascadingDeletion() {
 		return allow("")
 	}
 
@@ -142,12 +142,12 @@ func (v *Namespace) illegalCascadingDeletion(ns *forest.Namespace) admission.Res
 	cantDelete := []string{}
 	for _, cnm := range ns.ChildNames() {
 		cns := v.Forest.Get(cnm)
-		if cns.IsSub && !cns.AllowsCascadingDelete() {
+		if cns.IsSub && !cns.AllowsCascadingDeletion() {
 			cantDelete = append(cantDelete, cnm)
 		}
 	}
 	if len(cantDelete) != 0 {
-		msg := fmt.Sprintf("Please set allowCascadingDelete first either in the parent namespace or in all the subnamespaces.\n  Subnamespace(s) without allowCascadingDelete set: %s.", cantDelete)
+		msg := fmt.Sprintf("Please set allowCascadingDeletion first either in the parent namespace or in all the subnamespaces.\n  Subnamespace(s) without allowCascadingDelete set: %s.", cantDelete)
 		return deny(metav1.StatusReasonForbidden, msg)
 	}
 

--- a/incubator/hnc/internal/validators/namespace_test.go
+++ b/incubator/hnc/internal/validators/namespace_test.go
@@ -88,28 +88,28 @@ func TestDeleteOwnerNamespace(t *testing.T) {
 		logResult(t, got.AdmissionResponse.Result)
 		g.Expect(got.AdmissionResponse.Allowed).Should(BeFalse())
 
-		// Set allowCascadingDelete on one child.
-		b.UpdateAllowCascadingDelete(true)
+		// Set allowCascadingDeletion on one child.
+		b.UpdateAllowCascadingDeletion(true)
 		// Test
 		got = vns.handle(req)
 		// Report - Still shouldn't allow deleting the parent namespace.
 		logResult(t, got.AdmissionResponse.Result)
 		g.Expect(got.AdmissionResponse.Allowed).Should(BeFalse())
 
-		// Set allowCascadingDelete on the other child too.
-		c.UpdateAllowCascadingDelete(true)
+		// Set allowCascadingDeletion on the other child too.
+		c.UpdateAllowCascadingDeletion(true)
 		// Test
 		got = vns.handle(req)
 		// Report - Should allow deleting the parent namespace since both subnamespaces allow cascading deletion.
 		logResult(t, got.AdmissionResponse.Result)
 		g.Expect(got.AdmissionResponse.Allowed).Should(BeTrue())
 
-		// Unset allowCascadingDelete on one child but set allowCascadingDelete on the parent itself.
-		c.UpdateAllowCascadingDelete(false)
-		a.UpdateAllowCascadingDelete(true)
+		// Unset allowCascadingDeletion on one child but set allowCascadingDeletion on the parent itself.
+		c.UpdateAllowCascadingDeletion(false)
+		a.UpdateAllowCascadingDeletion(true)
 		// Test
 		got = vns.handle(req)
-		// Report - Should allow deleting the parent namespace with allowCascadingDelete set on it.
+		// Report - Should allow deleting the parent namespace with allowCascadingDeletion set on it.
 		logResult(t, got.AdmissionResponse.Result)
 		g.Expect(got.AdmissionResponse.Allowed).Should(BeTrue())
 	})

--- a/incubator/hnc/test/conversion/conversion_test.go
+++ b/incubator/hnc/test/conversion/conversion_test.go
@@ -107,7 +107,7 @@ spec:
 		FieldShouldContain(hierCRD, nsB, hierSingleton, ".spec.parent", nsA)
 	})
 
-	It("should convert HCs with allowCascadingDelete", func() {
+	It("should convert HCs allowCascadingDelete to allowCascadingDeletion", func() {
 		// Before conversion, create namespace A with allowCascadingDelete.
 		MustRun("kubectl create ns", nsA)
 		hierA := `# temp file created by conversion_test.go
@@ -119,15 +119,16 @@ metadata:
 spec:
   allowCascadingDelete: true`
 		MustApplyYAML(hierA)
+		FieldShouldContain(hierCRD, nsA, hierSingleton, ".spec", "allowCascadingDelete:true")
 
 		// Convert
 		setupV1alpha2()
 
 		// Verify CRD conversion.
 		verifyCRDConversion()
-		// Verify allowCascadingDelete in the new version.
+		// Verify allowCascadingDeletion in the new version.
 		FieldShouldContainWithTimeout(hierCRD, nsA, hierSingleton, ".apiVersion", "v1alpha2", crdConversionTime)
-		FieldShouldContain(hierCRD, nsA, hierSingleton, ".spec", "allowCascadingDelete:true")
+		FieldShouldContain(hierCRD, nsA, hierSingleton, ".spec", "allowCascadingDeletion:true")
 	})
 
 	It("should still have HC condition if it exists in v1alpha1", func() {


### PR DESCRIPTION
Use `allowCascadingDeletion` instead of `allowCascadingDelete` in
v1alpha2 HC schema. Update conversion test, integration test and e2e
tests.

Add a skipped (`PIt`) test case for #1155 . This test failed on both
master branch and this change, so it's not caused by this change. Added
the test so that the later fix can use `allowCascadingDeletion` directly.

Tested by `make test-conversion`, `make test` and `make test-e2e` (with
`FIt` on related tests only).

Fixes #1035 
Part of #868 