### PR TITLE
Remove resource creation time rest.

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/conversion/helper.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/helper.go
@@ -189,7 +189,6 @@ func ResetMetadata(obj metav1.Object) {
 	obj.SetUID("")
 	obj.SetResourceVersion("")
 	obj.SetGeneration(0)
-	obj.SetCreationTimestamp(metav1.Time{})
 	obj.SetDeletionTimestamp(nil)
 	obj.SetDeletionGracePeriodSeconds(nil)
 	obj.SetOwnerReferences(nil)


### PR DESCRIPTION
Resource creation time is used by performance monitoring module in k8s to present end to end resource creation latency. In virtual cluster case, resource creation time should be counted when tenant initiate the resource creation request in virtual cluster. Performing reset during super cluster syncing destroys useful metrics.