### PR TITLE
Set crd:trivialVersions=false for easier API upgrade

### DIFF
--- a/incubator/hnc/Makefile
+++ b/incubator/hnc/Makefile
@@ -30,8 +30,11 @@ HNC_RELEASED_IMG ?= "gcr.io/k8s-staging-multitenancy/hnc/controller:${HNC_IMG_TA
 
 CONTROLLER_GEN ?= "./bin/controller-gen"
 
-# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true"
+# No version conversion yet, but have per-version schema ready for version
+# conversion in next release. Otherwise we cannot patch it with per-version
+# validation, and will get error:
+# "Forbidden: top-level and per-version schemas are mutually exclusive"
+CRD_OPTIONS ?= "crd:trivialVersions=false"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 GOBIN ?= $(shell go env GOPATH)/bin


### PR DESCRIPTION
We were going to set `crd:trivialVersions=false` for per-version
validation in 0.6. However, we cannot patch CRD if the one in v0.5 is
still using top-level schema. We would get "`Forbidden: top-level and`
`per-version schemas are mutually exclusive`" error when upgrading HNC,
specifically CRDs.

Tested by API upgrading from this to the v0.6 change in a GKE cluster.
It passed after this change and failed with the above error before. Also
tested by `make test` to ensure it doesn't break v0.5.