### PR TITLE
Upgrade controller-tools to enable unservedversion

### DIFF
--- a/incubator/hnc/go.mod
+++ b/incubator/hnc/go.mod
@@ -18,11 +18,12 @@ require (
 	github.com/prometheus/client_golang v1.5.0
 	github.com/spf13/cobra v0.0.5
 	go.opencensus.io v0.22.3
+	go.uber.org/atomic v1.4.0
 	k8s.io/api v0.18.5
 	k8s.io/apiextensions-apiserver v0.18.5
 	k8s.io/apimachinery v0.18.5
 	k8s.io/cli-runtime v0.18.5
 	k8s.io/client-go v0.18.5
 	sigs.k8s.io/controller-runtime v0.6.1
-	sigs.k8s.io/controller-tools v0.2.5
+	sigs.k8s.io/controller-tools v0.2.8
 )

--- a/incubator/hnc/go.sum
+++ b/incubator/hnc/go.sum
@@ -719,6 +719,8 @@ sigs.k8s.io/controller-runtime v0.6.1 h1:LcK2+nk0kmaOnKGN+vBcWHqY5WDJNJNB/c5pW+s
 sigs.k8s.io/controller-runtime v0.6.1/go.mod h1:XRYBPdbf5XJu9kpS84VJiZ7h/u1hF3gEORz0efEja7A=
 sigs.k8s.io/controller-tools v0.2.5 h1:kH7HKWed9XO42OTxyhUtqyImiefdZV2Q9Jbrytvhf18=
 sigs.k8s.io/controller-tools v0.2.5/go.mod h1:+t0Hz6tOhJQCdd7IYO0mNzimmiM9sqMU0021u6UCF2o=
+sigs.k8s.io/controller-tools v0.2.8 h1:UmYsnu89dn8/wBhjKL3lkGyaDGRnPDYUx2+iwXRnylA=
+sigs.k8s.io/controller-tools v0.2.8/go.mod h1:9VKHPszmf2DHz/QmHkcfZoewO6BL7pPs9uAiBVsaJSE=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/incubator/hnc/vendor/modules.txt
+++ b/incubator/hnc/vendor/modules.txt
@@ -263,6 +263,7 @@ go.opencensus.io/trace/internal
 go.opencensus.io/trace/propagation
 go.opencensus.io/trace/tracestate
 # go.uber.org/atomic v1.4.0
+## explicit
 go.uber.org/atomic
 # go.uber.org/multierr v1.1.0
 go.uber.org/multierr
@@ -714,7 +715,7 @@ sigs.k8s.io/controller-runtime/pkg/webhook/admission
 sigs.k8s.io/controller-runtime/pkg/webhook/conversion
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/certwatcher
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
-# sigs.k8s.io/controller-tools v0.2.5
+# sigs.k8s.io/controller-tools v0.2.8
 ## explicit
 sigs.k8s.io/controller-tools/cmd/controller-gen
 sigs.k8s.io/controller-tools/pkg/crd

--- a/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/crd/conv.go
+++ b/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/crd/conv.go
@@ -35,7 +35,7 @@ func AsVersion(original apiext.CustomResourceDefinition, gv schema.GroupVersion)
 	// questionable decision.
 	intVer, err := conversionScheme.ConvertToVersion(&original, apiextinternal.SchemeGroupVersion)
 	if err != nil {
-		return nil, fmt.Errorf("unable to convert to internal CRD version: %v", err)
+		return nil, fmt.Errorf("unable to convert to internal CRD version: %w", err)
 	}
 
 	return conversionScheme.ConvertToVersion(intVer, gv)

--- a/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/crd/gen.go
+++ b/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/crd/gen.go
@@ -104,7 +104,7 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 		crdVersions = []string{"v1beta1"}
 	}
 
-	for _, groupKind := range kubeKinds {
+	for groupKind := range kubeKinds {
 		parser.NeedCRDFor(groupKind, g.MaxDescLen)
 		crdRaw := parser.CustomResourceDefinitions[groupKind]
 		addAttribution(&crdRaw)
@@ -206,9 +206,9 @@ func FindMetav1(roots []*loader.Package) *loader.Package {
 // FindKubeKinds locates all types that contain TypeMeta and ObjectMeta
 // (and thus may be a Kubernetes object), and returns the corresponding
 // group-kinds.
-func FindKubeKinds(parser *Parser, metav1Pkg *loader.Package) []schema.GroupKind {
+func FindKubeKinds(parser *Parser, metav1Pkg *loader.Package) map[schema.GroupKind]struct{} {
 	// TODO(directxman12): technically, we should be finding metav1 per-package
-	var kubeKinds []schema.GroupKind
+	kubeKinds := map[schema.GroupKind]struct{}{}
 	for typeIdent, info := range parser.Types {
 		hasObjectMeta := false
 		hasTypeMeta := false
@@ -257,7 +257,7 @@ func FindKubeKinds(parser *Parser, metav1Pkg *loader.Package) []schema.GroupKind
 			Group: parser.GroupVersions[pkg].Group,
 			Kind:  typeIdent.Name,
 		}
-		kubeKinds = append(kubeKinds, groupKind)
+		kubeKinds[groupKind] = struct{}{}
 	}
 
 	return kubeKinds

--- a/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/crd.go
+++ b/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/crd.go
@@ -45,6 +45,9 @@ var CRDMarkers = []*definitionWithHelp{
 
 	must(markers.MakeDefinition("kubebuilder:skipversion", markers.DescribesType, SkipVersion{})).
 		WithHelp(SkipVersion{}.Help()),
+
+	must(markers.MakeDefinition("kubebuilder:unservedversion", markers.DescribesType, UnservedVersion{})).
+		WithHelp(UnservedVersion{}.Help()),
 }
 
 // TODO: categories and singular used to be annotations types
@@ -277,6 +280,9 @@ func (s Resource) ApplyToCRD(crd *apiext.CustomResourceDefinitionSpec, version s
 	if s.Path != "" {
 		crd.Names.Plural = s.Path
 	}
+	if s.Singular != "" {
+		crd.Names.Singular = s.Singular
+	}
 	crd.Names.ShortNames = s.ShortName
 	crd.Names.Categories = s.Categories
 
@@ -287,6 +293,25 @@ func (s Resource) ApplyToCRD(crd *apiext.CustomResourceDefinitionSpec, version s
 		crd.Scope = apiext.ResourceScope(s.Scope)
 	}
 
+	return nil
+}
+
+// +controllertools:marker:generateHelp:category=CRD
+
+// UnservedVersion does not serve this version.
+//
+// This is useful if you need to drop support for a version in favor of a newer version.
+type UnservedVersion struct{}
+
+func (s UnservedVersion) ApplyToCRD(crd *apiext.CustomResourceDefinitionSpec, version string) error {
+	for i := range crd.Versions {
+		ver := &crd.Versions[i]
+		if ver.Name != version {
+			continue
+		}
+		ver.Served = false
+		break
+	}
 	return nil
 }
 

--- a/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/zz_generated.markerhelp.go
@@ -374,6 +374,17 @@ func (UniqueItems) Help() *markers.DefinitionHelp {
 	}
 }
 
+func (UnservedVersion) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "does not serve this version. ",
+			Details: "This is useful if you need to drop support for a version in favor of a newer version.",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{},
+	}
+}
+
 func (XEmbeddedResource) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
 		Category: "CRD validation",

--- a/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/crd/spec.go
+++ b/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/crd/spec.go
@@ -120,7 +120,7 @@ func (p *Parser) NeedCRDFor(groupKind schema.GroupKind, maxDescLen *int) {
 		}
 	}
 
-	// fix the name if the plural was changed (this is the form the name *has* to take, so no harm in chaning it).
+	// fix the name if the plural was changed (this is the form the name *has* to take, so no harm in changing it).
 	crd.Name = crd.Spec.Names.Plural + "." + groupKind.Group
 
 	// nothing to actually write
@@ -149,6 +149,19 @@ func (p *Parser) NeedCRDFor(groupKind schema.GroupKind, maxDescLen *int) {
 		// just add the error to the first relevant package for this CRD,
 		// since there's no specific error location
 		packages[0].AddError(fmt.Errorf("CRD for %s has no storage version", groupKind))
+	}
+
+	served := false
+	for _, ver := range crd.Spec.Versions {
+		if ver.Served {
+			served = true
+			break
+		}
+	}
+	if !served {
+		// just add the error to the first relevant package for this CRD,
+		// since there's no specific error location
+		packages[0].AddError(fmt.Errorf("CRD for %s with version(s) %v does not serve any version", groupKind, crd.Spec.Versions))
 	}
 
 	// NB(directxman12): CRD's status doesn't have omitempty markers, which means things

--- a/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/genall/options.go
+++ b/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/genall/options.go
@@ -128,7 +128,7 @@ func protoFromOptions(optionsRegistry *markers.Registry, options []string) (prot
 
 		val, err := defn.Parse(rawOpt)
 		if err != nil {
-			return protoRuntime{}, fmt.Errorf("unable to parse option %q: %v", rawOpt[1:], err)
+			return protoRuntime{}, fmt.Errorf("unable to parse option %q: %w", rawOpt[1:], err)
 		}
 
 		switch val := val.(type) {

--- a/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/markers/parse.go
+++ b/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/markers/parse.go
@@ -588,7 +588,7 @@ func ArgumentFromType(rawType reflect.Type) (Argument, error) {
 		arg.Type = SliceType
 		itemType, err := ArgumentFromType(rawType.Elem())
 		if err != nil {
-			return Argument{}, fmt.Errorf("bad slice item type: %v", err)
+			return Argument{}, fmt.Errorf("bad slice item type: %w", err)
 		}
 		arg.ItemType = &itemType
 	case reflect.Map:
@@ -598,7 +598,7 @@ func ArgumentFromType(rawType reflect.Type) (Argument, error) {
 		}
 		itemType, err := ArgumentFromType(rawType.Elem())
 		if err != nil {
-			return Argument{}, fmt.Errorf("bad slice item type: %v", err)
+			return Argument{}, fmt.Errorf("bad slice item type: %w", err)
 		}
 		arg.ItemType = &itemType
 	default:
@@ -720,7 +720,7 @@ func (d *Definition) loadFields() error {
 
 		argType, err := ArgumentFromType(field.Type)
 		if err != nil {
-			return fmt.Errorf("unable to extract type information for field %q: %v", field.Name, err)
+			return fmt.Errorf("unable to extract type information for field %q: %w", field.Name, err)
 		}
 
 		if argType.Type == RawType {

--- a/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/rbac/zz_generated.markerhelp.go
+++ b/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/rbac/zz_generated.markerhelp.go
@@ -56,6 +56,10 @@ func (Rule) Help() *markers.DefinitionHelp {
 				Summary: "specifies the API resources that this rule encompasses.",
 				Details: "",
 			},
+			"ResourceNames": markers.DetailedHelp{
+				Summary: "specifies the names of the API resources that this rule encompasses. Create requests cannot be restricted by resourcename, as the object's name is not known at authorization time.",
+				Details: "",
+			},
 			"Verbs": markers.DetailedHelp{
 				Summary: "specifies the (lowercase) kubernetes API verbs that this rule encompasses.",
 				Details: "",

--- a/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/schemapatcher/internal/yaml/convert.go
+++ b/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/schemapatcher/internal/yaml/convert.go
@@ -33,12 +33,12 @@ func ToYAML(rawObj interface{}) (*yaml.Node, error) {
 
 	rawJSON, err := json.Marshal(rawObj)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal object: %v", err)
+		return nil, fmt.Errorf("failed to marshal object: %w", err)
 	}
 
 	var out yaml.Node
 	if err := yaml.Unmarshal(rawJSON, &out); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal marshalled object: %v", err)
+		return nil, fmt.Errorf("unable to unmarshal marshalled object: %w", err)
 	}
 	return &out, nil
 }

--- a/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/schemapatcher/internal/yaml/nested.go
+++ b/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/schemapatcher/internal/yaml/nested.go
@@ -58,7 +58,7 @@ func asCloseAsPossible(root *yaml.Node, path ...string) (*yaml.Node, []string, e
 
 		nextNode, err := ValueInMapping(currNode, path[0])
 		if err != nil {
-			return nil, nil, fmt.Errorf("unable to get next node in path %v: %v", path, err)
+			return nil, nil, fmt.Errorf("unable to get next node in path %v: %w", path, err)
 		}
 
 		if nextNode == nil {

--- a/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/webhook/parser.go
+++ b/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/webhook/parser.go
@@ -19,7 +19,7 @@ limitations under the License.
 //
 // The markers take the form:
 //
-//  +kubebuilder:webhook:failurePolicy=<string>,groups=<[]string>,resources=<[]string>,verbs=<[]string>,versions=<[]string>,name=<string>,path=<string>,mutating=<bool>
+//  +kubebuilder:webhook:failurePolicy=<string>,matchPolicy=<string>,groups=<[]string>,resources=<[]string>,verbs=<[]string>,versions=<[]string>,name=<string>,path=<string>,mutating=<bool>
 package webhook
 
 import (
@@ -57,6 +57,10 @@ type Config struct {
 	// It may be either "ignore" (to skip the webhook and continue on) or "fail" (to reject
 	// the object in question).
 	FailurePolicy string
+	// MatchPolicy defines how the "rules" list is used to match incoming requests.
+	// Allowed values are "Exact" (match only if it exactly matches the specified rule)
+	// or "Equivalent" (match a request if it modifies a resource listed in rules, even via another API group or version).
+	MatchPolicy string `marker:",optional"`
 
 	// Groups specifies the API groups that this webhook receives requests for.
 	Groups []string
@@ -70,9 +74,15 @@ type Config struct {
 	// Versions specifies the API versions that this webhook receives requests for.
 	Versions []string
 
-	// Name indicates the name of this webhook configuration.
+	// Name indicates the name of this webhook configuration. Should be a domain with at least three segments separated by dots
 	Name string
-	// Path specifies that path that the API server should connect to this webhook on.
+
+	// Path specifies that path that the API server should connect to this webhook on. Must be
+	// prefixed with a '/validate-' or '/mutate-' depending on the type, and followed by
+	// $GROUP-$VERSION-$KIND where all values are lower-cased and the periods in the group
+	// are substituted for hyphens. For example, a validating webhook path for type
+	// batch.tutorial.kubebuilder.io/v1,Kind=CronJob would be
+	// /validate-batch-tutorial-kubebuilder-io-v1-cronjob
 	Path string
 }
 
@@ -101,10 +111,16 @@ func (c Config) ToMutatingWebhook() (admissionreg.MutatingWebhook, error) {
 		return admissionreg.MutatingWebhook{}, fmt.Errorf("%s is a validating webhook", c.Name)
 	}
 
+	matchPolicy, err := c.matchPolicy()
+	if err != nil {
+		return admissionreg.MutatingWebhook{}, err
+	}
+
 	return admissionreg.MutatingWebhook{
 		Name:          c.Name,
 		Rules:         c.rules(),
 		FailurePolicy: c.failurePolicy(),
+		MatchPolicy:   matchPolicy,
 		ClientConfig:  c.clientConfig(),
 	}, nil
 }
@@ -115,10 +131,16 @@ func (c Config) ToValidatingWebhook() (admissionreg.ValidatingWebhook, error) {
 		return admissionreg.ValidatingWebhook{}, fmt.Errorf("%s is a mutating webhook", c.Name)
 	}
 
+	matchPolicy, err := c.matchPolicy()
+	if err != nil {
+		return admissionreg.ValidatingWebhook{}, err
+	}
+
 	return admissionreg.ValidatingWebhook{
 		Name:          c.Name,
 		Rules:         c.rules(),
 		FailurePolicy: c.failurePolicy(),
+		MatchPolicy:   matchPolicy,
 		ClientConfig:  c.clientConfig(),
 	}, nil
 }
@@ -162,6 +184,22 @@ func (c Config) failurePolicy() *admissionreg.FailurePolicyType {
 		failurePolicy = admissionreg.FailurePolicyType(c.FailurePolicy)
 	}
 	return &failurePolicy
+}
+
+// matchPolicy converts the string value to the proper value for the API.
+func (c Config) matchPolicy() (*admissionreg.MatchPolicyType, error) {
+	var matchPolicy admissionreg.MatchPolicyType
+	switch strings.ToLower(c.MatchPolicy) {
+	case strings.ToLower(string(admissionreg.Exact)):
+		matchPolicy = admissionreg.Exact
+	case strings.ToLower(string(admissionreg.Equivalent)):
+		matchPolicy = admissionreg.Equivalent
+	case "":
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unknown value %q for matchPolicy", c.MatchPolicy)
+	}
+	return &matchPolicy, nil
 }
 
 // clientConfig returns the client config for a webhook.

--- a/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/webhook/zz_generated.markerhelp.go
+++ b/incubator/hnc/vendor/sigs.k8s.io/controller-tools/pkg/webhook/zz_generated.markerhelp.go
@@ -40,6 +40,10 @@ func (Config) Help() *markers.DefinitionHelp {
 				Summary: "specifies what should happen if the API server cannot reach the webhook. ",
 				Details: "It may be either \"ignore\" (to skip the webhook and continue on) or \"fail\" (to reject the object in question).",
 			},
+			"MatchPolicy": markers.DetailedHelp{
+				Summary: "defines how the \"rules\" list is used to match incoming requests. Allowed values are \"Exact\" (match only if it exactly matches the specified rule) or \"Equivalent\" (match a request if it modifies a resource listed in rules, even via another API group or version).",
+				Details: "",
+			},
 			"Groups": markers.DetailedHelp{
 				Summary: "specifies the API groups that this webhook receives requests for.",
 				Details: "",
@@ -57,11 +61,11 @@ func (Config) Help() *markers.DefinitionHelp {
 				Details: "",
 			},
 			"Name": markers.DetailedHelp{
-				Summary: "indicates the name of this webhook configuration.",
+				Summary: "indicates the name of this webhook configuration. Should be a domain with at least three segments separated by dots",
 				Details: "",
 			},
 			"Path": markers.DetailedHelp{
-				Summary: "specifies that path that the API server should connect to this webhook on.",
+				Summary: "specifies that path that the API server should connect to this webhook on. Must be prefixed with a '/validate-' or '/mutate-' depending on the type, and followed by $GROUP-$VERSION-$KIND where all values are lower-cased and the periods in the group are substituted for hyphens. For example, a validating webhook path for type batch.tutorial.kubebuilder.io/v1,Kind=CronJob would be /validate-batch-tutorial-kubebuilder-io-v1-cronjob",
 				Details: "",
 			},
 		},


### PR DESCRIPTION
Upgrade controller-tools to v0.2.8 where kubebuilder:unservedversion
marker is landed. See https://github.com/kubernetes-sigs/controller-tools/issues/462

Tested by make test.

Part of #1035 