### PR TITLE
Let subns with propagated objects be deleted

### DIFF
--- a/incubator/hnc/test/e2e/issues_test.go
+++ b/incubator/hnc/test/e2e/issues_test.go
@@ -31,6 +31,25 @@ var _ = Describe("Issues", func() {
 			nsSubSub2, nsSubChild, nsSubSubChild)
 	}) 
 
+	// Note that this was never actually a problem (only subnamespaces were affected) but it seems
+	// like a good thing to test anyway.
+	It("Should delete full namespaces with propagated objects - issue #1130", func() {
+		MustRun("kubectl create ns", nsParent)
+		MustRun("kubectl create ns", nsChild)
+		MustRun("kubectl hns set", nsChild, "--parent", nsParent)
+		MustRun("kubectl create rolebinding admin-rb -n", nsParent,
+			"--clusterrole=admin --serviceaccount="+nsParent+":default")
+		MustRun("kubectl delete ns", nsChild)
+	})
+
+	It("Should delete subnamespaces with propagated objects - issue #1130", func() {
+		MustRun("kubectl create ns", nsParent)
+		MustRun("kubectl hns create", nsChild, "-n", nsParent)
+		MustRun("kubectl create rolebinding admin-rb -n", nsParent,
+			"--clusterrole=admin --serviceaccount="+nsParent+":default")
+		MustRun("kubectl delete subns", nsChild, "-n", nsParent)
+	})
+
 	It("Should remove obsolete conditions CannotPropagateObject and CannotUpdateObject - issue #328", func() {
 		// Setting up hierarchy with rolebinding that HNC doesn't have permission to copy.
 		MustRun("kubectl create ns", nsParent)


### PR DESCRIPTION
See issue #1130. The HNC object validator was preventing the K8s
namespace controller from cleaning out a namespace to allow it to be
deleted. This change lets HNC understand that when a namespace is being
deleted, we should ignore the subnamespaceOf annotation. This allows the
HierarchyConfiguration object to be reset to its initial state (like a
full namespace would when it's being deleted), orphaning the namespace
and allowing all its propagated objects to be removed.

Tested: added new tests and ran them multiple times while watching the
logs. The subnamespace test failed without this change and passed every
time with it, with the logs showing the expected behaviour.

Fixes #1130