### PR TITLE
Add timeoutSeconds patch for webhook configuration

### DIFF
--- a/incubator/hnc/config/webhook/kustomization.yaml
+++ b/incubator/hnc/config/webhook/kustomization.yaml
@@ -4,3 +4,6 @@ resources:
 
 configurations:
 - kustomizeconfig.yaml
+
+patchesStrategicMerge:
+- webhook_patch.yaml

--- a/incubator/hnc/config/webhook/webhook_patch.yaml
+++ b/incubator/hnc/config/webhook/webhook_patch.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- name: objects.hnc.x-k8s.io
+  timeoutSeconds: 2


### PR DESCRIPTION
Cherrypick of #1039 . Tested by adding a 15s sleep to the object validator and confirmed that everything was ridiculously slow without this change and only annoyingly slow with it. I think this is good enough for v0.5.

Addresses #1023 