### PR TITLE
Switch to managed-by annotation

### DIFF
--- a/incubator/hnc/api/v1alpha2/hierarchy_types.go
+++ b/incubator/hnc/api/v1alpha2/hierarchy_types.go
@@ -35,7 +35,8 @@ const (
 	LabelInheritedFrom        = MetaGroup + "/inheritedFrom"
 	FinalizerHasSubnamespace  = MetaGroup + "/hasSubnamespace"
 	LabelTreeDepthSuffix      = ".tree." + MetaGroup + "/depth"
-	AnnotationManagedBy       = MetaGroup + "/managedBy"
+	AnnotationManagedBy       = MetaGroup + "/managed-by"
+	AnnotationManagedByV1A1   = MetaGroup + "/managedBy" // TODO: remove after v0.6 branches (#1177)
 	AnnotationPropagatePrefix = "propagate." + MetaGroup
 
 	AnnotationSelector = AnnotationPropagatePrefix + "/select"

--- a/incubator/hnc/api/v1alpha2/subnamespace_anchor.go
+++ b/incubator/hnc/api/v1alpha2/subnamespace_anchor.go
@@ -21,11 +21,11 @@ import (
 
 // Constants for the subnamespace anchor resource type and namespace annotation.
 const (
-	Anchors                  = "subnamespaceanchors"
-	AnchorKind               = "SubnamespaceAnchor"
-	AnchorAPIVersion         = MetaGroup + "/v1alpha2"
-	SubnamespaceOf           = MetaGroup + "/subnamespace-of"
-	DeprecatedSubnamespaceOf = MetaGroup + "/subnamespaceOf"
+	Anchors            = "subnamespaceanchors"
+	AnchorKind         = "SubnamespaceAnchor"
+	AnchorAPIVersion   = MetaGroup + "/v1alpha2"
+	SubnamespaceOf     = MetaGroup + "/subnamespace-of"
+	SubnamespaceOfV1A1 = MetaGroup + "/subnamespaceOf" // TODO: remove after v0.6 branches (#1177)
 )
 
 // SubnamespaceAnchorState describes the state of the subnamespace. The state could be

--- a/incubator/hnc/test/conversion/conversion_test.go
+++ b/incubator/hnc/test/conversion/conversion_test.go
@@ -48,17 +48,67 @@ var _ = Describe("Conversion from v1alpha1 to v1alpha2", func() {
 	)
 
 	BeforeEach(func() {
+		// CleanupNamespaces uses v1alpha2 which only exists in HNC v0.6. We don't know for sure if v0.6
+		// is installed right now but our best bet to clean up namespaces safely is to hope that it is.
+		// TODO: make CleanupNamespaces work regardless of whether HNC is running or not (see that
+		// function for details).
 		CleanupNamespaces(nsA, nsB)
-		// Tear down HNC for both the specified version and at HEAD.
+
+		// Almost all tests start with HNC v0.5 so just start there.
 		TearDownHNC(hncFromVersion)
 		setupV1alpha1(hncFromVersion)
 	})
 
 	AfterEach(func() {
+		// Restore to the initial starting point. Clean up namespaces before tearing down HNC to remove
+		// finalizers.
 		CleanupNamespaces(nsA, nsB)
-		// Only tear down HNC at HEAD, since that's what we just deployed.
 		TearDownHNC("")
 	})
+
+	It("should convert managedBy annotation", func() {
+		// Create externally managed namespace
+		MustRun("kubectl create ns", nsA)
+		MustRun("kubectl annotate ns", nsA, "hnc.x-k8s.io/managedBy=foo")
+
+		// Convert
+		setupV1alpha2()
+
+		// Verify correct annotation
+		FieldShouldContain("ns", "", nsA, ".metadata.annotations", "hnc.x-k8s.io/managed-by:foo")
+	})
+
+	It("should always respect the new managed-by annotation even if both exists before conversion (very unlikely)", func() {
+		// Create externally managed namespace with conflicting values
+		MustRun("kubectl create ns", nsA)
+		MustRun("kubectl annotate ns", nsA, "hnc.x-k8s.io/managedBy=foo")
+		MustRun("kubectl annotate ns", nsA, "hnc.x-k8s.io/managed-by=bar") // unknown to v0.5
+		// Both should just sit there
+		FieldShouldContain("ns", "", nsA, ".metadata.annotations", "hnc.x-k8s.io/managedBy:foo")
+		FieldShouldContain("ns", "", nsA, ".metadata.annotations", "hnc.x-k8s.io/managed-by:bar")
+
+		// Convert
+		setupV1alpha2()
+
+		// Only the new value should be present
+		FieldShouldNotContain("ns", "", nsA, ".metadata.annotations", "hnc.x-k8s.io/managedBy:foo")
+		FieldShouldContain("ns", "", nsA, ".metadata.annotations", "hnc.x-k8s.io/managed-by:bar")
+	})
+
+	It("should respect the new 'managed-by' annotation AFTER conversion if both exists", func() {
+		// Start with v1a2 this time
+		setupV1alpha2()
+
+		// Create the namespace with both the correct and obsolete annotations
+		MustRun("kubectl create ns", nsA)
+		MustRun("kubectl annotate ns", nsA, "hnc.x-k8s.io/managed-by=bar")
+		MustRun("kubectl annotate ns", nsA, "hnc.x-k8s.io/managedBy=foo") // deprecated in v0.6
+
+		// Verify that the deprecated version is removed
+		FieldShouldNotContain("ns", "", nsA, ".metadata.annotations", "hnc.x-k8s.io/managedBy:foo")
+		FieldShouldContain("ns", "", nsA, ".metadata.annotations", "hnc.x-k8s.io/managed-by:bar")
+	})
+
 
 	It("should convert subnamespace anchors and subnamespace-of annotation", func() {
 		// Before conversion, create namespace A and a subnamespace B.
@@ -67,8 +117,6 @@ var _ = Describe("Conversion from v1alpha1 to v1alpha2", func() {
 		// Convert
 		setupV1alpha2()
 
-		// Verify CRD conversion.
-		verifyCRDConversion()
 		// Verify subnamespace anchor status in the new version.
 		FieldShouldContainWithTimeout(anchorCRD, nsA, nsB, ".apiVersion", "v1alpha2", crdConversionTime)
 		FieldShouldContain(anchorCRD, nsA, nsB, ".status.status", "Ok")
@@ -87,8 +135,6 @@ var _ = Describe("Conversion from v1alpha1 to v1alpha2", func() {
 		// Convert
 		setupV1alpha2()
 
-		// Verify CRD conversion.
-		verifyCRDConversion()
 		// It should respect the new 'subnamespace-of' annotation even if it's wrong.
 		// Verify subnamespace anchor status ('Conflict') in the new version and the
 		// subnamespace annotation value ('wrongvalue').
@@ -104,8 +150,6 @@ var _ = Describe("Conversion from v1alpha1 to v1alpha2", func() {
 		// Convert
 		setupV1alpha2()
 
-		// Verify CRD conversion.
-		verifyCRDConversion()
 		// Verify subnamespace anchor status (not 'Conflict') in the new version and
 		// the 'subnamespace-of' annotation.
 		FieldShouldContainWithTimeout(anchorCRD, nsA, nsB, ".apiVersion", "v1alpha2", crdConversionTime)
@@ -137,8 +181,6 @@ spec:
 		// Convert
 		setupV1alpha2()
 
-		// Verify CRD conversion.
-		verifyCRDConversion()
 		// Verify the parent spec and the children status in the new version.
 		FieldShouldContainWithTimeout(hierCRD, nsA, hierSingleton, ".apiVersion", "v1alpha2", crdConversionTime)
 		FieldShouldContain(hierCRD, nsA, hierSingleton, ".status.children", nsB)
@@ -163,8 +205,6 @@ spec:
 		// Convert
 		setupV1alpha2()
 
-		// Verify CRD conversion.
-		verifyCRDConversion()
 		// Verify allowCascadingDeletion in the new version.
 		FieldShouldContainWithTimeout(hierCRD, nsA, hierSingleton, ".apiVersion", "v1alpha2", crdConversionTime)
 		FieldShouldContain(hierCRD, nsA, hierSingleton, ".spec", "allowCascadingDeletion:true")
@@ -181,8 +221,6 @@ spec:
 		// Convert
 		setupV1alpha2()
 
-		// Verify CRD conversion.
-		verifyCRDConversion()
 		// Verify conditions in the new version.
 		FieldShouldContainWithTimeout(hierCRD, nsB, hierSingleton, ".apiVersion", "v1alpha2", crdConversionTime)
 		FieldShouldContain(hierCRD, nsB, hierSingleton, ".status.conditions", "CritParentMissing")
@@ -192,8 +230,6 @@ spec:
 		// Convert
 		setupV1alpha2()
 
-		// Verify CRD conversion.
-		verifyCRDConversion()
 		// Verify default types in the new version.
 		FieldShouldContainWithTimeout(configCRD, "", configSingleton, ".apiVersion", "v1alpha2", crdConversionTime)
 		FieldShouldContainMultiple(configCRD, "", configSingleton, ".spec.types", []string{"Role", "RoleBinding"})
@@ -235,8 +271,6 @@ spec:
 		// Convert
 		setupV1alpha2()
 
-		// Verify CRD conversion.
-		verifyCRDConversion()
 		// Verify sync mode conversion.
 		FieldShouldContain(configCRD, "", configSingleton, ".spec.types", "Propagate")
 		FieldShouldNotContain(configCRD, "", configSingleton, ".spec.types", "propagate")
@@ -272,10 +306,8 @@ func setupV1alpha2(){
 	MustRun("kubectl apply -f ../../manifests/hnc-manager.yaml")
 	// Wait for the cert rotator to write caBundles in CRD conversion webhooks.
 	ensureCRDConvWHReady()
-}
 
-// Verify CRDs still have 'v1alpha1' in spec.versions but not in status.storedVersions.
-func verifyCRDConversion(){
+	// Verify CRDs still have 'v1alpha1' in spec.versions but not in status.storedVersions.
 	checkCRDVersionInField("v1alpha1", ".spec.versions", true)
 	checkCRDVersionInField("v1alpha2", ".spec.versions", true)
 	checkCRDVersionInField("v1alpha1", ".status.storedVersions", false)
@@ -308,16 +340,17 @@ func ensureCRDConvWHReady(){
 
 // createSampleV1alpha1Tree creates a tree with 'a' as the root, 'b' as the child.
 func createSampleV1alpha1Tree(){
-	MustRun("kubectl create ns e2e-conversion-test-a")
-	MustRun("kubectl create ns e2e-conversion-test-b")
+	MustRun("kubectl create ns", nsA)
+	MustRun("kubectl create ns", nsB)
 	hierB := `# temp file created by conversion_test.go
 apiVersion: hnc.x-k8s.io/v1alpha1
 kind: HierarchyConfiguration
 metadata:
   name: hierarchy
-  namespace: e2e-conversion-test-b
+  namespace: `+nsB+`
 spec:
-  parent: e2e-conversion-test-a`
+  parent: `+nsA+`
+`
 	MustApplyYAML(hierB)
 }
 
@@ -328,8 +361,9 @@ func createSampleV1alpha1Subnamespace(){
 apiVersion: hnc.x-k8s.io/v1alpha1
 kind: SubnamespaceAnchor
 metadata:
-  name: e2e-conversion-test-b
-  namespace: e2e-conversion-test-a`
+  name: `+nsB+`
+  namespace: `+nsA+`
+`
 	MustApplyYAML(subnsB)
 	FieldShouldContain(anchorCRD, nsA, nsB, ".status.status", "ok")
 	FieldShouldContain("ns", "", nsB, ".metadata.annotations", "hnc.x-k8s.io/subnamespaceOf:"+nsA)


### PR DESCRIPTION
This change updates HNC to recognize the managed-by annotation, and
convert any existing managedBy annotation from v1alpha1 to the new name.
It also adds some minor cleanups to the conversion tests and makes the
CleanupNamespaces function a bit more robust to account for some errors
I saw before the new tests were working.

Tested: new conversion test; all existing conversion tests pass.