### PR TITLE
Add timeoutSeconds patch for webhook configuration

### DIFF
--- a/incubator/hnc/config/webhook/kustomization.yaml
+++ b/incubator/hnc/config/webhook/kustomization.yaml
@@ -4,3 +4,6 @@ resources:
 
 configurations:
 - kustomizeconfig.yaml
+
+patchesStrategicMerge:
+- webhook_patch.yaml

--- a/incubator/hnc/config/webhook/webhook_patch.yaml
+++ b/incubator/hnc/config/webhook/webhook_patch.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- name: objects.hnc.x-k8s.io
+  timeoutSeconds: 2


### PR DESCRIPTION
Context: https://github.com/kubernetes-sigs/multi-tenancy/issues/1023

Add `timeoutSeconds` patch for webhook configuration. 

Currently, `controller-tools` does not support `timetouSeconds` marker ([I'm sending patches for it](https://github.com/kubernetes-sigs/controller-tools/pull/473)). So just add kustomize patches for it. 

## Test

Executing the following command (which is executed in `cloudbuild.yaml`) on my local PC, 

```
cd multi-tenancy/incubator/hnc
mkdir out
cd out
touch kustomization.yaml
kustomize edit add resource ../config/default
kustomize build . -o ./hnc-manager.yaml
```

[This](https://gist.github.com/tcnksm/1bfb91d412c7635315559b3f318806fb) is the output of `hnc-manager.yaml`. You can see `timeoutSecond` is added.

