### PR TITLE
Don't delete subns if anchor has conflict

### DIFF
--- a/incubator/hnc/test/e2e/issues_test.go
+++ b/incubator/hnc/test/e2e/issues_test.go
@@ -31,6 +31,26 @@ var _ = Describe("Issues", func() {
 			nsSubSub2, nsSubChild, nsSubSubChild)
 	}) 
 
+	It("Should not delete full namespace when a faulty anchor is deleted - issue #1149", func() {
+		// Setup
+		MustRun("kubectl create ns", nsParent)
+		MustRun("kubectl hns create", nsChild, "-n", nsParent)
+
+		// Wait for subns
+		MustRun("kubectl describe ns", nsChild)
+
+		// Remove annotation
+		MustRun("kubectl annotate ns", nsChild, "hnc.x-k8s.io/subnamespaceOf-")
+		RunShouldNotContain("subnamespaceOf", 1, "kubectl get -oyaml ns", nsChild)
+
+		// Delete anchor
+		MustRun("kubectl delete subns", nsChild, "-n", nsParent)
+		MustNotRun("kubectl get subns", nsChild, "-n", nsParent)
+
+		// Verify that namespace still exists
+		MustRun("kubectl describe ns", nsChild)
+	})
+
 	// Note that this was never actually a problem (only subnamespaces were affected) but it seems
 	// like a good thing to test anyway.
 	It("Should delete full namespaces with propagated objects - issue #1130", func() {


### PR DESCRIPTION
See issue #1149. This affects the ability to turn a subnamespace into a
full namespace. If you remove the subnamespaceOf annotation, move the
namespace to a new parent, and *then* clean up the anchor, everything's
ok. But if you delete the anchor _before_ moving the namespace, the
namespace gets deleted, which is clearly wrong.

This change is the minimal safe change needed to fix this in v0.5. In
v0.6, we should restructure these functions to be more heavily based on
the explicit state of the anchor, not the implied state.

Tested: new e2e test fails (hangs, actually) without this change and
passes with it. All e2e tests pass on GKE 1.17.