### PR TITLE
Update hncconfig webhook to avoid overwriting source

### DIFF
--- a/incubator/hnc/internal/forest/forest.go
+++ b/incubator/hnc/internal/forest/forest.go
@@ -82,6 +82,7 @@ func (f *Forest) Get(nm string) *Namespace {
 		children:        namedNamespaces{},
 		conditions:      conditions{},
 		originalObjects: objects{},
+		objectNames:     objectNames{},
 	}
 	f.namespaces[nm] = ns
 	return ns

--- a/incubator/hnc/internal/forest/namespace.go
+++ b/incubator/hnc/internal/forest/namespace.go
@@ -12,6 +12,7 @@ import (
 // with the API server. Since we need the V to work with the API server anyways anyways, we will choose to
 // use the GVK as the key in this map.
 type objects map[schema.GroupVersionKind]map[string]*unstructured.Unstructured
+type objectNames map[schema.GroupVersionKind]map[string]bool
 
 // conditions stores the conditions for a single namespace, in the form obj -> code -> msg. Note
 // that only one message can be stored per obj and code.
@@ -30,6 +31,10 @@ type Namespace struct {
 	// originalObjects store the objects created by users, identified by GVK and name.
 	// It serves as the source of truth for object controllers to propagate objects.
 	originalObjects objects
+
+	// objectNames store all the names of the original objects by GVK as long as
+	// there's an object reconciler for the GVK.
+	objectNames objectNames
 
 	// conditions store conditions so that object propagation can be disabled if there's a problem
 	// on this namespace.

--- a/incubator/hnc/internal/forest/namespaceobjects.go
+++ b/incubator/hnc/internal/forest/namespaceobjects.go
@@ -74,3 +74,35 @@ func (ns *Namespace) GetSource(gvk schema.GroupVersionKind, name string) *unstru
 	}
 	return nil
 }
+
+// AddObjectName adds object to the objectNames set.
+func (ns *Namespace) AddObjectName(gvk schema.GroupVersionKind, nm string) {
+	_, ok := ns.objectNames[gvk]
+	if !ok {
+		ns.objectNames[gvk] = make(map[string]bool)
+	}
+	ns.objectNames[gvk][nm] = true
+}
+
+// HasObjectName returns if the namespace has an object with that name.
+func (ns *Namespace) HasObjectName(gvk schema.GroupVersionKind, nm string) bool {
+	return ns.GetOriginalObject(gvk, nm) != nil
+}
+
+// RemoveObjectName removes the object from the objectNames set.
+func (ns *Namespace) RemoveObjectName(gvk schema.GroupVersionKind, nm string) {
+	delete(ns.objectNames[gvk], nm)
+	// Garbage collection
+	if len(ns.objectNames[gvk]) == 0 {
+		delete(ns.objectNames, gvk)
+	}
+}
+
+// GetObjectNames returns all the original object names by GVK.
+func (ns *Namespace) GetObjectNames(gvk schema.GroupVersionKind) []string {
+	o := []string{}
+	for nm, _ := range ns.objectNames[gvk] {
+		o = append(o, nm)
+	}
+	return o
+}

--- a/incubator/hnc/internal/validators/setup.go
+++ b/incubator/hnc/internal/validators/setup.go
@@ -65,7 +65,8 @@ func Create(mgr ctrl.Manager, f *forest.Forest) {
 
 	// Create webhook for the config
 	mgr.GetWebhookServer().Register(ConfigServingPath, &webhook.Admission{Handler: &HNCConfig{
-		Log: ctrl.Log.WithName("validators").WithName("HNCConfig"),
+		Log:    ctrl.Log.WithName("validators").WithName("HNCConfig"),
+		Forest: f,
 	}})
 
 	// Create webhook for the subnamespace anchors.


### PR DESCRIPTION
Add new field `objectNames` to `forest.Namespace` struct to store all
the names of user-created objects by GVK as long as there's an object
reconciler for that GVK.

Update object reonciler to add/remove reconciled source object for the
`objectNames` field in `syncSource()` and `syncMissingObject()` funcs.

Add new hncconfig webhook rules and new test cases. Check if changing
type mode(s) to `Propagate` would cause overwriting source by looking
up the `objectNames` data. Deny the request and output all the conflicts
if it would cause overwriting.

Tested by "make test" and manually on a GKE cluster with multiple
objects with the same name in the same tree or different trees.

The webhook message would look like this:
```
Cannot update configuration because setting types to 'Propagate' mode would overwrite user-created object(s):
 * Type: "/v1, Kind=Secret", Conflict(s):
   - "my-creds" in namespace "acme-org" would overwrite the one(s) in [team-a, team-b].
   - "my-creds" in namespace "bcme-org" would overwrite the one(s) in [team-c].
   - "my-creds2" in namespace "acme-org" would overwrite the one(s) in [team-b].
To fix this, please rename or remove the conflicting objects first.
```
Part of #1102, #1076 