### PR TITLE
Create minimial v1a2 to v1a1 converters

### DIFF
--- a/incubator/hnc/api/v1alpha1/hierarchy_types_conversion.go
+++ b/incubator/hnc/api/v1alpha1/hierarchy_types_conversion.go
@@ -38,14 +38,11 @@ func (src *HierarchyConfiguration) ConvertTo(dstRaw conversion.Hub) error {
 	return nil
 }
 
-// We don't need a conversion from v1alpha2 to v1alpha1. because we will never
-// serve both versions. We serve v1alpha1 in 0.5 and v1alpha2 in 0.6. Upgrading
-// from 0.5 to 0.6 only needs one-way conversion. Downgrading is not supported.
-// Thus we keep an empty ConvertFrom just to implement Convertible.
+// We don't need a conversion from v1alpha2 to v1alpha1. because we will never serve both versions.
+// However, the apiserver appears to ask for v1alpha1 even if there are no other clients and
+// complains if the metadata changes, so simply copy the metadata but nothing else.
 func (dst *HierarchyConfiguration) ConvertFrom(srcRaw conversion.Hub) error {
-	// We wanted to return errors.New("not supported") here considering this
-	// function should never be called, but in reality this error log is populated
-	// constantly even when all the HNC reconcilers and validators are disabled.
-	// To not pollute the logs, we decide to return nil here.
+	src := srcRaw.(*v1a2.HierarchyConfiguration)
+	dst.ObjectMeta = src.ObjectMeta
 	return nil
 }

--- a/incubator/hnc/api/v1alpha1/hnc_config_conversion.go
+++ b/incubator/hnc/api/v1alpha1/hnc_config_conversion.go
@@ -60,14 +60,11 @@ func (src *HNCConfiguration) ConvertTo(dstRaw conversion.Hub) error {
 	return nil
 }
 
-// We don't need a conversion from v1alpha2 to v1alpha1. because we will never
-// serve both versions. We serve v1alpha1 in 0.5 and v1alpha2 in 0.6. Upgrading
-// from 0.5 to 0.6 only needs one-way conversion. Downgrading is not supported.
-// Thus we keep an empty ConvertFrom just to implement Convertible.
+// We don't need a conversion from v1alpha2 to v1alpha1. because we will never serve both versions.
+// However, the apiserver appears to ask for v1alpha1 even if there are no other clients and
+// complains if the metadata changes, so simply copy the metadata but nothing else.
 func (dst *HNCConfiguration) ConvertFrom(srcRaw conversion.Hub) error {
-	// We wanted to return errors.New("not supported") here considering this
-	// function should never be called, but in reality this error log is populated
-	// constantly even when all the HNC reconcilers and validators are disabled.
-	// To not pollute the logs, we decide to return nil here.
+	src := srcRaw.(*v1a2.HNCConfiguration)
+	dst.ObjectMeta = src.ObjectMeta
 	return nil
 }

--- a/incubator/hnc/api/v1alpha1/subnamespace_anchor_conversion.go
+++ b/incubator/hnc/api/v1alpha1/subnamespace_anchor_conversion.go
@@ -34,14 +34,11 @@ func (src *SubnamespaceAnchor) ConvertTo(dstRaw conversion.Hub) error {
 	return nil
 }
 
-// We don't need a conversion from v1alpha2 to v1alpha1. because we will never
-// serve both versions. We serve v1alpha1 in 0.5 and v1alpha2 in 0.6. Upgrading
-// from 0.5 to 0.6 only needs one-way conversion. Downgrading is not supported.
-// Thus we keep an empty ConvertFrom just to implement Convertible.
+// We don't need a conversion from v1alpha2 to v1alpha1. because we will never serve both versions.
+// However, the apiserver appears to ask for v1alpha1 even if there are no other clients and
+// complains if the metadata changes, so simply copy the metadata but nothing else.
 func (dst *SubnamespaceAnchor) ConvertFrom(srcRaw conversion.Hub) error {
-	// We wanted to return errors.New("not supported") here considering this
-	// function should never be called, but in reality this error log is populated
-	// constantly even when all the HNC reconcilers and validators are disabled.
-	// To not pollute the logs, we decide to return nil here.
+	src := srcRaw.(*v1a2.SubnamespaceAnchor)
+	dst.ObjectMeta = src.ObjectMeta
 	return nil
 }


### PR DESCRIPTION
While investigating another issue, I looked at the logs from the K8s
apiserver and observed that we were seeing tons of errors as the
apiserver asked HNC to convert the v1a2 objects back to v1a1 -
specifically, that their names has changed. I have no idea why K8s is
asking for these objects to be backconverted, but after glancing at the
K8s source code, I guessed that copying the object metadata would work
to fix the issue, and it did.

Tested: observed no more logspam from the apiserver