### PR TITLE
Add '--force' flag when switching from 'Ignore' to 'Propagate' mode

### DIFF
--- a/incubator/hnc/test/e2e/kubectl_test.go
+++ b/incubator/hnc/test/e2e/kubectl_test.go
@@ -1,0 +1,16 @@
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "sigs.k8s.io/multi-tenancy/incubator/hnc/pkg/testutils"
+)
+
+var _ = Describe("HNS set-config", func() {
+	It("Should use '--force' flag to change from 'Ignore' to 'Propagate'", func() {
+		MustRun("kubectl hns config set-type --apiVersion v1 --kind Secret Ignore")
+		MustNotRun("kubectl hns config set-type --apiVersion v1 --kind Secret Propagate")
+		MustRun("kubectl hns config set-type --apiVersion v1 --kind Secret Propagate --force")
+		// check that we don't need '--force' flag when changing it back
+		MustRun("kubectl hns config set-type --apiVersion v1 --kind Secret Ignore")
+	})
+})


### PR DESCRIPTION
If the user switch the propagation mode directly from 'Ignore' to
'Propagate', it will fail with an error message telling the user that a
'--force' flag is needed. '-f' is also supported as a shorthand.

Tested: make test-e2e