### PR TITLE
add rest config into SyncerConfiguration

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/apis/config/types.go
+++ b/incubator/virtualcluster/pkg/syncer/apis/config/types.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 	componentbaseconfig "k8s.io/component-base/config"
 )
 
@@ -49,6 +50,9 @@ type SyncerConfiguration struct {
 
 	// DisableServiceAccountToken indicates whether disable service account token automatically mounted.
 	DisableServiceAccountToken bool
+
+	// Super master rest config
+	RestConfig *rest.Config
 }
 
 // SyncerLeaderElectionConfiguration expands LeaderElectionConfiguration


### PR DESCRIPTION
The purpose of this PR is to make the syncer framework more generic so it can be reused by users that need to support their own CRDs. This change passes rest config of super master in SyncerConfiguration struct. So users can construct/handle their CRD client to perform the DWS/UWS sync. 