### PR TITLE
Update object webhook to deny creating conflict object

### DIFF
--- a/incubator/hnc/internal/validators/object.go
+++ b/incubator/hnc/internal/validators/object.go
@@ -2,6 +2,7 @@ package validators
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	"github.com/go-logr/logr"
@@ -106,8 +107,13 @@ func (o *Object) handle(ctx context.Context, log logr.Logger, op admissionv1beta
 	oldSource, oldInherited := metadata.GetLabel(oldInst, api.LabelInheritedFrom)
 	newSource, newInherited := metadata.GetLabel(inst, api.LabelInheritedFrom)
 
-	// If the object wasn't and isn't inherited, it's none of our business.
+	// If the object wasn't and isn't inherited, we will check to see if the
+	// source can be created without causing any conflict.
 	if !oldInherited && !newInherited {
+		if yes, cnses := o.hasConflict(inst); yes {
+			msg := fmt.Sprintf("Cannot create %s '%s' in namespace '%s' because it would overwrite objects in the following descendant namespace(s): %v. Choose a different name for the object, or remove the conflicting objects from these namespaces.", inst.GroupVersionKind(), inst.GetName(), inst.GetNamespace(), cnses)
+			return deny(metav1.StatusReasonConflict, msg)
+		}
 		return allow("source object")
 	}
 
@@ -144,6 +150,33 @@ func (o *Object) handle(ctx context.Context, log logr.Logger, op admissionv1beta
 	// If you get here, it means the webhook config is misconfigured to include an operation that we
 	// actually don't support.
 	return deny(metav1.StatusReasonInternalError, "unknown operation: "+string(op))
+}
+
+// hasConflict checks if there's any conflicting objects in the descendants. Returns
+// true and a list of conflicting descendants, if yes.
+func (o *Object) hasConflict(inst *unstructured.Unstructured) (bool, []string) {
+	o.Forest.Lock()
+	defer o.Forest.Unlock()
+
+	// If the instance is empty (for a delete operation) or it's not namespace-scoped,
+	// there must be no conflict.
+	if inst == nil || inst.GetNamespace() == "" {
+		return false, nil
+	}
+
+	nm := inst.GetName()
+	gvk := inst.GroupVersionKind()
+	descs := o.Forest.Get(inst.GetNamespace()).DescendantNames()
+	conflicts := []string{}
+
+	// Get a list of conflicting descendants if there's any.
+	for _, desc := range descs {
+		if o.Forest.Get(desc).HasOriginalObject(gvk, nm) {
+			conflicts = append(conflicts, desc)
+		}
+	}
+
+	return len(conflicts) != 0, conflicts
 }
 
 func (o *Object) InjectClient(c client.Client) error {


### PR DESCRIPTION
Update object webhook to deny creating an object if an object with the
same name and type already exits in the descendants, and the type has
'Propagate' syncMode. Add new a new test case.

Tested manually on GKE cluster and by 'make test'.

The webhook output is like this:
```
Error from server (Conflict): admission webhook "objects.hnc.x-k8s.io" denied the request: Cannot create /v1, Kind=Secret 'my-creds' in namespace 'acme-org' because it would overwrite objects in the following descendant namespace(s): [team-a team-b]. Choose a different name for the object, or remove the conflicting objects from these namespaces.
```

Fixes #1079 
Part of #1076 