### PR TITLE
Improve test failure messages; fix some tests

### DIFF
--- a/incubator/hnc/test/e2e/issues_test.go
+++ b/incubator/hnc/test/e2e/issues_test.go
@@ -40,8 +40,8 @@ var _ = Describe("Issues", func() {
 		MustRun("kubectl describe ns", nsChild)
 
 		// Remove annotation
-		MustRun("kubectl annotate ns", nsChild, "hnc.x-k8s.io/subnamespaceOf-")
-		RunShouldNotContain("subnamespaceOf", 1, "kubectl get -oyaml ns", nsChild)
+		MustRun("kubectl annotate ns", nsChild, "hnc.x-k8s.io/subnamespace-of-")
+		RunShouldNotContain("subnamespace-of", 1, "kubectl get -oyaml ns", nsChild)
 
 		// Delete anchor
 		MustRun("kubectl delete subns", nsChild, "-n", nsParent)
@@ -106,7 +106,7 @@ var _ = Describe("Issues", func() {
 		// create a subnamespace without anchor by creating a full namespace with SubnamespaceOf annotation
 		MustRun("kubectl create ns", nsSub1)
 		MustRun("kubectl hns set", nsSub1, "--parent", nsParent)
-		MustRun("kubectl annotate ns", nsSub1, "hnc.x-k8s.io/subnamespaceOf="+nsParent)
+		MustRun("kubectl annotate ns", nsSub1, "hnc.x-k8s.io/subnamespace-of="+nsParent)
 		// If the subnamespace doesn't allow cascadingDeletion and the anchor is missing in the parent namespace, it should have 'SubnamespaceAnchorMissing' condition while its descendants shoudn't have any conditions."
 		// Expected: 'sub1' namespace is not deleted and should have 'SubnamespaceAnchorMissing' condition; no other conditions."
 		RunShouldContain("SubnamespaceAnchorMissing", defTimeout, "kubectl get hierarchyconfigurations.hnc.x-k8s.io -n", nsSub1, "-o yaml")
@@ -118,7 +118,7 @@ var _ = Describe("Issues", func() {
 		// create a subnamespace without anchor by creating a full namespace with SubnamespaceOf annotation
 		MustRun("kubectl create ns", nsSub1)
 		MustRun("kubectl hns set", nsSub1, "--parent", nsParent)
-		MustRun("kubectl annotate ns", nsSub1, "hnc.x-k8s.io/subnamespaceOf="+nsParent)
+		MustRun("kubectl annotate ns", nsSub1, "hnc.x-k8s.io/subnamespace-of="+nsParent)
 		RunShouldContain("SubnamespaceAnchorMissing", defTimeout, "kubectl get hierarchyconfigurations.hnc.x-k8s.io -n", nsSub1, "-o yaml")
 		// If the anchor is re-added, it should unset the 'SubnamespaceAnchorMissing' condition in the subnamespace.
 		// Operation: recreate the 'sub1' subns in 'parent' - kubectl hns create sub1 -n parent
@@ -343,8 +343,8 @@ var _ = Describe("Issues that require repairing HNC", func() {
 		// Creating subns (anchor) 'sub' in both parent and parent2
 		MustRun("kubectl hns create", nsChild, "-n", nsParent)
 		MustRun("kubectl hns create", nsChild, "-n", nsParent2)
-		// Subnamespace child should be created and have parent as the 'subnamespaceOf' annoation value:
-		RunShouldContain("subnamespaceOf: "+nsParent, defTimeout, "kubectl get ns", nsChild, "-o yaml")
+		// Subnamespace child should be created and have parent as the 'subnamespace-of' annoation value:
+		RunShouldContain("subnamespace-of: "+nsParent, defTimeout, "kubectl get ns", nsChild, "-o yaml")
 		// Creating a 'test-secret' in the subnamespace child
 		MustRun("kubectl create secret generic test-secret --from-literal=key=value -n", nsChild)
 		// subns (anchor) child in parent2 should have 'status: Conflict' because it's a bad anchor:

--- a/incubator/hnc/test/e2e/subnamespace_test.go
+++ b/incubator/hnc/test/e2e/subnamespace_test.go
@@ -1,10 +1,7 @@
 package e2e
 
 import (
-	"os/exec"
-
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	. "sigs.k8s.io/multi-tenancy/incubator/hnc/pkg/testutils"
 )
 
@@ -30,14 +27,10 @@ var _ = Describe("Subnamespaces", func() {
 		MustRun("kubectl hns create", nsB, "-n", nsA)
 
 		// verify
-		MustRun("kubectl get ns", nsB)
+		FieldShouldContain("ns", "", nsB, ".metadata.annotations", "subnamespace-of:"+nsA)
 
-		// The namespace "b" should have a "subnamespaceOf:a" annotation. The command to use:
-		// kubectl get ns b -o jsonpath='{.metadata.annotations.hnc\.x-k8s\.io/subnamespaceOf}'
-		out, err := exec.Command("kubectl", "get", "ns", nsB, "-o", "jsonpath='{.metadata.annotations.hnc\\.x-k8s\\.io/subnamespaceOf}'").Output()
-		// Convert []byte to string and remove the quotes to get the "subnamesapceOf" annotation value.
-		pnm := string(out)[1 : len(out)-1]
-		Expect(err).Should(BeNil())
-		Expect(pnm).Should(Equal(nsA))
+		// delete
+		MustRun("kubectl delete subns", nsB, "-n", nsA)
+		MustNotRun("kubectl get ns", nsB)
 	})
 })


### PR DESCRIPTION
Prior to this change, the failure messages from our current e2e and
conversion webhooks were very poor - they don't identify the line number
from the _test_ that causes a failure, since most of the failures are
hidden several levels deep in the testutils package. In addition, almost
no information is printed out about the command that caused the failure
\- you need to dig through the logs. Finally, many failures are printed
in unnecessarily verbose ways.

This change fixes all three problems, by using Gomega's WithOffset
functions to get the test line from the stack trace, using a custom
Gomega matcher to print out nicer information, and printint out the
failing command on failure. Take together, these three changes change
an error like this:

```
  Expected success, but got an error:
      <*errors.errorString | 0xc000067430>: {
          s: "Missing: Ok\n\nGot: Conflict",
      }
      Missing: Ok

      Got: Conflict

  <redacted>/multi-tenancy/incubator/hnc/pkg/testutils/testutils.go:110
```

to this:

```
  Command: [kubectl get subnamespaceanchors.hnc.x-k8s.io e2e-conversion-test-b -n e2e-conversion-test-a -o template --template={{.status.status}}]
  did not output the expected substring(s): Ok
  and instead output: Conflict

  <redacted>/multi-tenancy/incubator/hnc/test/conversion/conversion_test.go:112
```

This should make debugging far easier by identifying the exact command
and line number that caused the failure. Even for more sophisticated
functions like CleanupNamespaces where the line number might not be
useful, printing out the exact failing command should go a long way to
make these failures easier to diagnose.

Finally, while testing this change, I discovered that #1157 had broken
some e2e tests, so I fixed them.

Tested: all basic (see below) e2e and conversion tests pass. Manually
caused several failures like the one shown above and verified that the
error messages were better. I found that the e2e tests that require
HNC_REPAIR were failing but this was due to an unrelated error that's
already addressed by #1173.