### PR TITLE
vc: adding ingress resource syncing

### DIFF
--- a/incubator/virtualcluster/cmd/syncer/app/options/options.go
+++ b/incubator/virtualcluster/cmd/syncer/app/options/options.go
@@ -97,7 +97,7 @@ func (o *ResourceSyncerOptions) Flags() cliflag.NamedFlagSets {
 	fs.StringVar(&o.ComponentConfig.ClientConnection.Kubeconfig, "super-master-kubeconfig", o.ComponentConfig.ClientConnection.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
 	fs.BoolVar(&o.ComponentConfig.DisableServiceAccountToken, "disable-service-account-token", o.ComponentConfig.DisableServiceAccountToken, "DisableServiceAccountToken indicates whether disable service account token automatically mounted.")
 	fs.StringSliceVar(&o.ComponentConfig.DefaultOpaqueMetaDomains, "default-opaque-meta-domains", o.ComponentConfig.DefaultOpaqueMetaDomains, "DefaultOpaqueMetaDomains is the default opaque meta configuration for each Virtual Cluster.")
-	fs.StringSliceVar(&o.ComponentConfig.ExtraSyncingResources, "extra-syncing-resources", o.ComponentConfig.ExtraSyncingResources, "ExtraSyncingResources defines additional resources that need to be synced for each Virtual Cluster.")
+	fs.StringSliceVar(&o.ComponentConfig.ExtraSyncingResources, "extra-syncing-resources", o.ComponentConfig.ExtraSyncingResources, "ExtraSyncingResources defines additional resources that need to be synced for each Virtual Cluster. (priorityclass, ingress)")
 
 	serverFlags := fss.FlagSet("metricsServer")
 	serverFlags.StringVar(&o.Address, "address", o.Address, "The server address.")

--- a/incubator/virtualcluster/pkg/syncer/conversion/equality.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/equality.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
+	v1beta1extensions "k8s.io/api/extensions/v1beta1"
 	v1scheduling "k8s.io/api/scheduling/v1"
 	v1storage "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -491,6 +492,19 @@ func (e vcEquality) CheckStorageClassEquality(pObj, vObj *v1storage.StorageClass
 }
 
 func (e vcEquality) CheckPriorityClassEquality(pObj, vObj *v1scheduling.PriorityClass) *v1scheduling.PriorityClass {
+	pObjCopy := pObj.DeepCopy()
+	pObjCopy.ObjectMeta = vObj.ObjectMeta
+	// pObj.TypeMeta is empty
+	pObjCopy.TypeMeta = vObj.TypeMeta
+
+	if !equality.Semantic.DeepEqual(vObj, pObjCopy) {
+		return pObjCopy
+	} else {
+		return nil
+	}
+}
+
+func (e vcEquality) CheckIngressEquality(pObj, vObj *v1beta1extensions.Ingress) *v1beta1extensions.Ingress {
 	pObjCopy := pObj.DeepCopy()
 	pObjCopy.ObjectMeta = vObj.ObjectMeta
 	// pObj.TypeMeta is empty

--- a/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
+++ b/incubator/virtualcluster/pkg/syncer/mccontroller/mccontroller.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -498,6 +499,8 @@ func getTargetObject(objectType runtime.Object) runtime.Object {
 		return &v1.Endpoints{}
 	case *schedulingv1.PriorityClass:
 		return &schedulingv1.PriorityClass{}
+	case *extensionsv1beta1.Ingress:
+		return &extensionsv1beta1.Ingress{}
 	default:
 		return nil
 	}
@@ -531,6 +534,8 @@ func getTargetObjectList(objectType runtime.Object) runtime.Object {
 		return &v1.EndpointsList{}
 	case *schedulingv1.PriorityClass:
 		return &schedulingv1.PriorityClassList{}
+	case *extensionsv1beta1.Ingress:
+		return &extensionsv1beta1.IngressList{}
 	default:
 		return nil
 	}

--- a/incubator/virtualcluster/pkg/syncer/resources/ingress/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/ingress/checker.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	v1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/metrics"
+)
+
+var numSpecMissMatchedIngresses uint64
+var numStatusMissMatchedIngresses uint64
+var numUWMetaMissMatchedIngresses uint64
+
+func (c *controller) StartPatrol(stopCh <-chan struct{}) error {
+	if !cache.WaitForCacheSync(stopCh, c.ingressSynced) {
+		return fmt.Errorf("failed to wait for caches to sync before starting Ingress checker")
+	}
+	c.ingressPatroller.Start(stopCh)
+	return nil
+}
+
+// PatrollerDo check if ingresss keep consistency between super
+// master and tenant masters.
+func (c *controller) PatrollerDo() {
+	clusterNames := c.multiClusterIngressController.GetClusterNames()
+	if len(clusterNames) == 0 {
+		klog.Infof("tenant masters has no clusters, give up period checker")
+		return
+	}
+
+	wg := sync.WaitGroup{}
+	numSpecMissMatchedIngresses = 0
+	numStatusMissMatchedIngresses = 0
+	numUWMetaMissMatchedIngresses = 0
+
+	for _, clusterName := range clusterNames {
+		wg.Add(1)
+		go func(clusterName string) {
+			defer wg.Done()
+			c.checkIngressesOfTenantCluster(clusterName)
+		}(clusterName)
+	}
+	wg.Wait()
+
+	pIngresses, err := c.ingressLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("error listing ingresss from super master informer cache: %v", err)
+		return
+	}
+
+	for _, pIngress := range pIngresses {
+		clusterName, vNamespace := conversion.GetVirtualOwner(pIngress)
+		if len(clusterName) == 0 || len(vNamespace) == 0 {
+			continue
+		}
+		shouldDelete := false
+		vIngressObj, err := c.multiClusterIngressController.Get(clusterName, vNamespace, pIngress.Name)
+		if errors.IsNotFound(err) {
+			shouldDelete = true
+		}
+		if err == nil {
+			vIngress := vIngressObj.(*v1beta1.Ingress)
+			if pIngress.Annotations[constants.LabelUID] != string(vIngress.UID) {
+				shouldDelete = true
+				klog.Warningf("Found pIngress %s/%s delegated UID is different from tenant object.", pIngress.Namespace, pIngress.Name)
+			}
+		}
+		if shouldDelete {
+			deleteOptions := metav1.NewPreconditionDeleteOptions(string(pIngress.UID))
+			if err = c.ingressClient.Ingresses(pIngress.Namespace).Delete(context.TODO(), pIngress.Name, *deleteOptions); err != nil {
+				klog.Errorf("error deleting pIngress %s/%s in super master: %v", pIngress.Namespace, pIngress.Name, err)
+			} else {
+				metrics.CheckerRemedyStats.WithLabelValues("DeletedOrphanSuperMasterIngresses").Inc()
+			}
+		}
+	}
+
+	metrics.CheckerMissMatchStats.WithLabelValues("SpecMissMatchedIngresses").Set(float64(numSpecMissMatchedIngresses))
+	metrics.CheckerMissMatchStats.WithLabelValues("StatusMissMatchedIngresses").Set(float64(numStatusMissMatchedIngresses))
+	metrics.CheckerMissMatchStats.WithLabelValues("UWMetaMissMatchedIngresses").Set(float64(numUWMetaMissMatchedIngresses))
+}
+
+func (c *controller) checkIngressesOfTenantCluster(clusterName string) {
+	listObj, err := c.multiClusterIngressController.List(clusterName)
+	if err != nil {
+		klog.Errorf("error listing ingresss from cluster %s informer cache: %v", clusterName, err)
+		return
+	}
+	klog.V(4).Infof("check ingresss consistency in cluster %s", clusterName)
+	ingList := listObj.(*v1beta1.IngressList)
+	for i, vIngress := range ingList.Items {
+		targetNamespace := conversion.ToSuperMasterNamespace(clusterName, vIngress.Namespace)
+		pIngress, err := c.ingressLister.Ingresses(targetNamespace).Get(vIngress.Name)
+		if errors.IsNotFound(err) {
+			if err := c.multiClusterIngressController.RequeueObject(clusterName, &ingList.Items[i]); err != nil {
+				klog.Errorf("error requeue vingress %v/%v in cluster %s: %v", vIngress.Namespace, vIngress.Name, clusterName, err)
+			} else {
+				metrics.CheckerRemedyStats.WithLabelValues("RequeuedTenantIngresses").Inc()
+			}
+			continue
+		}
+
+		if err != nil {
+			klog.Errorf("failed to get pIngress %s/%s from super master cache: %v", targetNamespace, vIngress.Name, err)
+			continue
+		}
+
+		if pIngress.Annotations[constants.LabelUID] != string(vIngress.UID) {
+			klog.Errorf("Found pIngress %s/%s delegated UID is different from tenant object.", targetNamespace, pIngress.Name)
+			continue
+		}
+
+		spec, err := c.multiClusterIngressController.GetSpec(clusterName)
+		if err != nil {
+			klog.Errorf("fail to get cluster spec : %s", clusterName)
+			continue
+		}
+		updatedIngress := conversion.Equality(c.config, spec).CheckIngressEquality(pIngress, &ingList.Items[i])
+		if updatedIngress != nil {
+			atomic.AddUint64(&numSpecMissMatchedIngresses, 1)
+			klog.Warningf("spec of ingress %v/%v diff in super&tenant master", vIngress.Namespace, vIngress.Name)
+			if err := c.multiClusterIngressController.RequeueObject(clusterName, &ingList.Items[i]); err != nil {
+				klog.Errorf("error requeue vingress %v/%v in cluster %s: %v", vIngress.Namespace, vIngress.Name, clusterName, err)
+			} else {
+				metrics.CheckerRemedyStats.WithLabelValues("RequeuedTenantIngresses").Inc()
+			}
+		}
+
+		enqueue := false
+		updatedMeta := conversion.Equality(c.config, spec).CheckUWObjectMetaEquality(&pIngress.ObjectMeta, &ingList.Items[i].ObjectMeta)
+		if updatedMeta != nil {
+			atomic.AddUint64(&numUWMetaMissMatchedIngresses, 1)
+			enqueue = true
+			klog.Warningf("UWObjectMeta of vIngress %v/%v diff in super&tenant master", vIngress.Namespace, vIngress.Name)
+		}
+		if !equality.Semantic.DeepEqual(vIngress.Status, pIngress.Status) {
+			enqueue = true
+			atomic.AddUint64(&numStatusMissMatchedIngresses, 1)
+			klog.Warningf("Status of vIngress %v/%v diff in super&tenant master", vIngress.Namespace, vIngress.Name)
+		}
+		if enqueue {
+			c.enqueueIngress(pIngress)
+		}
+
+	}
+}

--- a/incubator/virtualcluster/pkg/syncer/resources/ingress/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/ingress/controller.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"fmt"
+
+	v1beta1 "k8s.io/api/extensions/v1beta1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	v1beta1extensions "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
+	listersv1beta1 "k8s.io/client-go/listers/extensions/v1beta1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+
+	vcclient "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/client/clientset/versioned"
+	vcinformers "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/client/informers/externalversions/tenancy/v1alpha1"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
+	mc "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
+	pa "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/patrol"
+	uw "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/uwcontroller"
+)
+
+type controller struct {
+	config *config.SyncerConfiguration
+	// super master ingress client
+	ingressClient v1beta1extensions.IngressesGetter
+	// super master informer/listers/synced functions
+	ingressLister listersv1beta1.IngressLister
+	ingressSynced cache.InformerSynced
+	// Connect to all tenant master ingress informers
+	multiClusterIngressController *mc.MultiClusterController
+	// UWcontroller
+	upwardIngressController *uw.UpwardController
+	// Periodic checker
+	ingressPatroller *pa.Patroller
+}
+
+func NewIngressController(config *config.SyncerConfiguration,
+	client clientset.Interface,
+	informer informers.SharedInformerFactory,
+	vcClient vcclient.Interface,
+	vcInformer vcinformers.VirtualClusterInformer,
+	options *manager.ResourceSyncerOptions) (manager.ResourceSyncer, *mc.MultiClusterController, *uw.UpwardController, error) {
+	c := &controller{
+		config:        config,
+		ingressClient: client.ExtensionsV1beta1(),
+	}
+	var mcOptions *mc.Options
+	if options == nil || options.MCOptions == nil {
+		mcOptions = &mc.Options{Reconciler: c}
+	} else {
+		mcOptions = options.MCOptions
+	}
+	mcOptions.MaxConcurrentReconciles = constants.DwsControllerWorkerLow
+	multiClusterIngressController, err := mc.NewMCController("tenant-masters-ingress-controller", &v1beta1.Ingress{}, *mcOptions)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create ingress mc controller: %v", err)
+	}
+	c.multiClusterIngressController = multiClusterIngressController
+
+	c.ingressLister = informer.Extensions().V1beta1().Ingresses().Lister()
+	if options != nil && options.IsFake {
+		c.ingressSynced = func() bool { return true }
+	} else {
+		c.ingressSynced = informer.Extensions().V1beta1().Ingresses().Informer().HasSynced
+	}
+
+	var uwOptions *uw.Options
+	if options == nil || options.UWOptions == nil {
+		uwOptions = &uw.Options{Reconciler: c}
+	} else {
+		uwOptions = options.UWOptions
+	}
+	uwOptions.MaxConcurrentReconciles = constants.UwsControllerWorkerLow
+	upwardIngressController, err := uw.NewUWController("ingress-upward-controller", &v1beta1.Ingress{}, *uwOptions)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create ingress upward controller: %v", err)
+	}
+	c.upwardIngressController = upwardIngressController
+
+	var patrolOptions *pa.Options
+	if options == nil || options.PatrolOptions == nil {
+		patrolOptions = &pa.Options{Reconciler: c}
+	} else {
+		patrolOptions = options.PatrolOptions
+	}
+	ingressPatroller, err := pa.NewPatroller("ingress-patroller", &v1beta1.Ingress{}, *patrolOptions)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create ingress patroller: %v", err)
+	}
+	c.ingressPatroller = ingressPatroller
+
+	informer.Extensions().V1beta1().Ingresses().Informer().AddEventHandler(
+		cache.FilteringResourceEventHandler{
+			FilterFunc: func(obj interface{}) bool {
+				switch t := obj.(type) {
+				case *v1beta1.Ingress:
+					return true
+				case cache.DeletedFinalStateUnknown:
+					if _, ok := t.Obj.(*v1beta1.Ingress); ok {
+						return true
+					}
+					utilruntime.HandleError(fmt.Errorf("unable to convert object %v to *v1beta1.Ingress", obj))
+					return false
+				default:
+					utilruntime.HandleError(fmt.Errorf("unable to handle object in super master ingress controller: %v", obj))
+					return false
+				}
+			},
+			Handler: cache.ResourceEventHandlerFuncs{
+				AddFunc: c.enqueueIngress,
+				UpdateFunc: func(oldObj, newObj interface{}) {
+					newIngress := newObj.(*v1beta1.Ingress)
+					oldIngress := oldObj.(*v1beta1.Ingress)
+					if newIngress.ResourceVersion != oldIngress.ResourceVersion {
+						c.enqueueIngress(newObj)
+					}
+				},
+				DeleteFunc: c.enqueueIngress,
+			},
+		})
+	return c, multiClusterIngressController, upwardIngressController, nil
+}
+
+func (c *controller) enqueueIngress(obj interface{}) {
+	svc, ok := obj.(*v1beta1.Ingress)
+	if !ok {
+		return
+	}
+
+	clusterName, _ := conversion.GetVirtualOwner(svc)
+	if clusterName == "" {
+		return
+	}
+
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %v: %v", obj, err))
+		return
+	}
+	c.upwardIngressController.AddToQueue(key)
+}
+
+func (c *controller) AddCluster(cluster mc.ClusterInterface) {
+	klog.Infof("tenant-masters-ingress-controller watch cluster %s for ingress resource", cluster.GetClusterName())
+	err := c.multiClusterIngressController.WatchClusterResource(cluster, mc.WatchOptions{})
+	if err != nil {
+		klog.Errorf("failed to watch cluster %s ingress event: %v", cluster.GetClusterName(), err)
+	}
+}
+
+func (c *controller) RemoveCluster(cluster mc.ClusterInterface) {
+	klog.Infof("tenant-masters-ingress-controller stop watching cluster %s for ingress resource", cluster.GetClusterName())
+	c.multiClusterIngressController.TeardownClusterResource(cluster)
+}

--- a/incubator/virtualcluster/pkg/syncer/resources/ingress/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/ingress/dws.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"context"
+	"fmt"
+
+	v1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/reconciler"
+)
+
+func (c *controller) StartDWS(stopCh <-chan struct{}) error {
+	if !cache.WaitForCacheSync(stopCh, c.ingressSynced) {
+		return fmt.Errorf("failed to wait for caches to sync before starting Ingress dws")
+	}
+	return c.multiClusterIngressController.Start(stopCh)
+}
+
+func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {
+	klog.V(4).Infof("reconcile ingress %s/%s for cluster %s", request.Namespace, request.Name, request.ClusterName)
+	targetNamespace := conversion.ToSuperMasterNamespace(request.ClusterName, request.Namespace)
+	pIngress, err := c.ingressLister.Ingresses(targetNamespace).Get(request.Name)
+	pExists := true
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return reconciler.Result{Requeue: true}, err
+		}
+		pExists = false
+	}
+	vExists := true
+	vIngressObj, err := c.multiClusterIngressController.Get(request.ClusterName, request.Namespace, request.Name)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return reconciler.Result{Requeue: true}, err
+		}
+		vExists = false
+	}
+
+	if vExists && !pExists {
+		vIngress := vIngressObj.(*v1beta1.Ingress)
+		err := c.reconcileIngressCreate(request.ClusterName, targetNamespace, request.UID, vIngress)
+		if err != nil {
+			klog.Errorf("failed reconcile ingress %s/%s CREATE of cluster %s %v", request.Namespace, request.Name, request.ClusterName, err)
+			return reconciler.Result{Requeue: true}, err
+		}
+	} else if !vExists && pExists {
+		err := c.reconcileIngressRemove(request.ClusterName, targetNamespace, request.UID, request.Name, pIngress)
+		if err != nil {
+			klog.Errorf("failed reconcile ingress %s/%s DELETE of cluster %s %v", request.Namespace, request.Name, request.ClusterName, err)
+			return reconciler.Result{Requeue: true}, err
+		}
+	} else if vExists && pExists {
+		vIngress := vIngressObj.(*v1beta1.Ingress)
+		err := c.reconcileIngressUpdate(request.ClusterName, targetNamespace, request.UID, pIngress, vIngress)
+		if err != nil {
+			klog.Errorf("failed reconcile ingress %s/%s UPDATE of cluster %s %v", request.Namespace, request.Name, request.ClusterName, err)
+			return reconciler.Result{Requeue: true}, err
+		}
+	} else {
+		// object is gone.
+	}
+	return reconciler.Result{}, nil
+}
+
+func (c *controller) reconcileIngressCreate(clusterName, targetNamespace, requestUID string, ingress *v1beta1.Ingress) error {
+	vcName, _, _, err := c.multiClusterIngressController.GetOwnerInfo(clusterName)
+	if err != nil {
+		return err
+	}
+	newObj, err := conversion.BuildMetadata(clusterName, vcName, targetNamespace, ingress)
+	if err != nil {
+		return err
+	}
+
+	pIngress := newObj.(*v1beta1.Ingress)
+
+	pIngress, err = c.ingressClient.Ingresses(targetNamespace).Create(context.TODO(), pIngress, metav1.CreateOptions{})
+	if errors.IsAlreadyExists(err) {
+		if pIngress.Annotations[constants.LabelUID] == requestUID {
+			klog.Infof("ingress %s/%s of cluster %s already exist in super master", targetNamespace, pIngress.Name, clusterName)
+			return nil
+		} else {
+			return fmt.Errorf("pIngress %s/%s exists but its delegated object UID is different.", targetNamespace, pIngress.Name)
+		}
+	}
+	return err
+}
+
+func (c *controller) reconcileIngressUpdate(clusterName, targetNamespace, requestUID string, pIngress, vIngress *v1beta1.Ingress) error {
+	if pIngress.Annotations[constants.LabelUID] != requestUID {
+		return fmt.Errorf("pIngress %s/%s delegated UID is different from updated object.", targetNamespace, pIngress.Name)
+	}
+
+	spec, err := c.multiClusterIngressController.GetSpec(clusterName)
+	if err != nil {
+		return err
+	}
+	updated := conversion.Equality(c.config, spec).CheckIngressEquality(pIngress, vIngress)
+	if updated != nil {
+		_, err = c.ingressClient.Ingresses(targetNamespace).Update(context.TODO(), updated, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *controller) reconcileIngressRemove(clusterName, targetNamespace, requestUID, name string, pIngress *v1beta1.Ingress) error {
+	if pIngress.Annotations[constants.LabelUID] != requestUID {
+		return fmt.Errorf("To be deleted pIngress %s/%s delegated UID is different from deleted object.", targetNamespace, name)
+	}
+
+	opts := &metav1.DeleteOptions{
+		PropagationPolicy: &constants.DefaultDeletionPolicy,
+		Preconditions:     metav1.NewUIDPreconditions(string(pIngress.UID)),
+	}
+	err := c.ingressClient.Ingresses(targetNamespace).Delete(context.TODO(), name, *opts)
+	if errors.IsNotFound(err) {
+		klog.Warningf("To be deleted ingress %s/%s not found in super master", targetNamespace, name)
+		return nil
+	}
+	return err
+}

--- a/incubator/virtualcluster/pkg/syncer/resources/ingress/dws_test.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/ingress/dws_test.go
@@ -1,0 +1,346 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"strings"
+	"testing"
+
+	v1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	core "k8s.io/client-go/testing"
+	util "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/util/test"
+
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+)
+
+func tenantIngress(name, namespace, uid string) *v1beta1.Ingress {
+	return &v1beta1.Ingress{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Ingress",
+			APIVersion: "v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			UID:       types.UID(uid),
+		},
+	}
+}
+
+func superIngress(name, namespace, uid, clusterKey string) *v1beta1.Ingress {
+	return &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				constants.LabelUID:       uid,
+				constants.LabelNamespace: "default",
+				constants.LabelCluster:   clusterKey,
+			},
+		},
+	}
+}
+
+func TestDWIngressCreation(t *testing.T) {
+	testTenant := &v1alpha1.VirtualCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "tenant-1",
+			UID:       "7374a172-c35d-45b1-9c8e-bf5c5b614937",
+		},
+		Spec: v1alpha1.VirtualClusterSpec{},
+		Status: v1alpha1.VirtualClusterStatus{
+			Phase: v1alpha1.ClusterRunning,
+		},
+	}
+
+	defaultClusterKey := conversion.ToClusterKey(testTenant)
+	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+
+	testcases := map[string]struct {
+		ExistingObjectInSuper  []runtime.Object
+		ExistingObjectInTenant *v1beta1.Ingress
+
+		ExpectedCreatedIngresses []string
+		ExpectedError            string
+	}{
+		"new ingress": {
+			ExistingObjectInSuper:    []runtime.Object{},
+			ExistingObjectInTenant:   tenantIngress("ing-1", "default", "12345"),
+			ExpectedCreatedIngresses: []string{superDefaultNSName + "/ing-1"},
+		},
+		"new ingress but already exists": {
+			ExistingObjectInSuper: []runtime.Object{
+				superIngress("ing-1", superDefaultNSName, "12345", defaultClusterKey),
+			},
+			ExistingObjectInTenant:   tenantIngress("ing-1", "default", "12345"),
+			ExpectedCreatedIngresses: []string{},
+			ExpectedError:            "",
+		},
+		"new serivce but existing different uid one": {
+			ExistingObjectInSuper: []runtime.Object{
+				superIngress("ing-1", superDefaultNSName, "123456", defaultClusterKey),
+			},
+			ExistingObjectInTenant:   tenantIngress("ing-1", "default", "12345"),
+			ExpectedCreatedIngresses: []string{},
+			ExpectedError:            "delegated UID is different",
+		},
+	}
+
+	for k, tc := range testcases {
+		t.Run(k, func(t *testing.T) {
+			actions, reconcileErr, err := util.RunDownwardSync(NewIngressController,
+				testTenant,
+				tc.ExistingObjectInSuper,
+				[]runtime.Object{tc.ExistingObjectInTenant},
+				tc.ExistingObjectInTenant,
+				nil)
+			if err != nil {
+				t.Errorf("%s: error running downward sync: %v", k, err)
+				return
+			}
+
+			if reconcileErr != nil {
+				if tc.ExpectedError == "" {
+					t.Errorf("expected no error, but got \"%v\"", reconcileErr)
+				} else if !strings.Contains(reconcileErr.Error(), tc.ExpectedError) {
+					t.Errorf("expected error msg \"%s\", but got \"%v\"", tc.ExpectedError, reconcileErr)
+				}
+			} else {
+				if tc.ExpectedError != "" {
+					t.Errorf("expected error msg \"%s\", but got empty", tc.ExpectedError)
+				}
+			}
+
+			if len(tc.ExpectedCreatedIngresses) != len(actions) {
+				t.Errorf("%s: Expected to create ingress %#v. Actual actions were: %#v", k, tc.ExpectedCreatedIngresses, actions)
+				return
+			}
+			for i, expectedName := range tc.ExpectedCreatedIngresses {
+				action := actions[i]
+				if !action.Matches("create", "ingresses") {
+					t.Errorf("%s: Unexpected action %s", k, action)
+				}
+				createdSVC := action.(core.CreateAction).GetObject().(*v1beta1.Ingress)
+				fullName := createdSVC.Namespace + "/" + createdSVC.Name
+				if fullName != expectedName {
+					t.Errorf("%s: Expected %s to be created, got %s", k, expectedName, fullName)
+				}
+			}
+		})
+	}
+}
+
+func TestDWIngressDeletion(t *testing.T) {
+	testTenant := &v1alpha1.VirtualCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "tenant-1",
+			UID:       "7374a172-c35d-45b1-9c8e-bf5c5b614937",
+		},
+		Spec: v1alpha1.VirtualClusterSpec{},
+		Status: v1alpha1.VirtualClusterStatus{
+			Phase: v1alpha1.ClusterRunning,
+		},
+	}
+
+	defaultClusterKey := conversion.ToClusterKey(testTenant)
+	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+
+	testcases := map[string]struct {
+		ExistingObjectInSuper []runtime.Object
+		EnqueueObject         *v1beta1.Ingress
+
+		ExpectedDeletedIngresses []string
+		ExpectedError            string
+	}{
+		"delete ingress": {
+			ExistingObjectInSuper: []runtime.Object{
+				superIngress("ing-1", superDefaultNSName, "12345", defaultClusterKey),
+			},
+			EnqueueObject:            tenantIngress("ing-1", "default", "12345"),
+			ExpectedDeletedIngresses: []string{superDefaultNSName + "/ing-1"},
+		},
+		"delete ingress but already gone": {
+			ExistingObjectInSuper:    []runtime.Object{},
+			EnqueueObject:            tenantIngress("ing-1", "default", "12345"),
+			ExpectedDeletedIngresses: []string{},
+			ExpectedError:            "",
+		},
+		"delete ingress but existing different uid one": {
+			ExistingObjectInSuper: []runtime.Object{
+				superIngress("ing-1", superDefaultNSName, "123456", defaultClusterKey),
+			},
+			EnqueueObject:            tenantIngress("ing-1", "default", "12345"),
+			ExpectedDeletedIngresses: []string{},
+			ExpectedError:            "delegated UID is different",
+		},
+	}
+
+	for k, tc := range testcases {
+		t.Run(k, func(t *testing.T) {
+			actions, reconcileErr, err := util.RunDownwardSync(NewIngressController, testTenant, tc.ExistingObjectInSuper, nil, tc.EnqueueObject, nil)
+			if err != nil {
+				t.Errorf("%s: error running downward sync: %v", k, err)
+				return
+			}
+
+			if reconcileErr != nil {
+				if tc.ExpectedError == "" {
+					t.Errorf("expected no error, but got \"%v\"", reconcileErr)
+				} else if !strings.Contains(reconcileErr.Error(), tc.ExpectedError) {
+					t.Errorf("expected error msg \"%s\", but got \"%v\"", tc.ExpectedError, reconcileErr)
+				}
+			} else {
+				if tc.ExpectedError != "" {
+					t.Errorf("expected error msg \"%s\", but got empty", tc.ExpectedError)
+				}
+			}
+
+			if len(tc.ExpectedDeletedIngresses) != len(actions) {
+				t.Errorf("%s: Expected to delete ingress %#v. Actual actions were: %#v", k, tc.ExpectedDeletedIngresses, actions)
+				return
+			}
+			for i, expectedName := range tc.ExpectedDeletedIngresses {
+				action := actions[i]
+				if !action.Matches("delete", "ingresses") {
+					t.Errorf("%s: Unexpected action %s", k, action)
+				}
+				fullName := action.(core.DeleteAction).GetNamespace() + "/" + action.(core.DeleteAction).GetName()
+				if fullName != expectedName {
+					t.Errorf("%s: Expected %s to be created, got %s", k, expectedName, fullName)
+				}
+			}
+		})
+	}
+}
+
+func applySpecToIngress(ing *v1beta1.Ingress, spec *v1beta1.IngressSpec) *v1beta1.Ingress {
+	ing.Spec = *spec.DeepCopy()
+	return ing
+}
+
+func TestDWIngressUpdate(t *testing.T) {
+	testTenant := &v1alpha1.VirtualCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "tenant-1",
+			UID:       "7374a172-c35d-45b1-9c8e-bf5c5b614937",
+		},
+		Spec: v1alpha1.VirtualClusterSpec{},
+		Status: v1alpha1.VirtualClusterStatus{
+			Phase: v1alpha1.ClusterRunning,
+		},
+	}
+
+	defaultClusterKey := conversion.ToClusterKey(testTenant)
+	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+
+	nginx := "nginx"
+	spec1 := &v1beta1.IngressSpec{
+		IngressClassName: &nginx,
+		Backend: &v1beta1.IngressBackend{
+			ServiceName: "nginx",
+		},
+	}
+
+	spec2 := &v1beta1.IngressSpec{
+		IngressClassName: &nginx,
+		Backend: &v1beta1.IngressBackend{
+			ServiceName: "nginx",
+		},
+	}
+
+	haproxy := "haproxy"
+	spec3 := &v1beta1.IngressSpec{
+		IngressClassName: &haproxy,
+		Backend: &v1beta1.IngressBackend{
+			ServiceName: "haproxy",
+		},
+	}
+
+	testcases := map[string]struct {
+		ExistingObjectInSuper  []runtime.Object
+		ExistingObjectInTenant *v1beta1.Ingress
+
+		ExpectedUpdatedIngresses []runtime.Object
+		ExpectedError            string
+	}{
+		"no diff": {
+			ExistingObjectInSuper: []runtime.Object{
+				applySpecToIngress(superIngress("ing-1", superDefaultNSName, "12345", defaultClusterKey), spec1),
+			},
+			ExistingObjectInTenant:   applySpecToIngress(tenantIngress("ing-1", "default", "12345"), spec2),
+			ExpectedUpdatedIngresses: []runtime.Object{},
+		},
+		"diff exists but uid is wrong": {
+			ExistingObjectInSuper: []runtime.Object{
+				applySpecToIngress(superIngress("ing-1", superDefaultNSName, "12345", defaultClusterKey), spec1),
+			},
+			ExistingObjectInTenant:   applySpecToIngress(tenantIngress("ing-1", "default", "123456"), spec3),
+			ExpectedUpdatedIngresses: []runtime.Object{},
+			ExpectedError:            "delegated UID is different",
+		},
+	}
+	for k, tc := range testcases {
+		t.Run(k, func(t *testing.T) {
+			actions, reconcileErr, err := util.RunDownwardSync(NewIngressController,
+				testTenant,
+				tc.ExistingObjectInSuper,
+				[]runtime.Object{tc.ExistingObjectInTenant},
+				tc.ExistingObjectInTenant,
+				nil)
+			if err != nil {
+				t.Errorf("%s: error running downward sync: %v", k, err)
+				return
+			}
+
+			if reconcileErr != nil {
+				if tc.ExpectedError == "" {
+					t.Errorf("expected no error, but got \"%v\"", reconcileErr)
+				} else if !strings.Contains(reconcileErr.Error(), tc.ExpectedError) {
+					t.Errorf("expected error msg \"%s\", but got \"%v\"", tc.ExpectedError, reconcileErr)
+				}
+			} else {
+				if tc.ExpectedError != "" {
+					t.Errorf("expected error msg \"%s\", but got empty", tc.ExpectedError)
+				}
+			}
+
+			if len(tc.ExpectedUpdatedIngresses) != len(actions) {
+				t.Errorf("%s: Expected to update ingress %#v. Actual actions were: %#v", k, tc.ExpectedUpdatedIngresses, actions)
+				return
+			}
+			for i, obj := range tc.ExpectedUpdatedIngresses {
+				action := actions[i]
+				if !action.Matches("update", "ingresses") {
+					t.Errorf("%s: Unexpected action %s", k, action)
+				}
+				actionObj := action.(core.UpdateAction).GetObject()
+				if !equality.Semantic.DeepEqual(obj, actionObj) {
+					t.Errorf("%s: Expected updated ingress is %v, got %v", k, obj, actionObj)
+				}
+			}
+		})
+	}
+}

--- a/incubator/virtualcluster/pkg/syncer/resources/ingress/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/ingress/uws.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"context"
+	"fmt"
+
+	pkgerr "github.com/pkg/errors"
+	v1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+)
+
+// StartUWS starts the upward syncer
+// and blocks until an empty struct is sent to the stop channel.
+func (c *controller) StartUWS(stopCh <-chan struct{}) error {
+	if !cache.WaitForCacheSync(stopCh, c.ingressSynced) {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+	return c.upwardIngressController.Start(stopCh)
+}
+
+func (c *controller) BackPopulate(key string) error {
+	pNamespace, pName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("invalid resource key %v: %v", key, err))
+		return nil
+	}
+
+	pIngress, err := c.ingressLister.Ingresses(pNamespace).Get(pName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	clusterName, vNamespace := conversion.GetVirtualOwner(pIngress)
+	if clusterName == "" || vNamespace == "" {
+		klog.Infof("drop ingress %s/%s which is not belongs to any tenant", pNamespace, pName)
+		return nil
+	}
+
+	vIngressObj, err := c.multiClusterIngressController.Get(clusterName, vNamespace, pName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return pkgerr.Wrapf(err, "could not find pIngress %s/%s's vIngress in controller cache", vNamespace, pName)
+	}
+	vIngress := vIngressObj.(*v1beta1.Ingress)
+	if pIngress.Annotations[constants.LabelUID] != string(vIngress.UID) {
+		return fmt.Errorf("BackPopulated pIngress %s/%s delegated UID is different from updated object.", pIngress.Namespace, pIngress.Name)
+	}
+
+	tenantClient, err := c.multiClusterIngressController.GetClusterClient(clusterName)
+	if err != nil {
+		return pkgerr.Wrapf(err, "failed to create client from cluster %s config", clusterName)
+	}
+
+	spec, err := c.multiClusterIngressController.GetSpec(clusterName)
+	if err != nil {
+		return pkgerr.Wrapf(err, "failed to get spec of cluster %s", clusterName)
+	}
+
+	var newIngress *v1beta1.Ingress
+	updatedMeta := conversion.Equality(c.config, spec).CheckUWObjectMetaEquality(&pIngress.ObjectMeta, &vIngress.ObjectMeta)
+	if updatedMeta != nil {
+		newIngress = vIngress.DeepCopy()
+		newIngress.ObjectMeta = *updatedMeta
+		if _, err = tenantClient.ExtensionsV1beta1().Ingresses(vIngress.Namespace).Update(context.TODO(), newIngress, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("failed to back populate ingress %s/%s meta update for cluster %s: %v", vIngress.Namespace, vIngress.Name, clusterName, err)
+		}
+	}
+
+	if !equality.Semantic.DeepEqual(vIngress.Status, pIngress.Status) {
+		if newIngress == nil {
+			newIngress = vIngress.DeepCopy()
+		} else {
+			// vIngress has been updated, let us fetch the lastest version.
+			if newIngress, err = tenantClient.ExtensionsV1beta1().Ingresses(vIngress.Namespace).Get(context.TODO(), vIngress.Name, metav1.GetOptions{}); err != nil {
+				return fmt.Errorf("failed to retrieve vIngress %s/%s from cluster %s: %v", vIngress.Namespace, vIngress.Name, clusterName, err)
+			}
+		}
+		newIngress.Status = pIngress.Status
+		if _, err = tenantClient.ExtensionsV1beta1().Ingresses(vIngress.Namespace).UpdateStatus(context.TODO(), newIngress, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("failed to back populate ingress %s/%s status update for cluster %s: %v", vIngress.Namespace, vIngress.Name, clusterName, err)
+		}
+	}
+	return nil
+}

--- a/incubator/virtualcluster/pkg/syncer/resources/ingress/uws_test.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/ingress/uws_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	v1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	core "k8s.io/client-go/testing"
+	util "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/util/test"
+
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+)
+
+func applyLoadBalancerToIngress(ing *v1beta1.Ingress, ip string) *v1beta1.Ingress {
+	ing.Status.LoadBalancer.Ingress = []v1.LoadBalancerIngress{
+		{
+			IP: ip,
+		},
+	}
+	return ing
+}
+
+func TestUWIngress(t *testing.T) {
+	testTenant := &v1alpha1.VirtualCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "tenant-1",
+			UID:       "7374a172-c35d-45b1-9c8e-bf5c5b614937",
+		},
+		Status: v1alpha1.VirtualClusterStatus{
+			Phase: v1alpha1.ClusterRunning,
+		},
+	}
+
+	defaultClusterKey := conversion.ToClusterKey(testTenant)
+	superDefaultNSName := conversion.ToSuperMasterNamespace(defaultClusterKey, "default")
+
+	testcases := map[string]struct {
+		ExistingObjectInSuper  []runtime.Object
+		ExistingObjectInTenant []runtime.Object
+		EnqueuedKey            string
+		ExpectedUpdatedObject  []runtime.Object
+		ExpectedNoOperation    bool
+		ExpectedError          string
+	}{
+		"pIngress not found": {
+			ExistingObjectInTenant: []runtime.Object{
+				tenantIngress("ing", "default", "12345"),
+			},
+			EnqueuedKey:         superDefaultNSName + "/ing",
+			ExpectedNoOperation: true,
+		},
+		"pIngress not created by syncer": {
+			ExistingObjectInSuper: []runtime.Object{
+				tenantIngress("kubernetes", superDefaultNSName, "12345"),
+			},
+			EnqueuedKey:         superDefaultNSName + "/kubernetes",
+			ExpectedNoOperation: true,
+		},
+		"pIngress exists but vIngress does not exist": {
+			ExistingObjectInSuper: []runtime.Object{
+				superIngress("ing", superDefaultNSName, "12345", defaultClusterKey),
+			},
+			EnqueuedKey:   superDefaultNSName + "/ing",
+			ExpectedError: "",
+		},
+		"pIngress exists, vIngress exists with different uid": {
+			ExistingObjectInSuper: []runtime.Object{
+				superIngress("ing", superDefaultNSName, "123456", defaultClusterKey),
+			},
+			ExistingObjectInTenant: []runtime.Object{
+				tenantIngress("ing", "default", "12345"),
+			},
+			EnqueuedKey:   superDefaultNSName + "/ing",
+			ExpectedError: "delegated UID is different",
+		},
+		"pIngress exists, vIngress exists with no diff": {
+			ExistingObjectInSuper: []runtime.Object{
+				superIngress("ing", superDefaultNSName, "123456", defaultClusterKey),
+			},
+			ExistingObjectInTenant: []runtime.Object{
+				tenantIngress("ing", "default", "12345"),
+			},
+			EnqueuedKey:         superDefaultNSName + "/ing",
+			ExpectedNoOperation: true,
+		},
+	}
+
+	for k, tc := range testcases {
+		t.Run(k, func(t *testing.T) {
+			actions, reconcileErr, err := util.RunUpwardSync(NewIngressController, testTenant, tc.ExistingObjectInSuper, tc.ExistingObjectInTenant, tc.EnqueuedKey, nil)
+			if err != nil {
+				t.Errorf("%s: error running upward sync: %v", k, err)
+				return
+			}
+
+			if tc.ExpectedNoOperation {
+				if len(actions) != 0 {
+					t.Errorf("%s: Expect no operation, got %v", k, actions)
+					return
+				}
+				return
+			}
+
+			if reconcileErr != nil {
+				if tc.ExpectedError == "" {
+					t.Errorf("expected no error, but got \"%v\"", reconcileErr)
+				} else if !strings.Contains(reconcileErr.Error(), tc.ExpectedError) {
+					t.Errorf("expected error msg \"%s\", but got \"%v\"", tc.ExpectedError, reconcileErr)
+				}
+			} else {
+				if tc.ExpectedError != "" {
+					t.Errorf("expected error msg \"%s\", but got empty", tc.ExpectedError)
+				}
+			}
+
+			for _, obj := range tc.ExpectedUpdatedObject {
+				matched := false
+				for _, action := range actions {
+					if !action.Matches("update", "ingresses") {
+						continue
+					}
+					actionObj := action.(core.UpdateAction).GetObject()
+					if !equality.Semantic.DeepEqual(obj, actionObj) {
+						exp, _ := json.Marshal(obj)
+						got, _ := json.Marshal(actionObj)
+						t.Errorf("%s: Expected updated Ingress is %v, got %v", k, string(exp), string(got))
+					}
+					matched = true
+					break
+				}
+				if !matched {
+					t.Errorf("%s: Expect updated Ingress %+v but not found", k, obj)
+				}
+			}
+		})
+	}
+}

--- a/incubator/virtualcluster/pkg/syncer/resources/register.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/register.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/resources/configmap"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/resources/endpoints"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/resources/event"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/resources/ingress"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/resources/namespace"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/resources/node"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/resources/persistentvolume"
@@ -49,6 +50,7 @@ func init() {
 		configmap.NewConfigMapController,
 		endpoints.NewEndpointsController,
 		event.NewEventController,
+		ingress.NewIngressController,
 		namespace.NewNamespaceController,
 		node.NewNodeController,
 		persistentvolume.NewPVController,
@@ -59,9 +61,11 @@ func init() {
 		serviceaccount.NewServiceAccountController,
 		storageclass.NewStorageClassController,
 	}
+
 	ExtraResourceController = make(map[string]manager.ResourceSyncerNew)
 	// add extra resource syncer controller here
 	ExtraResourceController["priorityclass"] = priorityclass.NewPriorityClassController
+	ExtraResourceController["ingress"] = ingress.NewIngressController
 }
 
 func Register(config *config.SyncerConfiguration,

--- a/incubator/virtualcluster/pkg/syncer/util/test/runDWS.go
+++ b/incubator/virtualcluster/pkg/syncer/util/test/runDWS.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	extensionsV1beta1 "k8s.io/api/extensions/v1beta1"
 	schedulingV1 "k8s.io/api/scheduling/v1"
 	storageV1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -183,6 +184,8 @@ func getObjectInformer(informer informers.SharedInformerFactory, obj runtime.Obj
 		return informer.Storage().V1().StorageClasses().Informer()
 	case *schedulingV1.PriorityClass:
 		return informer.Scheduling().V1().PriorityClasses().Informer()
+	case *extensionsV1beta1.Ingress:
+		return informer.Extensions().V1beta1().Ingresses().Informer()
 	default:
 		return nil
 	}


### PR DESCRIPTION
This loosely implements uws and dws syncing for `ingress` resources within the sync controller. While it's not mutating the ingress now I've implemented this so that it could easily be added.

Let me know if you think this should be considered under the additional syncer resources.

Closes: #1062

Signed-off-by: Chris Hein <me@chrishein.com>