### PR TITLE
Update hncconfig webhook to handle object overwriting and refactor forest `sourceObjects` field

### DIFF
--- a/incubator/hnc/internal/forest/forest.go
+++ b/incubator/hnc/internal/forest/forest.go
@@ -96,6 +96,19 @@ func (f *Forest) GetNamespaceNames() []string {
 	return names
 }
 
+// GetRoots returns all the root namespaces in the cluster. Any possible cycles
+// are omitted since we look for namespaces with no parent and cycles must
+// always be at roots.
+func (f *Forest) GetRoots() []*Namespace {
+	nses := []*Namespace{}
+	for _, ns := range f.namespaces {
+		if ns.parent == nil {
+			nses = append(nses, ns)
+		}
+	}
+	return nses
+}
+
 // AddTypeSyncer adds a reconciler to the types list.
 func (f *Forest) AddTypeSyncer(nss TypeSyncer) {
 	f.types = append(f.types, nss)

--- a/incubator/hnc/internal/forest/forest.go
+++ b/incubator/hnc/internal/forest/forest.go
@@ -77,11 +77,11 @@ func (f *Forest) Get(nm string) *Namespace {
 		return ns
 	}
 	ns = &Namespace{
-		forest:          f,
-		name:            nm,
-		children:        namedNamespaces{},
-		conditions:      conditions{},
-		originalObjects: objects{},
+		forest:        f,
+		name:          nm,
+		children:      namedNamespaces{},
+		conditions:    conditions{},
+		sourceObjects: objects{},
 	}
 	f.namespaces[nm] = ns
 	return ns

--- a/incubator/hnc/internal/forest/namespace.go
+++ b/incubator/hnc/internal/forest/namespace.go
@@ -27,9 +27,9 @@ type Namespace struct {
 	exists               bool
 	allowCascadingDelete bool
 
-	// originalObjects store the objects created by users, identified by GVK and name.
+	// sourceObjects store the objects created by users, identified by GVK and name.
 	// It serves as the source of truth for object controllers to propagate objects.
-	originalObjects objects
+	sourceObjects objects
 
 	// conditions store conditions so that object propagation can be disabled if there's a problem
 	// on this namespace.

--- a/incubator/hnc/internal/reconcilers/hnc_config.go
+++ b/incubator/hnc/internal/reconcilers/hnc_config.go
@@ -396,7 +396,7 @@ func (r *ConfigReconciler) setTypeStatuses(inst *api.HNCConfiguration) {
 			nms := r.Forest.GetNamespaceNames()
 			for _, nm := range nms {
 				ns := r.Forest.Get(nm)
-				numSrc += ns.GetNumOriginalObjects(gvk)
+				numSrc += ns.GetNumSourceObjects(gvk)
 			}
 			status.NumSourceObjects = &numSrc
 		}

--- a/incubator/hnc/internal/validators/hierarchy.go
+++ b/incubator/hnc/internal/validators/hierarchy.go
@@ -246,7 +246,10 @@ func (v *Hierarchy) getConflictingObjectsOfType(gvk schema.GroupVersionKind, new
 	// Get all the source objects in the new ancestors that would be propagated
 	// into the descendants.
 	newAnsSrcObjs := make(map[string]bool)
-	for _, o := range newParent.GetPropagatingObjects(gvk) {
+	// TODO additionally check if the ancestor source objects obey the
+	//  'shouldPropagateSource()' rules from the reconcilers/object.go. Only
+	//  propagatable ancestor source would cause overwriting conflict.
+	for _, o := range newParent.GetAncestorSourceObjects(gvk, "") {
 		newAnsSrcObjs[o.GetName()] = true
 	}
 
@@ -254,7 +257,7 @@ func (v *Hierarchy) getConflictingObjectsOfType(gvk schema.GroupVersionKind, new
 	cos := []string{}
 	dnses := append(ns.DescendantNames(), ns.Name())
 	for _, dns := range dnses {
-		for _, o := range v.Forest.Get(dns).GetOriginalObjects(gvk) {
+		for _, o := range v.Forest.Get(dns).GetSourceObjects(gvk) {
 			if newAnsSrcObjs[o.GetName()] {
 				co := fmt.Sprintf("Namespace %q: %s (%v)", dns, o.GetName(), gvk)
 				cos = append(cos, co)

--- a/incubator/hnc/internal/validators/hncconfig_test.go
+++ b/incubator/hnc/internal/validators/hncconfig_test.go
@@ -7,8 +7,11 @@ import (
 
 	. "github.com/onsi/gomega"
 	"k8s.io/api/admission/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/forest"
+	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/foresttest"
 
 	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
 )
@@ -48,7 +51,8 @@ func TestDeletingOtherObject(t *testing.T) {
 }
 
 func TestRBACTypes(t *testing.T) {
-	config := &HNCConfig{}
+	f := forest.NewForest()
+	config := &HNCConfig{Forest: f}
 
 	tests := []struct {
 		name    string
@@ -187,8 +191,51 @@ func TestNonRBACTypes(t *testing.T) {
 			g := NewGomegaWithT(t)
 			c := &api.HNCConfiguration{Spec: api.HNCConfigurationSpec{Types: tc.configs}}
 			c.Name = api.HNCConfigSingleton
-			config := &HNCConfig{validator: tc.validator}
+			config := &HNCConfig{validator: tc.validator, Forest: forest.NewForest()}
 
+			got := config.handle(context.Background(), c)
+
+			logResult(t, got.AdmissionResponse.Result)
+			g.Expect(got.AdmissionResponse.Allowed).Should(Equal(tc.allow))
+		})
+	}
+}
+
+func TestPropagateConflict(t *testing.T) {
+	tests := []struct {
+		name         string
+		inNamespaces string
+		allow        bool
+	}{{
+		name:         "Objects with the same name existing in namespaces that one is not an ancestor of the other would not cause overwriting conflict",
+		inNamespaces: "bc",
+		allow:        true,
+	}, {
+		name:         "Objects with the same name existing in namespaces that one is an ancestor of the other would have overwriting conflict",
+		inNamespaces: "ab",
+		allow:        false,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			configs := []api.TypeSynchronizationSpec{
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: "Propagate"},
+				{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: "Propagate"},
+				{APIVersion: "v1", Kind: "Secret", Mode: "Propagate"}}
+			c := &api.HNCConfiguration{Spec: api.HNCConfigurationSpec{Types: configs}}
+			c.Name = api.HNCConfigSingleton
+			// Create a forest with "a" as the parent and "b" and "c" as the children.
+			f := foresttest.Create("-aa")
+			config := &HNCConfig{validator: fakeGVKValidator{}, Forest: f}
+
+			// Add source objects to the forest.
+			inst := &unstructured.Unstructured{}
+			inst.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"})
+			inst.SetName("my-creds")
+			for _, c := range tc.inNamespaces {
+				f.Get(string(c)).SetSourceObject(inst)
+			}
 			got := config.handle(context.Background(), c)
 
 			logResult(t, got.AdmissionResponse.Result)

--- a/incubator/hnc/internal/validators/object.go
+++ b/incubator/hnc/internal/validators/object.go
@@ -173,7 +173,7 @@ func (o *Object) hasConflict(inst *unstructured.Unstructured) (bool, []string) {
 
 	// Get a list of conflicting descendants if there's any.
 	for _, desc := range descs {
-		if o.Forest.Get(desc).HasOriginalObject(gvk, nm) {
+		if o.Forest.Get(desc).HasSourceObject(gvk, nm) {
 			conflicts = append(conflicts, desc)
 		}
 	}

--- a/incubator/hnc/internal/validators/object_test.go
+++ b/incubator/hnc/internal/validators/object_test.go
@@ -398,5 +398,5 @@ func createSecret(nm, nsn string, f *forest.Forest) {
 	inst.SetName(nm)
 	inst.SetNamespace(nsn)
 	inst.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"})
-	f.Get(nsn).SetOriginalObject(inst)
+	f.Get(nsn).SetSourceObject(inst)
 }

--- a/incubator/hnc/internal/validators/setup.go
+++ b/incubator/hnc/internal/validators/setup.go
@@ -65,7 +65,8 @@ func Create(mgr ctrl.Manager, f *forest.Forest) {
 
 	// Create webhook for the config
 	mgr.GetWebhookServer().Register(ConfigServingPath, &webhook.Admission{Handler: &HNCConfig{
-		Log: ctrl.Log.WithName("validators").WithName("HNCConfig"),
+		Log:    ctrl.Log.WithName("validators").WithName("HNCConfig"),
+		Forest: f,
 	}})
 
 	// Create webhook for the subnamespace anchors.


### PR DESCRIPTION
Update forest field `sourceObjects` to store all the names of user-created
objects by GVK as long as there's an object reconciler for that GVK.

Change object reonciler behaviors dependent on the previous forest field
`originalObjects`, which only stores source objects for 'Propagate' types.
Add test cases for corner cases.

Add new hncconfig webhook rules and new test cases. Check if changing
type mode(s) to `Propagate` would cause overwriting source by looking
up the `objectNames` data. Deny the request and output all the conflicts
if it would cause overwriting.

Tested by "make test" and manually on a GKE cluster with multiple
objects with the same name in the same tree or different trees. Passed
all e2e tests too.

The webhook message would look like this:
```
Cannot update configuration because setting type "/v1, Kind=Secret" to 'Propagate' mode would overwrite user-created object(s):
  Object "my-creds2" in namespace "acme-org" would overwrite the one in "team-a"
  Object "my-creds2" in namespace "acme-org" would overwrite the one in "team-b"
  Object "my-creds" in namespace "bcme-org" would overwrite the one in "team-c"
  Object "my-creds2" in namespace "bcme-org" would overwrite the one in "team-c"
To fix this, please rename or remove the conflicting objects first.
```
Part of #1102, #1076 