### PR TITLE
Document how to move a subnamespace

### DIFF
--- a/incubator/hnc/docs/user-guide/how-to.md
+++ b/incubator/hnc/docs/user-guide/how-to.md
@@ -355,7 +355,7 @@ To achieve this, we need to:
 
  - Add the `hnc.x-k8s.io/subnamespaceOf` annotation back to `ns-product-2`, but with a parent of `ns-team-2`
  ```
-  kubectl annotate namespace myns hnc.x-k8s.io/subnamespaceOf=ns-team-2
+  kubectl annotate namespace ns-product-2 hnc.x-k8s.io/subnamespaceOf=ns-team-2
  ```
 
  - Create a new subnamespaceanchor in the `ns-team-2` namespace

--- a/incubator/hnc/docs/user-guide/how-to.md
+++ b/incubator/hnc/docs/user-guide/how-to.md
@@ -328,10 +328,10 @@ Consider the following tree:
 
 ```
 org
- - ns-team1 (full namespace)
+ - ns-team-1 (full namespace)
    - ns-product-1 (subnamespace)
    - ns-product-2 (subnamespace)
- - ns-team2 (full namespace)
+ - ns-team-2 (full namespace)
    - ns-product-3 (subnamespace)
 ```
 
@@ -372,9 +372,9 @@ The tree now looks like this:
 
 ```
 org
- - ns-team1 (full namespace)
+ - ns-team-1 (full namespace)
    - ns-product-1 (subnamespace)
- - ns-team2 (full namespace)
+ - ns-team-2 (full namespace)
    - ns-product-2 (subnamespace)
    - ns-product-3 (subnamespace)
 ```


### PR DESCRIPTION
Relates to #1045 

This PR adds documentation in the howto on how to move a subnamespace within the hierarchy tree. 
