### PR TITLE
Fix the Rolebinding update logic

### DIFF
--- a/incubator/hnc/internal/reconcilers/object.go
+++ b/incubator/hnc/internal/reconcilers/object.go
@@ -538,10 +538,38 @@ func (r *ObjectReconciler) writeObject(ctx context.Context, log logr.Logger, ins
 	var err error = nil
 	stats.WriteObject(inst.GroupVersionKind())
 	if exist {
-		log.Info("Updating")
+		log.Info("Updating object")
 		err = r.Update(ctx, inst)
+		// RoleBindings can't have their Roles changed after they're created 
+		// (see  https://github.com/kubernetes-sigs/multi-tenancy/issues/798).
+		// If an RB was quickly delete and re-created in an ancestor namespace
+		// - fast enough that by the time that HNC notices, the new RB exists; or 
+		// if there's a change to the RBs when HNC isn't running - HNC could see 
+		// it as an update (not a delete + create) and attempt to update the RBs in
+		// all descendant namespaces, and this will fail. In order to handle this 
+		// case, we try to delete and re-create the rolebinding here
+		
+		// We only found this issue with the RoleBinding object, but we *think* this 
+		// will also be helpful for other similar objects that end up with the same error
+		// type. If we find out later that this assumption is not true, we can update the
+		// logic here to only deal with RoleBinding.
+
+		// The error type is 'Invalid' after I tested it out with different error types 
+		// from https://godoc.org/k8s.io/apimachinery/pkg/api/errors
+		if err != nil && errors.IsInvalid(err) {
+			if err = r.Delete(ctx, inst); err == nil {
+				err = r.Create(ctx, inst)
+				if err != nil {
+					log.Info("Unable to create new object.") // error is handles below
+				} else {
+					log.Info("Couldn't update object but delete and re-create it.")
+				}
+			} else {
+				log.Info("Unable to delete the existing object.") // error is handles below
+			}
+		}
 	} else {
-		log.Info("Creating")
+		log.Info("Creating object")
 		err = r.Create(ctx, inst)
 	}
 	if err != nil {

--- a/incubator/hnc/test/e2e/rolebinding_test.go
+++ b/incubator/hnc/test/e2e/rolebinding_test.go
@@ -1,0 +1,46 @@
+package e2e
+
+import (
+	"time"
+	. "github.com/onsi/ginkgo"
+	. "sigs.k8s.io/multi-tenancy/incubator/hnc/pkg/testutils"
+)
+
+var _ = Describe("HNC should delete and create a new Rolebinding instead of updating it", func() {
+
+	const (
+		nsParent = "parent"
+		nsChild  = "child"
+	)
+
+	BeforeEach(func() {
+		CheckHNCPath()
+		CleanupNamespaces(nsParent, nsChild)
+	})
+
+	AfterEach(func() {
+		CleanupNamespaces(nsParent, nsChild)
+		RecoverHNC()
+	})
+
+	FIt("Should delete and create a Rolebinding when HNC is undeployed - issue #798", func() {
+		// NOTE: THERE IS ONE CASE THAT THIS TEST WILL ALWAYS PASS EVEN IF CODE IS BROKEN:
+		// After recovering HNC, if nsChild gets reconciled first, the 'admin' rolebinding will
+		// be deleted, and the 'edit' rolebinding will be created when nsParent gets reconciled.
+		// In this case the rolebinding would not be considered as 'updated' and the test will pass
+		MustRun("kubectl create ns", nsParent)
+		MustRun("kubectl hns create", nsChild, "-n", nsParent)
+		MustRun("kubectl create rolebinding test --clusterrole=admin --serviceaccount=default:default -n", nsParent)
+		FieldShouldContain("rolebinding", nsChild, "test", ".roleRef.name", "admin")
+		MustRun("kubectl delete deployment --all -n hnc-system")
+		// The pod might take up to a minite to be deleted, we force the deletion here to save time
+		MustRun("kubectl delete pods --all -n hnc-system --grace-period=0 --force")
+		RunShouldContain("No resources found", 60, "kubectl get pods -n hnc-system")
+		MustRun("kubectl delete rolebinding test -n", nsParent)
+		MustNotRun("kubectl describe rolebinding test -n", nsParent)
+		MustRun("kubectl create rolebinding test --clusterrole=edit --serviceaccount=default:default -n", nsParent)
+		FieldShouldContain("rolebinding", nsParent, "test", ".roleRef.name", "edit")
+		RecoverHNC()
+		FieldShouldContain("rolebinding", nsChild, "test", ".roleRef.name", "edit")
+	})
+})


### PR DESCRIPTION
RoleBindings can't have their Roles changed after they're created. If an RB was quickly delete and re-created in an ancestor namespace - fast enough that by the time that HNC notices, the new RB exists - HNC could see it as an update (not a delete + create) and attempt to update the RBs in all descendant namespaces, and this will fail. In order to handle this case, we try to delete and re-create the rolebinding instead.

Tested: make test-e2e

Fix #798