### PR TITLE
Update "subnamespace-of" sub-namespace annotation

### DIFF
--- a/incubator/hnc/api/v1alpha2/subnamespace_anchor.go
+++ b/incubator/hnc/api/v1alpha2/subnamespace_anchor.go
@@ -21,10 +21,11 @@ import (
 
 // Constants for the subnamespace anchor resource type and namespace annotation.
 const (
-	Anchors          = "subnamespaceanchors"
-	AnchorKind       = "SubnamespaceAnchor"
-	AnchorAPIVersion = MetaGroup + "/v1alpha2"
-	SubnamespaceOf   = MetaGroup + "/subnamespaceOf"
+	Anchors                  = "subnamespaceanchors"
+	AnchorKind               = "SubnamespaceAnchor"
+	AnchorAPIVersion         = MetaGroup + "/v1alpha2"
+	SubnamespaceOf           = MetaGroup + "/subnamespace-of"
+	DeprecatedSubnamespaceOf = MetaGroup + "/subnamespaceOf"
 )
 
 // SubnamespaceAnchorState describes the state of the subnamespace. The state could be
@@ -48,7 +49,7 @@ type SubnamespaceAnchorStatus struct {
 	// - "Missing": the subnamespace has not been created yet. This should be the default state when
 	// the anchor is just created.
 	//
-	// - "Ok": the subnamespace exists.
+	// - "Ok": the subnamespace exists. This is the only good state of the anchor.
 	//
 	// - "Conflict": a namespace of the same name already exists. The admission controller will
 	// attempt to prevent this.

--- a/incubator/hnc/config/crd/bases/hnc.x-k8s.io_subnamespaceanchors.yaml
+++ b/incubator/hnc/config/crd/bases/hnc.x-k8s.io_subnamespaceanchors.yaml
@@ -59,7 +59,7 @@ spec:
             description: SubnamespaceAnchorStatus defines the observed state of SubnamespaceAnchor.
             properties:
               status:
-                description: "Describes the state of the subnamespace anchor. \n Currently, the supported values are: \n - \"Missing\": the subnamespace has not been created yet. This should be the default state when the anchor is just created. \n - \"Ok\": the subnamespace exists. \n - \"Conflict\": a namespace of the same name already exists. The admission controller will attempt to prevent this. \n - \"Forbidden\": the anchor was created in a namespace that doesn't allow children, such as kube-system or hnc-system. The admission controller will attempt to prevent this."
+                description: "Describes the state of the subnamespace anchor. \n Currently, the supported values are: \n - \"Missing\": the subnamespace has not been created yet. This should be the default state when the anchor is just created. \n - \"Ok\": the subnamespace exists. This is the only good state of the anchor. \n - \"Conflict\": a namespace of the same name already exists. The admission controller will attempt to prevent this. \n - \"Forbidden\": the anchor was created in a namespace that doesn't allow children, such as kube-system or hnc-system. The admission controller will attempt to prevent this."
                 type: string
             type: object
         type: object

--- a/incubator/hnc/internal/reconcilers/hierarchy_config_test.go
+++ b/incubator/hnc/internal/reconcilers/hierarchy_config_test.go
@@ -358,7 +358,6 @@ var _ = Describe("Hierarchy", func() {
 		Eventually(getLabel(ctx, nms[5], nms[1]+api.LabelTreeDepthSuffix)).Should(Equal("2"))
 		Eventually(getLabel(ctx, nms[5], nms[0]+api.LabelTreeDepthSuffix)).Should(Equal("3"))
 	})
-
 })
 
 func hasCondition(ctx context.Context, nm string, code api.Code) func() bool {


### PR DESCRIPTION
Update the sub-namespace annotation into `subnamespace-of` from
`subnamespaceOf` in v1alpha2. Update the namespace annotation in the
hierarchyConfiguration reconciler.

Add documentation that `Ok` is the only good state of anchor.

Update conversion tests.

Update util funcs CleanupNamespace() and RecoverHNC() to report failure
in cleanup.

Tested by `make test-conversion`, `make test` and manually.

Part of #868 