### PR TITLE
Fix certs in K8s 1.19

### DIFF
--- a/incubator/hnc/third_party/open-policy-agent/gatekeeper/pkg/webhook/certs.go
+++ b/incubator/hnc/third_party/open-policy-agent/gatekeeper/pkg/webhook/certs.go
@@ -283,6 +283,9 @@ func (cr *CertRotator) createCACert() (*KeyPairArtifacts, error) {
 			CommonName:   cr.CAName,
 			Organization: []string{cr.CaOrganization},
 		},
+		DNSNames: []string{
+			cr.CAName,
+		},
 		NotBefore:             begin,
 		NotAfter:              end,
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign,
@@ -319,6 +322,9 @@ func (cr *CertRotator) createCertPEM(ca *KeyPairArtifacts) ([]byte, []byte, erro
 		SerialNumber: big.NewInt(1),
 		Subject: pkix.Name{
 			CommonName: cr.DNSName,
+		},
+		DNSNames: []string{
+			cr.DNSName,
 		},
 		NotBefore:             begin,
 		NotAfter:              end,


### PR DESCRIPTION
This change incorporates
https://github.com/open-policy-agent/gatekeeper/pull/813 and
https://github.com/open-policy-agent/gatekeeper/pull/811 to allow HNC's
internal cert generator to work on K8s 1.19, which uses Go 1.15.

Tested: HNC cannot be installed on KIND 1.19 without this change, and
can successfully be installed and have all e2e test run with it.