### PR TITLE
Fix HNC startup issues

### DIFF
--- a/incubator/hnc/go.mod
+++ b/incubator/hnc/go.mod
@@ -27,3 +27,5 @@ require (
 	sigs.k8s.io/controller-runtime v0.6.3
 	sigs.k8s.io/controller-tools v0.2.8
 )
+
+replace sigs.k8s.io/controller-runtime => github.com/adrianludwin/controller-runtime v0.6.3-ts-fix

--- a/incubator/hnc/go.sum
+++ b/incubator/hnc/go.sum
@@ -41,6 +41,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/adrianludwin/controller-runtime v0.6.3-ts-fix h1:UiTkM6oeOHhiG2Bm87PPWCEU54FNVq/IffLnNcx5cRk=
+github.com/adrianludwin/controller-runtime v0.6.3-ts-fix/go.mod h1:WlZNXcM0++oyaQt4B7C2lEE5JYRs8vJUzRP4N4JpdAY=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=

--- a/incubator/hnc/vendor/modules.txt
+++ b/incubator/hnc/vendor/modules.txt
@@ -672,7 +672,7 @@ k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/pointer
 k8s.io/utils/trace
-# sigs.k8s.io/controller-runtime v0.6.3
+# sigs.k8s.io/controller-runtime v0.6.3 => github.com/adrianludwin/controller-runtime v0.6.3-ts-fix
 ## explicit
 sigs.k8s.io/controller-runtime
 sigs.k8s.io/controller-runtime/pkg/builder
@@ -758,3 +758,4 @@ sigs.k8s.io/kustomize/pkg/types
 sigs.k8s.io/structured-merge-diff/v3/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
+# sigs.k8s.io/controller-runtime => github.com/adrianludwin/controller-runtime v0.6.3-ts-fix

--- a/incubator/hnc/vendor/sigs.k8s.io/controller-runtime/pkg/envtest/webhook.go
+++ b/incubator/hnc/vendor/sigs.k8s.io/controller-runtime/pkg/envtest/webhook.go
@@ -64,6 +64,9 @@ type WebhookInstallOptions struct {
 	// it will be automatically populated by the local temp dir
 	LocalServingCertDir string
 
+	// CAData is the CA that can be used to trust the serving certificates in LocalServingCertDir.
+	LocalServingCAData []byte
+
 	// MaxTime is the max time to wait
 	MaxTime time.Duration
 
@@ -143,8 +146,12 @@ func (o *WebhookInstallOptions) generateHostPort() (string, error) {
 	return net.JoinHostPort(host, fmt.Sprintf("%d", port)), nil
 }
 
-// Install installs specified webhooks to the API server
-func (o *WebhookInstallOptions) Install(config *rest.Config) error {
+// PrepWithoutInstalling does the setup parts of Install (populating host-port,
+// setting up CAs, etc), without actually truing to do anything with webhook
+// definitions.  This is largely useful for internal testing of
+// controller-runtime, where we need a random host-port & caData for webhook
+// tests, but may be useful in similar scenarios.
+func (o *WebhookInstallOptions) PrepWithoutInstalling() error {
 	hookCA, err := o.setupCA()
 	if err != nil {
 		return err
@@ -155,6 +162,15 @@ func (o *WebhookInstallOptions) Install(config *rest.Config) error {
 
 	err = o.ModifyWebhookDefinitions(hookCA)
 	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Install installs specified webhooks to the API server
+func (o *WebhookInstallOptions) Install(config *rest.Config) error {
+	if err := o.PrepWithoutInstalling(); err != nil {
 		return err
 	}
 
@@ -273,6 +289,7 @@ func (o *WebhookInstallOptions) setupCA() ([]byte, error) {
 		return nil, fmt.Errorf("unable to write webhook serving key to disk: %v", err)
 	}
 
+	o.LocalServingCAData = certData
 	return certData, nil
 }
 

--- a/incubator/hnc/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/server.go
+++ b/incubator/hnc/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/server.go
@@ -76,6 +76,9 @@ type Server struct {
 
 	// defaultingOnce ensures that the default fields are only ever set once.
 	defaultingOnce sync.Once
+
+	// mu protects access to the webhook map & setFields for Start, Register, etc
+	mu sync.Mutex
 }
 
 // setDefaults does defaulting for the Server.
@@ -111,6 +114,9 @@ func (*Server) NeedLeaderElection() bool {
 // Register marks the given webhook as being served at the given path.
 // It panics if two hooks are registered on the same path.
 func (s *Server) Register(path string, hook http.Handler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.defaultingOnce.Do(s.setDefaults)
 	_, found := s.webhooks[path]
 	if found {
@@ -119,7 +125,28 @@ func (s *Server) Register(path string, hook http.Handler) {
 	// TODO(directxman12): call setfields if we've already started the server
 	s.webhooks[path] = hook
 	s.WebhookMux.Handle(path, instrumentedHook(path, hook))
-	log.Info("registering webhook", "path", path)
+
+	regLog := log.WithValues("path", path)
+	regLog.Info("registering webhook")
+
+	// we've already been "started", inject dependencies here.
+	// Otherwise, InjectFunc will do this for us later.
+	if s.setFields != nil {
+		if err := s.setFields(hook); err != nil {
+			// TODO(directxman12): swallowing this error isn't great, but we'd have to
+			// change the signature to fix that
+			regLog.Error(err, "unable to inject fields into webhook during registration")
+		}
+
+		baseHookLog := log.WithName("webhooks")
+
+		// NB(directxman12): we don't propagate this further by wrapping setFields because it's
+		// unclear if this is how we want to deal with log propagation.  In this specific instance,
+		// we want to be able to pass a logger to webhooks because they don't know their own path.
+		if _, err := inject.LoggerInto(baseHookLog.WithValues("webhook", path), hook); err != nil {
+			regLog.Error(err, "unable to logger into webhook during registration")
+		}
+	}
 }
 
 // instrumentedHook adds some instrumentation on top of the given webhook.
@@ -150,21 +177,6 @@ func (s *Server) Start(stop <-chan struct{}) error {
 
 	baseHookLog := log.WithName("webhooks")
 	baseHookLog.Info("starting webhook server")
-
-	// inject fields here as opposed to in Register so that we're certain to have our setFields
-	// function available.
-	for hookPath, webhook := range s.webhooks {
-		if err := s.setFields(webhook); err != nil {
-			return err
-		}
-
-		// NB(directxman12): we don't propagate this further by wrapping setFields because it's
-		// unclear if this is how we want to deal with log propagation.  In this specific instance,
-		// we want to be able to pass a logger to webhooks because they don't know their own path.
-		if _, err := inject.LoggerInto(baseHookLog.WithValues("webhook", hookPath), webhook); err != nil {
-			return err
-		}
-	}
 
 	certPath := filepath.Join(s.CertDir, s.CertName)
 	keyPath := filepath.Join(s.CertDir, s.KeyName)
@@ -238,5 +250,20 @@ func (s *Server) Start(stop <-chan struct{}) error {
 // InjectFunc injects the field setter into the server.
 func (s *Server) InjectFunc(f inject.Func) error {
 	s.setFields = f
+
+	// inject fields here that weren't injected in Register because we didn't have setFields yet.
+	baseHookLog := log.WithName("webhooks")
+	for hookPath, webhook := range s.webhooks {
+		if err := s.setFields(webhook); err != nil {
+			return err
+		}
+
+		// NB(directxman12): we don't propagate this further by wrapping setFields because it's
+		// unclear if this is how we want to deal with log propagation.  In this specific instance,
+		// we want to be able to pass a logger to webhooks because they don't know their own path.
+		if _, err := inject.LoggerInto(baseHookLog.WithValues("webhook", hookPath), webhook); err != nil {
+			return err
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
This essentially reverts #1087, which breaks HNC on new clusters that
haven't previously had HNC installed. It fixes the nondeterministic
crashing problem by patching in
https://github.com/kubernetes-sigs/controller-runtime/pull/1155, which
has been applied to controller-runtime 0.6.3 in @adrianludwin's repo.
This is a temporary hack and will be removed when controller-runtime
releases its own fix - likely 0.6.4.

Tested: with the reversion of #1087 (main.go), HNC can be installed on a
fresh cluster again but fails to start up ~50% of the time. With the fix
to controller-runtime, it passes on 20/20 startup attempts. Ran e2e
tests and got the same result as without this change (four failures).