### PR TITLE
Implement noneSelector and add test cases

### DIFF
--- a/incubator/hnc/api/v1alpha2/hierarchy_types.go
+++ b/incubator/hnc/api/v1alpha2/hierarchy_types.go
@@ -41,6 +41,7 @@ const (
 
 	AnnotationSelector     = AnnotationPropagatePrefix + "/select"
 	AnnotationTreeSelector = AnnotationPropagatePrefix + "/treeSelect"
+	AnnotationNoneSelector = AnnotationPropagatePrefix + "/none"
 )
 
 // Condition codes. *All* codes must also be documented in the comment to Condition.Code, be


### PR DESCRIPTION
If the noneSelector is set to true, the object should not br propagated
to any child namspaces regardless of other selectors

Tested: make test
The test cases test the noneSelector by itself, noneSelector combined
with other selectors, and setting then resetting the noneSelector