### PR TITLE
Support --version option for hnc plugin

### DIFF
--- a/incubator/hnc/Makefile
+++ b/incubator/hnc/Makefile
@@ -247,7 +247,7 @@ release: check-release-env test
 	@echo "Invoking Cloud Build"
 	@echo "*********************************************"
 	@echo "*********************************************"
-	@gcloud builds submit --config cloudbuild.yaml --no-source --substitutions=_HNC_REPO_USER=${HNC_REPO_USER},_HNC_IMG_NAME=${HNC_IMG_NAME},_HNC_IMG_TAG=${HNC_IMG_TAG},_HNC_USER=${HNC_USER},_HNC_PERSONAL_ACCESS_TOKEN=${HNC_PAT},_HNC_RELEASE_ID=${HNC_RELEASE_ID},_HNC_RELEASED_IMG=${HNC_RELEASED_IMG}
+	@gcloud builds submit --config cloudbuild.yaml --no-source --substitutions=_HNC_REPO_USER=${HNC_REPO_USER},_HNC_IMG_NAME=${HNC_IMG_NAME},_HNC_IMG_TAG=${HNC_IMG_TAG},_HNC_USER=${HNC_USER},_HNC_PERSONAL_ACCESS_TOKEN=${HNC_PAT},_HNC_RELEASE_ID=${HNC_RELEASE_ID},_HNC_RELEASED_IMG=${HNC_RELEASED_IMG},_HNC_VERSION=${HNC_IMG_TAG}
 	@echo Pushing image to K8s staging
 	@docker pull ${HNC_IMG}
 	@docker tag ${HNC_IMG} ${HNC_RELEASED_IMG}

--- a/incubator/hnc/cloudbuild.yaml
+++ b/incubator/hnc/cloudbuild.yaml
@@ -30,8 +30,10 @@ steps:
     kustomize build . -o ./hnc-manager.yaml
 
     # Build plugin
-    GOOS=linux GOARCH=amd64 go build -o kubectl-hns_linux_amd64 ../cmd/kubectl/main.go
-    GOOS=darwin GOARCH=amd64 go build -o kubectl-hns_darwin_amd64 ../cmd/kubectl/main.go
+    GOOS=linux GOARCH=amd64 go build -ldflags="-X sigs.k8s.io/multi-tenancy/incubator/hnc/internal/version.Version=$_HNC_VERSION"\
+                                     -o kubectl-hns_linux_amd64 ../cmd/kubectl/main.go
+    GOOS=darwin GOARCH=amd64 go build -ldflags="-X sigs.k8s.io/multi-tenancy/incubator/hnc/internal/version.Version=$_HNC_VERSION"\
+                                     -o kubectl-darwin_amd64 ../cmd/kubectl/main.go
 # Upload manifest
 - name: gcr.io/cloud-builders/curl
   args:

--- a/incubator/hnc/internal/kubectl/root.go
+++ b/incubator/hnc/internal/kubectl/root.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
+	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/version"
 )
 
 var k8sClient *kubernetes.Clientset
@@ -64,8 +65,9 @@ func init() {
 		// However, since only the first word of the Use field will be displayed in the
 		// "Usage" section of a root command, we set it to "kubectl-hns" here so that both
 		// "kubectl" and "hns" will be shown in the "Usage" section.
-		Use:   "kubectl-hns",
-		Short: "Manipulates hierarchical namespaces provided by HNC",
+		Use:     "kubectl-hns",
+		Version: version.Version,
+		Short:   "Manipulates hierarchical namespaces provided by HNC",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			config, err := kubecfgFlags.ToRESTConfig()
 			if err != nil {
@@ -99,6 +101,7 @@ func init() {
 	rootCmd.AddCommand(newTreeCmd())
 	rootCmd.AddCommand(newCreateCmd())
 	rootCmd.AddCommand(newConfigCmd())
+	rootCmd.AddCommand(newVersionCmd())
 }
 
 func Execute() {

--- a/incubator/hnc/internal/kubectl/version.go
+++ b/incubator/hnc/internal/kubectl/version.go
@@ -1,0 +1,36 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/version"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show version of HNC plugin",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("kubectl-hns version %s\n", version.Version)
+	},
+}
+
+func newVersionCmd() *cobra.Command {
+	return versionCmd
+}

--- a/incubator/hnc/internal/version/version.go
+++ b/incubator/hnc/internal/version/version.go
@@ -1,0 +1,20 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+// Version is verion for HNC. This variable is overwritten in cloudbuild.yaml
+// to match the version of the Docker image.
+var Version = "(UNKNOWN)"


### PR DESCRIPTION
Related: https://github.com/kubernetes-sigs/multi-tenancy/issues/861

Add `cobra.Command.Version`. This enables the plugin to have `--version` option flag to show its version. I'm not sure the way to embed the version string is what you expect.  

## Test

I've build it on local and tried its output,

```bash
$ go build -ldflags="-X sigs.k8s.io/multi-tenancy/incubator/hnc/internal/version.Version=v0.5.2" -o kubectl-hns  cmd/kubectl/main.go
```
```bash
$ ./kubectl-hns version
kubectl-hns version v0.5.2
```