### PR TITLE
Fix a nil pointer issue in HC webhook when setting as root

### DIFF
--- a/incubator/hnc/internal/validators/hierarchy.go
+++ b/incubator/hnc/internal/validators/hierarchy.go
@@ -225,6 +225,11 @@ func (v *Hierarchy) checkParent(ns, curParent, newParent *forest.Namespace) admi
 
 // getConflictingObjects returns a list of namespaced objects if there's any conflict.
 func (v *Hierarchy) getConflictingObjects(newParent, ns *forest.Namespace) []string {
+	// If the new parent is nil,  early exit since it's impossible to introduce
+	// new naming conflicts.
+	if newParent == nil {
+		return nil
+	}
 	// Traverse all the types with 'Propagate' mode to find any conflicts.
 	conflicts := []string{}
 	for _, t := range v.Forest.GetTypeSyncers() {

--- a/incubator/hnc/internal/validators/hierarchy_test.go
+++ b/incubator/hnc/internal/validators/hierarchy_test.go
@@ -128,6 +128,7 @@ func TestChangeParentWithConflict(t *testing.T) {
 		{name: "ok: no conflict in ancestors", nnm: "a", pnm: "c"},
 		{name: "conflict in subtree leaf and the new parent", nnm: "c", pnm: "a", fail: true},
 		{name: "conflict in subtree leaf and a new ancestor (not the parent)", nnm: "c", pnm: "b", fail: true},
+		{name: "ok: set a namespace as root", nnm: "d", pnm: ""},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
The bug was found when running e2e tests that the webhook got
INTERNAL_ERROR when setting a namespace as root. Fix it by checking if
the new parent is nil. If yes, early exit since it's impossible to
introduce new naming conflicts.

Add a new unit test case for it. The test failed before and passed after
the change.

Tested by make test and manually.