### PR TITLE
add metric numbers of overwritten object

### DIFF
--- a/incubator/hnc/internal/reconcilers/object.go
+++ b/incubator/hnc/internal/reconcilers/object.go
@@ -377,7 +377,7 @@ func (r *ObjectReconciler) getTopSourceToPropagate(log logr.Logger, inst *unstru
 	for _, obj := range objs {
 		// If the source cannot propagate, ignore it.
 		// TODO: add a webhook rule to prevent e.g. removing a source finalizer that
-		//  would cause overwrting the source objects in the descendents.
+		//  would cause overwriting the source objects in the descendents.
 		//  See https://github.com/kubernetes-sigs/multi-tenancy/issues/1120
 		if !r.shouldPropagateSource(log, obj, inst.GetNamespace()) {
 			continue
@@ -394,6 +394,7 @@ func (r *ObjectReconciler) syncPropagated(log logr.Logger, inst, srcInst *unstru
 	// Delete this local source object from the forest if it exists. (This could
 	// only happen when we are trying to overwrite a conflicting source).
 	ns.DeleteSourceObject(r.GVK, inst.GetName())
+	stats.OverwriteObject(r.GVK)
 
 	// If no source object exists, delete this object. This can happen when the source was deleted by
 	// users or the admin decided this type should no longer be propagated.

--- a/incubator/hnc/internal/stats/metrics.go
+++ b/incubator/hnc/internal/stats/metrics.go
@@ -31,6 +31,7 @@ var (
 	objectReconcileConcurrent     = ocstats.Int64("object_reconcile_concurrent_peak", "The peak concurrent object reconciliations happened in the last reporting period", "reconciliations")
 	objectWritesTotal             = ocstats.Int64("object_writes_total", "The number of object writes happened during object reconciliations", "writes")
 	namespaceConditions           = ocstats.Int64("namespace_conditions", "The number of namespaces with conditions", "conditions")
+	objectOverwritesTotal         = ocstats.Int64("object_overwrites_total", "The number of overwritten objects", "overwrites")
 )
 
 // Create Tags. Tags are used to group and filter collected metrics later on.
@@ -93,7 +94,7 @@ var (
 	}
 
 	objectWritesView = &ocview.View{
-		Name:        "hnc/reconcilers/object/object_writes_total",
+		Name:        "hnc/reconcilers/object/writes_total",
 		Measure:     objectWritesTotal,
 		Description: "The number of object writes happened during object reconciliations",
 		Aggregation: ocview.LastValue(),
@@ -106,6 +107,14 @@ var (
 		Description: "The number of namespaces with conditions",
 		Aggregation: ocview.LastValue(),
 		TagKeys:     []tag.Key{KeyNamespaceConditionType, KeyNamespaceConditionReason},
+	}
+
+	objectOverwritesTotalView = &ocview.View{
+		Name:        "hnc/reconcilers/object/overwrites_total",
+		Measure:     objectOverwritesTotal,
+		Description: "The number of overwritten objects",
+		Aggregation: ocview.LastValue(),
+		TagKeys:     []tag.Key{KeyGroupKind},
 	}
 )
 
@@ -133,6 +142,7 @@ func startRecordingMetrics() {
 		objectReconcileConcurrentView,
 		objectWritesView,
 		namespaceConditionsView,
+		objectOverwritesTotalView,
 	); err != nil {
 		log.Error(err, "Failed to register the views")
 	}


### PR DESCRIPTION
Signed-off-by: frbimo <fr.bimo@gmail.com>

fixes: #1158

This change adds an `overwritten_object` metric. 
Metrics will shows the total number of overwritten object on Propagate mode. 

Tested: 

directly inspected the /metrics endpoint on the HNC pod via curl. Double checked the metrics on prometheus stack using `serviceMonitor` by accessing prometheus UI. 

NB: scraping through prometheus with `annotation` was not working at the time author testing. prometheus `serviceMonitor` works fine. 