### PR TITLE
Add test for propagating object to selected namespaces

### DIFF
--- a/incubator/hnc/internal/reconcilers/object_test.go
+++ b/incubator/hnc/internal/reconcilers/object_test.go
@@ -45,6 +45,44 @@ var _ = Describe("Secret", func() {
 		cleanupObjects(ctx)
 	})
 
+	// Exceptions have not been implemented, so we are ignoring the following three tests for now.
+	// They should be enabled once exception is done.
+	PIt("should propagate object only to selected namespace using treeSelect", func() {
+		setParent(ctx, barName, fooName)
+		setParent(ctx, bazName, fooName)
+
+		// Create a secret that does NOT propogate to bazName
+		a := map[string]string{"propagate.hnc.x-k8s.io/treeSelect": "!" + bazName}
+		makeObjectWithAnnotation(ctx, "Secret", fooName, "fooSecret", a)
+
+		Eventually(hasObject(ctx, "Secret", barName, "fooSecret")).Should(BeTrue())
+		Consistently(hasObject(ctx, "Secret", bazName, "fooSecret")).Should(BeFalse())
+	})
+
+	PIt("should propagate object only to selected namespace using select", func() {
+		setParent(ctx, barName, fooName)
+		setParent(ctx, bazName, fooName)
+
+		// Create a secret that does NOT propogate to bazName
+		a := map[string]string{"propagate.hnc.x-k8s.io/select": "!propagate.hnc.x-k8s.io/" + bazName}
+		makeObjectWithAnnotation(ctx, "Secret", fooName, "fooSecret", a)
+
+		Eventually(hasObject(ctx, "Secret", barName, "fooSecret")).Should(BeTrue())
+		Consistently(hasObject(ctx, "Secret", bazName, "fooSecret")).Should(BeFalse())
+	})
+
+	PIt("should not propagate object to any namespace using none", func() {
+		setParent(ctx, barName, fooName)
+		setParent(ctx, bazName, fooName)
+
+		// Create a secret that does NOT propogate to bazName
+		a := map[string]string{"propagate.hnc.x-k8s.io/none": "true"}
+		makeObjectWithAnnotation(ctx, "Secret", fooName, "fooSecret", a)
+
+		Consistently(hasObject(ctx, "Secret", barName, "fooSecret")).Should(BeFalse())
+		Consistently(hasObject(ctx, "Secret", bazName, "fooSecret")).Should(BeFalse())
+	})
+
 	It("should be copied to descendents", func() {
 		setParent(ctx, barName, fooName)
 		setParent(ctx, bazName, barName)

--- a/incubator/hnc/internal/reconcilers/test_helpers_test.go
+++ b/incubator/hnc/internal/reconcilers/test_helpers_test.go
@@ -182,6 +182,19 @@ func makeObject(ctx context.Context, kind string, nsName, name string) {
 	createdObjects = append(createdObjects, inst)
 }
 
+// makeObjectWithAnnotation creates an empty object with annotation given kind in a specific
+// namespace. The kind and its corresponding GVK should be included in the GVKs map.
+func makeObjectWithAnnotation(ctx context.Context, kind string, nsName,
+	name string, a map[string]string) {
+	inst := &unstructured.Unstructured{}
+	inst.SetGroupVersionKind(GVKs[kind])
+	inst.SetNamespace(nsName)
+	inst.SetName(name)
+	inst.SetAnnotations(a)
+	ExpectWithOffset(1, k8sClient.Create(ctx, inst)).Should(Succeed())
+	createdObjects = append(createdObjects, inst)
+}
+
 // deleteObject deletes an object of the given kind in a specific namespace. The kind and
 // its corresponding GVK should be included in the GVKs map.
 func deleteObject(ctx context.Context, kind string, nsName, name string) {


### PR DESCRIPTION
This test is expected to fail now, and pass when the exception is
implemented. We ignore this test for now with `PIt` block.

Tested: make test