### PR TITLE
Fix a very rare flaky test on Prow

### DIFF
--- a/incubator/hnc/internal/reconcilers/object_test.go
+++ b/incubator/hnc/internal/reconcilers/object_test.go
@@ -211,7 +211,7 @@ var _ = Describe("Secret", func() {
 		// 'bar' but not 'foo', since the one in 'foo' cannot propagate with
 		// finalizer. Add a 500-millisecond gap to allow overwriting the object.
 		time.Sleep(500 * time.Millisecond)
-		Expect(objectInheritedFrom(ctx, "Role", bazName, "baz-role")).Should(Equal(barName))
+		Eventually(objectInheritedFrom(ctx, "Role", bazName, "baz-role")).Should(Equal(barName))
 	})
 
 	It("should have deletions propagated after crit conditions are removed", func() {


### PR DESCRIPTION
This flaky test cannot be reproduced when `make test` for 10+ times.
Update the `Expect` to `Eventually` to make it less likely to fail.

Tested by 'make test'.

See failed Prow [log](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_multi-tenancy/1144/pull-hnc-test/1309517615571406848).