### PR TITLE
Support server-side dry run

### DIFF
--- a/incubator/hnc/config/webhook/webhook_patch.yaml
+++ b/incubator/hnc/config/webhook/webhook_patch.yaml
@@ -6,3 +6,12 @@ metadata:
 webhooks:
 - name: objects.hnc.x-k8s.io
   timeoutSeconds: 2
+  sideEffects: None
+- name: subnamespaceanchors.hnc.x-k8s.io
+  sideEffects: None
+- name: hierarchyconfigurations.hnc.x-k8s.io
+  sideEffects: None
+- name: hncconfigurations.hnc.x-k8s.io
+  sideEffects: None
+- name: namespaces.hnc.x-k8s.io
+  sideEffects: None


### PR DESCRIPTION
See issue #1027. To support server-side dry-run, all admission webhooks
must state that they do not have any side effects. Our version of
controller-gen doesn't include the sideEffects marker so I added them as
a kustomization patch.

I'll port this to the master branch after this change.

Tested: server-side dry-run fails on a pod creation in Kind 1.18 without
this fix and passes with it. GKE doesn't have 1.18 yet so I couldn't
test it there, but I also tested it on GKE 1.15 (the oldest currently
supported version) to ensure that it had no ill effects, and all e2e
tests work fine on both Kind 1.18 and GKE 1.15.