### PR TITLE
Update hc validator to check object conflicts

### DIFF
--- a/incubator/hnc/internal/forest/namespaceobjects.go
+++ b/incubator/hnc/internal/forest/namespaceobjects.go
@@ -63,6 +63,14 @@ func (ns *Namespace) GetPropagatedObjects(gvk schema.GroupVersionKind) []*unstru
 	return o
 }
 
+// GetPropagatingObjects returns all the source objects to be propagated into the
+// descendants of this namespace.
+// TODO update this function to reflect the changes introduced by the future HNC
+//  exceptions implementation.
+func (ns *Namespace) GetPropagatingObjects(gvk schema.GroupVersionKind) []*unstructured.Unstructured {
+	return append(ns.GetPropagatedObjects(gvk), ns.GetOriginalObjects(gvk)...)
+}
+
 // GetSource returns the original copy in the ancestors if it exists.
 // Otherwise, return nil.
 func (ns *Namespace) GetSource(gvk schema.GroupVersionKind, name string) *unstructured.Unstructured {

--- a/incubator/hnc/internal/reconcilers/object.go
+++ b/incubator/hnc/internal/reconcilers/object.go
@@ -540,21 +540,21 @@ func (r *ObjectReconciler) writeObject(ctx context.Context, log logr.Logger, ins
 	if exist {
 		log.Info("Updating object")
 		err = r.Update(ctx, inst)
-		// RoleBindings can't have their Roles changed after they're created 
+		// RoleBindings can't have their Roles changed after they're created
 		// (see  https://github.com/kubernetes-sigs/multi-tenancy/issues/798).
 		// If an RB was quickly delete and re-created in an ancestor namespace
-		// - fast enough that by the time that HNC notices, the new RB exists; or 
-		// if there's a change to the RBs when HNC isn't running - HNC could see 
+		// - fast enough that by the time that HNC notices, the new RB exists; or
+		// if there's a change to the RBs when HNC isn't running - HNC could see
 		// it as an update (not a delete + create) and attempt to update the RBs in
-		// all descendant namespaces, and this will fail. In order to handle this 
+		// all descendant namespaces, and this will fail. In order to handle this
 		// case, we try to delete and re-create the rolebinding here
-		
-		// We only found this issue with the RoleBinding object, but we *think* this 
+
+		// We only found this issue with the RoleBinding object, but we *think* this
 		// will also be helpful for other similar objects that end up with the same error
 		// type. If we find out later that this assumption is not true, we can update the
 		// logic here to only deal with RoleBinding.
 
-		// The error type is 'Invalid' after I tested it out with different error types 
+		// The error type is 'Invalid' after I tested it out with different error types
 		// from https://godoc.org/k8s.io/apimachinery/pkg/api/errors
 		if err != nil && errors.IsInvalid(err) {
 			if err = r.Delete(ctx, inst); err == nil {

--- a/incubator/hnc/internal/validators/hierarchy.go
+++ b/incubator/hnc/internal/validators/hierarchy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/go-logr/logr"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
@@ -12,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -210,7 +212,52 @@ func (v *Hierarchy) checkParent(ns, curParent, newParent *forest.Namespace) admi
 		return deny(metav1.StatusReasonConflict, "Illegal parent: "+reason)
 	}
 
+	// Prevent overwriting source objects in the descendants after the hierarchy change.
+	if co := v.getConflictingObjects(newParent, ns); len(co) != 0 {
+		msg := "Cannot update hierarchy because it would overwrite the following object(s):\n"
+		msg += "  * " + strings.Join(co, "\n  * ") + "\n"
+		msg += "To fix this, please rename or remove the conflicting objects first."
+		return deny(metav1.StatusReasonConflict, msg)
+	}
+
 	return allow("")
+}
+
+// getConflictingObjects returns a list of namespaced objects if there's any conflict.
+func (v *Hierarchy) getConflictingObjects(newParent, ns *forest.Namespace) []string {
+	// Traverse all the types with 'Propagate' mode to find any conflicts.
+	conflicts := []string{}
+	for _, t := range v.Forest.GetTypeSyncers() {
+		if t.GetMode() == api.Propagate {
+			conflicts = append(conflicts, v.getConflictingObjectsOfType(t.GetGVK(), newParent, ns)...)
+		}
+	}
+	return conflicts
+}
+
+// getConflictingObjectsOfType returns a list of namespaced objects if there's
+// any conflict between the new ancestors and the descendants.
+func (v *Hierarchy) getConflictingObjectsOfType(gvk schema.GroupVersionKind, newParent, ns *forest.Namespace) []string {
+	// Get all the source objects in the new ancestors that would be propagated
+	// into the descendants.
+	newAnsSrcObjs := make(map[string]bool)
+	for _, o := range newParent.GetPropagatingObjects(gvk) {
+		newAnsSrcObjs[o.GetName()] = true
+	}
+
+	// Look in the descendants to find if there's any conflict.
+	cos := []string{}
+	dnses := append(ns.DescendantNames(), ns.Name())
+	for _, dns := range dnses {
+		for _, o := range v.Forest.Get(dns).GetOriginalObjects(gvk) {
+			if newAnsSrcObjs[o.GetName()] {
+				co := fmt.Sprintf("Namespace %q: %s (%v)", dns, o.GetName(), gvk)
+				cos = append(cos, co)
+			}
+		}
+	}
+
+	return cos
 }
 
 type serverCheckType int


### PR DESCRIPTION
Add an additional rule to make sure there's no potential object
overwriting in hierarchy changes. Format the webhook message to:
```
Cannot update hierarchy because it would overwrite the following object(s):
  * Namespace "team-b": my-creds (/v1, Kind=Secret)
  * Namespace "team-b": my-creds2 (/v1, Kind=Secret)
To fix this, please rename or remove the conflicting objects first.
```

Format the object webhook message to:
```
Cannot create "my-creds2" (/v1, Kind=Secret) in namespace "acme-org" because it would overwrite objects in the following descendant namespace(s):
  * team-a
  * team-b
To fix this, choose a different name for the object, or remove the conflicting objects from the above namespaces.
```

Tested manually on GKE cluster and by 'make test' with new test
cases.

Part of #1076 