### PR TITLE
Improve HNC Config test diagnosis/stability

### DIFF
--- a/incubator/hnc/internal/reconcilers/object_test.go
+++ b/incubator/hnc/internal/reconcilers/object_test.go
@@ -39,10 +39,7 @@ var _ = Describe("Secret", func() {
 	})
 
 	AfterEach(func() {
-		// Change current config back to the default value.
-		Eventually(func() error {
-			return resetHNCConfigToDefault(ctx)
-		}).Should(Succeed())
+		resetHNCConfigToDefault(ctx)
 		cleanupObjects(ctx)
 	})
 

--- a/incubator/hnc/internal/reconcilers/suite_test.go
+++ b/incubator/hnc/internal/reconcilers/suite_test.go
@@ -53,7 +53,11 @@ var (
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	SetDefaultEventuallyTimeout(time.Second * 2)
+	// Prow machines appear to be very overloaded. While 2s seems to work just fine on a workstation
+	// (1s is usually not enough), we've seen some errors on Prow that can only really be attributed
+	// to needing more time. So let's set this to 4s for now.
+	// - aludwin, Oct 2020
+	SetDefaultEventuallyTimeout(time.Second * 4)
 	RunSpecsWithDefaultAndCustomReporters(t,
 		"Reconciler Suite",
 		[]Reporter{printer.NewlineReporter{}})


### PR DESCRIPTION
The HNC Config tests were flaky when run in a loaded environment, such
as on Prow, and produced hard-to-reproduce errors. I was able to
reproduce them about 20% of the time using the `stress` utility to load
up my workstation.

The concrete proble I found was that the tests were not always waiting
for changes to the HNC config to be picked up - see my comments in #1170
for details. I've addressed this by adding a setTypeConfig function that
always waits for config changes to appear in the status before the test
can proceed.

I also added or fixed ...WithOffset() Gomega assertions now that I
actually understand how they work, and focused on never having any
_nested_ assertions since they make it impossible to get the correct
originating line number. I also changed some functions' names to better
match the way they're used (e.g. don't use "has" in the name if it
doesn't return a bool).

Tested: on a loaded workstation, the HNC config tests now pass 10/10
times. While I was working on the tests and had a bunch of problems, all
the line numbers were correct and useful.

FTR, on my 12-core workstation, the command I used to load it up was
`stress -m 22 -i 24 -c 24`. Anything higher and the apiserver wouldn't
start; anything lower and it didn't seem to have enough effect. This was
enough to increase the runtime of the tests from ~30s to ~50s so it
seemed to be doing a reasonable job.

Fixes #1170 