### PR TITLE
VC:  kubectl vc exec: switch workspace among virtualclusters

### DIFF
--- a/incubator/virtualcluster/cmd/kubectl-vc/exec.go
+++ b/incubator/virtualcluster/cmd/kubectl-vc/exec.go
@@ -42,7 +42,7 @@ const (
 	kubectl vc exec foo/bar
 
 	# Customize kubeconfig file path
-	kubectl vc exec --kube-file-dir /path/to/file foo/bar`
+	kubectl vc exec --kubeconfig-file-dir /path/to/file foo/bar`
 )
 
 type ExecOption struct {
@@ -67,7 +67,7 @@ func NewCmdExec(f Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&o.namespace, "namespace", "n", metav1.NamespaceDefault, "If present, the namespace scope for this CLI request")
-	cmd.Flags().StringVar(&o.kubeFileDir, "kube-file-dir", filepath.Join(os.Getenv("HOME"), ".kube/vc/"), "The directory to place the kubeconfig of specific vc")
+	cmd.Flags().StringVar(&o.kubeFileDir, "kubeconfig-file-dir", filepath.Join(os.Getenv("HOME"), ".kube/vc/"), "The directory to place the kubeconfig of specific vc")
 
 	return cmd
 }

--- a/incubator/virtualcluster/cmd/kubectl-vc/exec.go
+++ b/incubator/virtualcluster/cmd/kubectl-vc/exec.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	vcclient "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/client/clientset/versioned"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+)
+
+const (
+	execExample = `
+	# Switch to a virtualcluster
+	kubectl vc exec -n foo bar
+
+	# Specific vc by namespaced name
+	kubectl vc exec foo/bar
+
+	# Customize kubeconfig file path
+	kubectl vc exec --kube-file-dir /path/to/file foo/bar`
+)
+
+type ExecOption struct {
+	client      client.Client
+	vcclient    vcclient.Interface
+	namespace   string
+	name        string
+	kubeFileDir string
+}
+
+func NewCmdExec(f Factory) *cobra.Command {
+	o := &ExecOption{}
+
+	cmd := &cobra.Command{
+		Use:     "exec VC_NAME",
+		Short:   "Switch to virtualcluster workspace",
+		Example: execExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			CheckErr(o.Complete(f, cmd, args))
+			CheckErr(o.Run())
+		},
+	}
+
+	cmd.Flags().StringVarP(&o.namespace, "namespace", "n", metav1.NamespaceDefault, "If present, the namespace scope for this CLI request")
+	cmd.Flags().StringVar(&o.kubeFileDir, "kube-file-dir", filepath.Join(os.Getenv("HOME"), ".kube/vc/"), "The directory to place the kubeconfig of specific vc")
+
+	return cmd
+}
+
+func (o *ExecOption) Complete(f Factory, cmd *cobra.Command, args []string) error {
+	var err error
+	o.vcclient, err = f.VirtualClusterClientSet()
+	if err != nil {
+		return err
+	}
+
+	o.client, err = f.GenericClient()
+	if err != nil {
+		return err
+	}
+
+	if len(args) == 0 {
+		return UsageErrorf(cmd, "VC_NAME should not be empty")
+	}
+
+	o.name = args[0]
+	if strings.Contains(o.name, "/") {
+		namespacedName := strings.SplitN(o.name, "/", 2)
+		o.namespace = namespacedName[0]
+		o.name = namespacedName[1]
+	}
+
+	return nil
+}
+
+func (o *ExecOption) Run() error {
+	kbFilePath, err := o.placeVCKubeconfig(o.namespace, o.name)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("kubeconfig for virtualcluster %s/%s is placed at:\n\n\t%s\n\n", o.namespace, o.name, kbFilePath)
+
+	return enterVCShell(kbFilePath, o.namespace, o.name)
+}
+
+func (o *ExecOption) placeVCKubeconfig(ns, name string) (string, error) {
+	vc, err := o.vcclient.TenancyV1alpha1().VirtualClusters(ns).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	cv, err := o.vcclient.TenancyV1alpha1().ClusterVersions().Get(vc.Spec.ClusterVersionName, metav1.GetOptions{})
+	if err != nil {
+		return "", errors.Wrapf(err, "cluster version not found")
+	}
+
+	kbBytes, err := genKubeConfig(o.client, vc, cv)
+	if err != nil {
+		return "", err
+	}
+
+	if err = os.MkdirAll(o.kubeFileDir, 0755); err != nil {
+		return "", err
+	}
+
+	kbFilePath := filepath.Join(o.kubeFileDir, conversion.ToClusterKey(vc)+".kubeconfig")
+	err = ioutil.WriteFile(kbFilePath, kbBytes, 0644)
+
+	return kbFilePath, err
+}
+
+func enterVCShell(kbFilePath, ns, name string) error {
+	fmt.Printf("❗ You are now at VirtualCluster %s/%s\n", ns, name)
+	fmt.Println("❗ use regular kubectl commands to operate vc in this temporary workspace")
+	fmt.Println("❗ type 'exit' to exit")
+
+	c := exec.Command(os.Getenv("SHELL"))
+	c.Env = append(os.Environ(),
+		fmt.Sprintf("KUBECONFIG=%v", kbFilePath),
+		fmt.Sprintf("PS1=[\\u@vc:\033[01;32m%s/%s\033[00m \\W]\\$ ", ns, name),
+	)
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+
+	defer func() {
+		fmt.Printf("❗ exit VirtualCluster %s/%s\n", ns, name)
+	}()
+	return c.Run()
+}

--- a/incubator/virtualcluster/cmd/kubectl-vc/root.go
+++ b/incubator/virtualcluster/cmd/kubectl-vc/root.go
@@ -40,6 +40,7 @@ func main() {
 	}
 
 	rootCmd.AddCommand(NewCmdCreate(f))
+	rootCmd.AddCommand(NewCmdExec(f))
 
 	CheckErr(rootCmd.Execute())
 }

--- a/incubator/virtualcluster/cmd/kubectl-vc/util.go
+++ b/incubator/virtualcluster/cmd/kubectl-vc/util.go
@@ -83,11 +83,11 @@ func CheckErr(err error) {
 	}
 }
 
-// getYamlContent reads the yaml content from the `yamlPath`
-func getYamlContent(yamlPath string) ([]byte, error) {
-	if isURL(yamlPath) {
+// readFromFileOrURL reads the content from the file path or url.
+func readFromFileOrURL(path string) ([]byte, error) {
+	if isURL(path) {
 		// read from an URL
-		resp, err := http.Get(yamlPath)
+		resp, err := http.Get(path)
 		if err != nil {
 			return nil, err
 		}
@@ -97,8 +97,8 @@ func getYamlContent(yamlPath string) ([]byte, error) {
 		return yamlContent, nil
 	}
 	// read from a file
-	yamlContent, err := ioutil.ReadFile(yamlPath)
-	return yamlContent, err
+	content, err := ioutil.ReadFile(path)
+	return content, err
 }
 
 // isURL checks if `path` is an URL

--- a/incubator/virtualcluster/go.mod
+++ b/incubator/virtualcluster/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
-	github.com/urfave/cli v1.20.0
 	go.uber.org/zap v1.10.0
 	golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7
 	k8s.io/api v0.18.6

--- a/incubator/virtualcluster/go.sum
+++ b/incubator/virtualcluster/go.sum
@@ -630,7 +630,6 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ultraware/funlen v0.0.1/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lPbfaF6xhA=
 github.com/ultraware/funlen v0.0.2/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lPbfaF6xhA=
-github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=


### PR DESCRIPTION
```bash
[root@vm virtualcluster]# kubectl vc
VirtualCluster Command tool

Usage:
  kubectl-vc [flags]
  kubectl-vc [command]

Available Commands:
  create      Create a new VirtualCluster
  exec        Switch to virtualcluster workspace
  help        Help about any command

Flags:
  -h, --help      help for kubectl-vc
      --version   version for kubectl-vc

Use "kubectl-vc [command] --help" for more information about a command.
[root@vm virtualcluster]# kubectl vc exec -h
Switch to virtualcluster workspace

Usage:
  kubectl-vc exec VC_NAME [flags]

Examples:

	# Switch to a virtualcluster
	kubectl vc exec -n foo bar

	# Specific vc by namespaced name
	kubectl vc exec foo/bar

	# Customize kubeconfig file path
	kubectl vc exec --kube-file-dir /path/to/file foo/bar

Flags:
  -h, --help                   help for exec
      --kube-file-dir string   The directory to place the kubeconfig of specific vc (default "/root/.kube/vc")
  -n, --namespace string       If present, the namespace scope for this CLI request (default "default")
[root@vm virtualcluster]# kubectl vc exec default/vc-sample-1
kubeconfig for virtualcluster default/vc-sample-1 is placed at:

	/root/.kube/vc/default-8c6873-vc-sample-1.kubeconfig

❗ You are now at VirtualCluster default/vc-sample-1
❗ use regular kubectl commands to operate vc in this temporary workspace
❗ type 'exit' to exit
[root@vc:default/vc-sample-1 virtualcluster]# k cluster-info
Kubernetes master is running at https://10.0.2.15:31510

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
[root@vc:default/vc-sample-1 virtualcluster]# exit
exit
❗ exit VirtualCluster default/vc-sample-1
[root@vm virtualcluster]#
```

In legacy terminal
```bash
[root@vm virtualcluster]# TERM=dumb kubectl vc exec vc-sample-1
kubeconfig for virtualcluster default/vc-sample-1 is placed at:

	/root/.kube/vc/default-b59386-vc-sample-1.kubeconfig

!! You are now at VirtualCluster default/vc-sample-1
!! use regular kubectl commands to operate vc in this temporary workspace
!! type 'exit' to exit
[root@vc:default/vc-sample-1 virtualcluster]# exit
exit
!! exit VirtualCluster default/vc-sample-1
```

-  refactor to cobra
-  kubectl vc exec: switch workspace among virtualclusters

Signed-off-by: zhuangqh <zhuangqhc@gmail.com>

@salaxander @charleszheng44 