### PR TITLE
Implement selector when using treeSelect annotation

### DIFF
--- a/incubator/hnc/api/v1alpha2/hierarchy_types.go
+++ b/incubator/hnc/api/v1alpha2/hierarchy_types.go
@@ -39,7 +39,8 @@ const (
 	AnnotationManagedByV1A1   = MetaGroup + "/managedBy" // TODO: remove after v0.6 branches (#1177)
 	AnnotationPropagatePrefix = "propagate." + MetaGroup
 
-	AnnotationSelector = AnnotationPropagatePrefix + "/select"
+	AnnotationSelector     = AnnotationPropagatePrefix + "/select"
+	AnnotationTreeSelector = AnnotationPropagatePrefix + "/treeSelect"
 )
 
 // Condition codes. *All* codes must also be documented in the comment to Condition.Code, be

--- a/incubator/hnc/internal/reconcilers/test_helpers_test.go
+++ b/incubator/hnc/internal/reconcilers/test_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -321,4 +322,13 @@ func objectInheritedFrom(ctx context.Context, kind string, nsName, name string) 
 	}
 	lif, _ := inst.GetLabels()["hnc.x-k8s.io/inheritedFrom"]
 	return lif
+}
+
+// replaceStrings returns a copy of str with all non-overlapping instances of the keys in table
+// replaced by values in table
+func replaceStrings(str string, table map[string]string) string {
+	for key, val := range table {
+		str = strings.ReplaceAll(str, key, val)
+	}
+	return str
 }


### PR DESCRIPTION
When user set `{"propagate.hnc.x-k8s.io/treeSelect": "!baz"}`, HNC
should not propagate this object to `baz` namespace. This annotation
also supports multiple namespace select, which means if user set `{"propagate.hnc.x-k8s.io/treeSelect": "!baz, !bar"}`, HNC should not propagate this object to neither `baz` nor `bar`. These two cases are included in `object_test.go`.

When both `treeSelect` and `select` present, HNC will only propagate to
the namespace that matches both of the two selectors.

Tested: make test
The test cases covers the following situations:
- select/treeSelect to one single namespace AND multiple namespaces
- when select AND treeSelect both exists
- when select/treeSelect is updated

I believe these cover all of the selector test cases