### PR TITLE
Update docs for v0.5.3

### DIFF
--- a/incubator/hnc/README.md
+++ b/incubator/hnc/README.md
@@ -35,7 +35,7 @@ Lead developer: @adrianludwin (aludwin@google.com).
 ### Getting started and learning more
 
 The [latest version of HNC is
-v0.5.2](https://github.com/kubernetes-sigs/multi-tenancy/releases/tag/hnc-v0.5.2).
+v0.5.3](https://github.com/kubernetes-sigs/multi-tenancy/releases/tag/hnc-v0.5.3).
 To install HNC on your cluster, and the `kubectl-hns` plugin on your
 workstation, follow the instructions on that page.
 
@@ -60,8 +60,12 @@ milestones are defined:
   stabilize the API and add productionization features.
 * [v0.5 - COMPLETE JUL 2020](https://github.com/kubernetes-sigs/multi-tenancy/milestone/13):
   feature simplification and improved testing and stability.
-* [v0.6 - TARGET SEP 2020](https://github.com/kubernetes-sigs/multi-tenancy/milestone/14):
+* [v0.6 - TARGET OCT 2020](https://github.com/kubernetes-sigs/multi-tenancy/milestone/14):
   introduce the v1alpha2 API and fully automated end-to-end testing.
+  * NB: v0.6 has been delayed since v0.5 got significant usage and therefore
+    needed several updates on its branch, which distracted from v1alpha2
+    development. As of late Sep 2020, we believe the v0.5 branch is largely
+    finished and we'll be on track to release v0.6 in October.
 * [Backlog](https://github.com/kubernetes-sigs/multi-tenancy/milestone/9):
   all unscheduled work.
 


### PR DESCRIPTION
Update all references to v0.5.3 and document the user-facing changes.

Staged at:
* https://github.com/adrianludwin/multi-tenancy/blob/docs-053/incubator/hnc/README.md
* https://github.com/adrianludwin/multi-tenancy/blob/docs-053/incubator/hnc/docs/user-guide/how-to.md