### PR TITLE
VC: Use optional env var for Docker registry in Makefile

### DIFF
--- a/incubator/virtualcluster/Makefile
+++ b/incubator/virtualcluster/Makefile
@@ -2,7 +2,8 @@
 export GO111MODULE=on
 
 # Image URL to use all building/pushing image targets
-IMG ?= virtualcluster/manager-amd64 virtualcluster/vn-agent-amd64 virtualcluster/syncer-amd64
+DOCKER_REG ?= ${or ${VC_DOCKER_REGISTRY},"virtualcluster"}
+IMG ?= ${DOCKER_REG}/manager-amd64 ${DOCKER_REG}/vn-agent-amd64 ${DOCKER_REG}/syncer-amd64
 
 # TEST_FLAGS used as flags of go test.
 TEST_FLAGS ?= -v --race


### PR DESCRIPTION
Very small change! I was trying to do some local development, and noticed in the build script we can set the `VC_DOCKER_REGISTRY` variable when building the images.

I added this functionality to the Makefile as well to make pushing to a custom repo and testing very easy. It still defaults to `virtual cluster`