### PR TITLE
Regenerate CRD yamls with controller-tools v0.2.8

### DIFF
--- a/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hierarchyconfigurations.yaml
+++ b/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hierarchyconfigurations.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.2.8
   creationTimestamp: null
   name: hierarchyconfigurations.hnc.x-k8s.io
 spec:
@@ -20,14 +20,10 @@ spec:
       description: Hierarchy is the Schema for the hierarchies API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -35,8 +31,7 @@ spec:
           description: HierarchySpec defines the desired state of Hierarchy
           properties:
             allowCascadingDelete:
-              description: AllowCascadingDelete indicates if the subnamespaces of
-                this namespace are allowed to cascading delete.
+              description: AllowCascadingDelete indicates if the subnamespaces of this namespace are allowed to cascading delete.
               type: boolean
             parent:
               description: Parent indicates the parent of this namespace, if any.
@@ -46,20 +41,17 @@ spec:
           description: HierarchyStatus defines the observed state of Hierarchy
           properties:
             children:
-              description: Children indicates the direct children of this namespace,
-                if any.
+              description: Children indicates the direct children of this namespace, if any.
               items:
                 type: string
               type: array
             conditions:
-              description: Conditions describes the errors and the affected objects,
-                if any.
+              description: Conditions describes the errors and the affected objects, if any.
               items:
                 description: Condition specifies the condition and the affected objects.
                 properties:
                   affects:
-                    description: Affects is a list of group-version-kind-namespace-name
-                      that uniquely identifies the object(s) affected by the condition.
+                    description: Affects is a list of group-version-kind-namespace-name that uniquely identifies the object(s) affected by the condition.
                     items:
                       description: AffectedObject defines uniquely identifiable objects.
                       properties:
@@ -76,56 +68,10 @@ spec:
                       type: object
                     type: array
                   code:
-                    description: "Describes the condition in a machine-readable string
-                      value. The currently valid values are shown below, but new values
-                      may be added over time. This field is always present in a condition.
-                      \n All codes that begin with the prefix `Crit` indicate that
-                      all HNC activities (e.g. propagating objects, updating labels)
-                      have been paused in this namespaces. HNC will resume updating
-                      the namespace once the condition has been resolved. Non-critical
-                      conditions typically indicate some kind of error that HNC itself
-                      can ignore, but likely indicates that the hierarchical structure
-                      is out-of-sync with the users' expectations. \n If the validation
-                      webhooks are working properly, there should typically not be
-                      any conditions on any namespaces, although some may appear transiently
-                      when the HNC controller is restarted. These should quickly resolve
-                      themselves (<30s). However, validation webhooks are not perfect,
-                      especially if multiple users are modifying the same namespace
-                      trees quickly, so it's important to monitor for critical conditions
-                      and resolve them if they arise. See the user guide for more
-                      information. \n Currently, the supported values are: \n - \"CritParentMissing\":
-                      the specified parent is missing and the namespace is an orphan.
-                      \n - \"CritCycle\": the namespace is a member of a cycle. For
-                      example, if namespace B says that its parent is namespace A,
-                      but namespace A says that its parent is namespace B, then A
-                      and B are in a cycle with each other and both of them will have
-                      the CritCycle condition. \n - \"CritDeletingCRD\": The HierarchyConfiguration
-                      CRD is being deleted. No more objects will be propagated into
-                      or out of this namespace. It is expected that the HNC controller
-                      will be stopped soon after the CRDs are fully deleted. \n -
-                      \"CritAncestor\": a critical error exists in an ancestor namespace,
-                      so this namespace is no longer being updated either. \n - \"SubnamespaceAnchorMissing\":
-                      this namespace is a subnamespace, but the anchor referenced
-                      in its `subnamespaceOf` annotation does not exist in the parent.
-                      \n - \"CannotPropagateObject\": this namespace contains an object
-                      that couldn't be propagated *out* of this namespace, to one
-                      or more of this namespace's descendants. If the object couldn't
-                      be propagated to *any* descendants - for example, because it
-                      has a finalizer on it (HNC can't propagate objects with finalizers),
-                      the `Affects` field will point to the object in this namespace.
-                      Otherwise, if it couldn't be propagated to *some* descendants,
-                      `Affects` will contain a list of the objects in those descendants
-                      that couldn't be created or updated. \n - \"CannotUpdateObject\":
-                      this namespace has an object that couldn't be propagated *into*
-                      this namespace - that is, it couldn't be created in the first
-                      place, or it couldn't be updated. The `Affects` field will point
-                      to the source object, which will always be in a namespace that's
-                      an ancestor of this namespace."
+                    description: "Describes the condition in a machine-readable string value. The currently valid values are shown below, but new values may be added over time. This field is always present in a condition. \n All codes that begin with the prefix `Crit` indicate that all HNC activities (e.g. propagating objects, updating labels) have been paused in this namespaces. HNC will resume updating the namespace once the condition has been resolved. Non-critical conditions typically indicate some kind of error that HNC itself can ignore, but likely indicates that the hierarchical structure is out-of-sync with the users' expectations. \n If the validation webhooks are working properly, there should typically not be any conditions on any namespaces, although some may appear transiently when the HNC controller is restarted. These should quickly resolve themselves (<30s). However, validation webhooks are not perfect, especially if multiple users are modifying the same namespace trees quickly, so it's important to monitor for critical conditions and resolve them if they arise. See the user guide for more information. \n Currently, the supported values are: \n - \"CritParentMissing\": the specified parent is missing and the namespace is an orphan. \n - \"CritCycle\": the namespace is a member of a cycle. For example, if namespace B says that its parent is namespace A, but namespace A says that its parent is namespace B, then A and B are in a cycle with each other and both of them will have the CritCycle condition. \n - \"CritDeletingCRD\": The HierarchyConfiguration CRD is being deleted. No more objects will be propagated into or out of this namespace. It is expected that the HNC controller will be stopped soon after the CRDs are fully deleted. \n - \"CritAncestor\": a critical error exists in an ancestor namespace, so this namespace is no longer being updated either. \n - \"SubnamespaceAnchorMissing\": this namespace is a subnamespace, but the anchor referenced in its `subnamespaceOf` annotation does not exist in the parent. \n - \"CannotPropagateObject\": this namespace contains an object that couldn't be propagated *out* of this namespace, to one or more of this namespace's descendants. If the object couldn't be propagated to *any* descendants - for example, because it has a finalizer on it (HNC can't propagate objects with finalizers), the `Affects` field will point to the object in this namespace. Otherwise, if it couldn't be propagated to *some* descendants, `Affects` will contain a list of the objects in those descendants that couldn't be created or updated. \n - \"CannotUpdateObject\": this namespace has an object that couldn't be propagated *into* this namespace - that is, it couldn't be created in the first place, or it couldn't be updated. The `Affects` field will point to the source object, which will always be in a namespace that's an ancestor of this namespace."
                     type: string
                   msg:
-                    description: A human-readable description of the condition, if
-                      the `code` and `affects` fields are not sufficiently clear on
-                      their own.
+                    description: A human-readable description of the condition, if the `code` and `affects` fields are not sufficiently clear on their own.
                     type: string
                 required:
                 - code

--- a/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
+++ b/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.2.8
   creationTimestamp: null
   name: hncconfigurations.hnc.x-k8s.io
 spec:
@@ -17,18 +17,13 @@ spec:
   scope: Cluster
   validation:
     openAPIV3Schema:
-      description: HNCConfiguration is a cluster-wide configuration for HNC as a whole.
-        See details in http://bit.ly/hnc-type-configuration
+      description: HNCConfiguration is a cluster-wide configuration for HNC as a whole. See details in http://bit.ly/hnc-type-configuration
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -36,22 +31,18 @@ spec:
           description: HNCConfigurationSpec defines the desired state of HNC configuration.
           properties:
             types:
-              description: Types indicates the desired synchronization states of kinds,
-                if any.
+              description: Types indicates the desired synchronization states of kinds, if any.
               items:
-                description: TypeSynchronizationSpec defines the desired synchronization
-                  state of a specific kind.
+                description: TypeSynchronizationSpec defines the desired synchronization state of a specific kind.
                 properties:
                   apiVersion:
-                    description: API version of the kind defined below. This is used
-                      to unambiguously identifies the kind.
+                    description: API version of the kind defined below. This is used to unambiguously identifies the kind.
                     type: string
                   kind:
                     description: Kind to be configured.
                     type: string
                   mode:
-                    description: Synchronization mode of the kind. If the field is
-                      empty, it will be treated as "Propagate".
+                    description: Synchronization mode of the kind. If the field is empty, it will be treated as "Propagate".
                     enum:
                     - Propagate
                     - Ignore
@@ -69,48 +60,27 @@ spec:
             conditions:
               description: Conditions describes the errors, if any.
               items:
-                description: HNCConfigurationCondition specifies the code and the
-                  description of an error condition.
+                description: HNCConfigurationCondition specifies the code and the description of an error condition.
                 properties:
                   code:
-                    description: "Describes the condition in a machine-readable string
-                      value. The currently valid values are shown below, but new values
-                      may be added over time. This field is always present in a condition.
-                      \n Conditions typically indicate some kinds of error that HNC
-                      itself can ignore. However, the behaviors of some types might
-                      be out-of-sync with the users' expectations. \n Currently, the
-                      supported values are: \n - \"objectReconcilerCreationFailed\":
-                      an error exists when creating the object reconciler for the
-                      type specified in Msg. \n - \"multipleConfigurationsForOneType\":
-                      Multiple configurations exist for the type specified in the
-                      Msg. One type should only have one configuration."
+                    description: "Describes the condition in a machine-readable string value. The currently valid values are shown below, but new values may be added over time. This field is always present in a condition. \n Conditions typically indicate some kinds of error that HNC itself can ignore. However, the behaviors of some types might be out-of-sync with the users' expectations. \n Currently, the supported values are: \n - \"objectReconcilerCreationFailed\": an error exists when creating the object reconciler for the type specified in Msg. \n - \"multipleConfigurationsForOneType\": Multiple configurations exist for the type specified in the Msg. One type should only have one configuration."
                     type: string
                   msg:
-                    description: A human-readable description of the condition, if
-                      the `code` field is not sufficiently clear on their own. If
-                      the condition is only for specific types, Msg will include information
-                      about the types (e.g., GVK).
+                    description: A human-readable description of the condition, if the `code` field is not sufficiently clear on their own. If the condition is only for specific types, Msg will include information about the types (e.g., GVK).
                     type: string
                 required:
                 - code
                 type: object
               type: array
             namespaceConditions:
-              description: NamespaceConditions is a map of namespace condition codes
-                to the namespaces affected by those codes. If HNC is operating normally,
-                no conditions will be present; if there are any conditions beginning
-                with the "Crit" (critical) prefix, this means that HNC cannot function
-                in the affected namespaces. The HierarchyConfiguration object in each
-                of the affected namespaces will have more information. To learn more
-                about conditions, see https://github.com/kubernetes-sigs/multi-tenancy/blob/master/incubator/hnc/docs/user-guide/concepts.md#admin-conditions.
+              description: NamespaceConditions is a map of namespace condition codes to the namespaces affected by those codes. If HNC is operating normally, no conditions will be present; if there are any conditions beginning with the "Crit" (critical) prefix, this means that HNC cannot function in the affected namespaces. The HierarchyConfiguration object in each of the affected namespaces will have more information. To learn more about conditions, see https://github.com/kubernetes-sigs/multi-tenancy/blob/master/incubator/hnc/docs/user-guide/concepts.md#admin-conditions.
               items:
                 properties:
                   code:
                     description: Code is a namespace condition code
                     type: string
                   namespaces:
-                    description: Namespaces is the list of namespaces affected by
-                      this code
+                    description: Namespaces is the list of namespaces affected by this code
                     items:
                       type: string
                     type: array
@@ -120,34 +90,25 @@ spec:
                 type: object
               type: array
             types:
-              description: Types indicates the observed synchronization states of
-                kinds, if any.
+              description: Types indicates the observed synchronization states of kinds, if any.
               items:
-                description: TypeSynchronizationStatus defines the observed synchronization
-                  state of a specific kind.
+                description: TypeSynchronizationStatus defines the observed synchronization state of a specific kind.
                 properties:
                   apiVersion:
-                    description: API version of the kind defined below. This is used
-                      to unambiguously identifies the kind.
+                    description: API version of the kind defined below. This is used to unambiguously identifies the kind.
                     type: string
                   kind:
                     description: Kind to be configured.
                     type: string
                   mode:
-                    description: Mode describes the synchronization mode of the kind.
-                      Typically, it will be the same as the mode in the spec, except
-                      when the reconciler has fallen behind or when the mode is omitted
-                      from the spec and the default is chosen.
+                    description: Mode describes the synchronization mode of the kind. Typically, it will be the same as the mode in the spec, except when the reconciler has fallen behind or when the mode is omitted from the spec and the default is chosen.
                     type: string
                   numPropagatedObjects:
-                    description: Tracks the number of objects that are being propagated
-                      to descendant namespaces. The propagated objects are created
-                      by HNC.
+                    description: Tracks the number of objects that are being propagated to descendant namespaces. The propagated objects are created by HNC.
                     minimum: 0
                     type: integer
                   numSourceObjects:
-                    description: Tracks the number of objects that are created by
-                      users.
+                    description: Tracks the number of objects that are created by users.
                     minimum: 0
                     type: integer
                 required:

--- a/incubator/hnc/config/crd/bases/hnc.x-k8s.io_subnamespaceanchors.yaml
+++ b/incubator/hnc/config/crd/bases/hnc.x-k8s.io_subnamespaceanchors.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.2.8
   creationTimestamp: null
   name: subnamespaceanchors.hnc.x-k8s.io
 spec:
@@ -19,18 +19,13 @@ spec:
   scope: Namespaced
   validation:
     openAPIV3Schema:
-      description: SubnamespaceAnchor is the Schema for the subnamespace API. See
-        details at http://bit.ly/hnc-self-serve-ux.
+      description: SubnamespaceAnchor is the Schema for the subnamespace API. See details at http://bit.ly/hnc-self-serve-ux.
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -38,14 +33,7 @@ spec:
           description: SubnamespaceAnchorStatus defines the observed state of SubnamespaceAnchor.
           properties:
             status:
-              description: "Describes the state of the subnamespace anchor. \n Currently,
-                the supported values are: \n - \"Missing\": the subnamespace has not
-                been created yet. This should be the default state when the anchor
-                is just created. \n - \"Ok\": the subnamespace exists. \n - \"Conflict\":
-                a namespace of the same name already exists. The admission controller
-                will attempt to prevent this. \n - \"Forbidden\": the anchor was created
-                in a namespace that doesn't allow children, such as kube-system or
-                hnc-system. The admission controller will attempt to prevent this."
+              description: "Describes the state of the subnamespace anchor. \n Currently, the supported values are: \n - \"Missing\": the subnamespace has not been created yet. This should be the default state when the anchor is just created. \n - \"Ok\": the subnamespace exists. \n - \"Conflict\": a namespace of the same name already exists. The admission controller will attempt to prevent this. \n - \"Forbidden\": the anchor was created in a namespace that doesn't allow children, such as kube-system or hnc-system. The admission controller will attempt to prevent this."
               type: string
           type: object
       type: object


### PR DESCRIPTION
The diff is a reverse of #1124 plus the controller-gen version changed
from v0.2.5 to v0.2.8.

Update the CRD yamls with v0.2.8 controller-tools (controller-gen). This
should be the stable generated CRD yamls. If you get a different
version, you can delete your local 'bin/controller-gen' and rerun 'make
manifests'. It will install controller-gen v0.2.8 for you.

Tested by make test.

We got #1124 before probably because we have the go.mod updated in
#1093 but we didn't upgrade our local controller-gen.