### PR TITLE
Delete bad anchors and fix e2e tests

### DIFF
--- a/incubator/hnc/internal/validators/anchor.go
+++ b/incubator/hnc/internal/validators/anchor.go
@@ -72,32 +72,34 @@ func (v *Anchor) handle(req *anchorRequest) admission.Response {
 	cnm := req.anchor.Name
 	cns := v.Forest.Get(cnm)
 
-	if req.op == v1beta1.Create {
+	switch req.op {
+	case v1beta1.Create:
+		// Can't create subnamespaces in excluded namespaces
 		if config.EX[pnm] {
 			msg := fmt.Sprintf("The namespace %s is not allowed to create subnamespaces. Please create subnamespaces in a different namespace.", pnm)
 			return deny(metav1.StatusReasonForbidden, msg)
 		}
 
+		// Can't create anchors for existing namespaces, _unless_ it's for a subns with a missing
+		// anchor.
 		if cns.Exists() {
-			// Forbid this, unless it's to allow an anchor to be created for an existing subnamespace
-			// that's just missing its anchor.
-			if cns.Parent().Name() == pnm && cns.IsSub {
-				return allow("")
+			childIsMissingAnchor := (cns.Parent().Name() == pnm && cns.IsSub)
+			if !childIsMissingAnchor {
+				msg := fmt.Sprintf("The requested namespace %s already exists. Please use a different name.", cnm)
+				return deny(metav1.StatusReasonConflict, msg)
 			}
-			msg := fmt.Sprintf("The requested namespace %s already exists. Please use a different name.", cnm)
-			return deny(metav1.StatusReasonConflict, msg)
 		}
-	}
 
-	if req.op == v1beta1.Delete {
-		// Allow deleting a bad anchor.
-		if cns.Parent().Name() != pnm {
-			return allow("")
-		}
-		if cns.Exists() && cns.ChildNames() != nil && !cns.AllowsCascadingDeletion() {
+	case v1beta1.Delete:
+		// Don't allow the anchor to be deleted if it's in a good state and has descendants of its own,
+		// unless allowCascadingDeletion is set.
+		if req.anchor.Status.State == api.Ok && cns.ChildNames() != nil && !cns.AllowsCascadingDeletion() {
 			msg := fmt.Sprintf("The subnamespace %s is not a leaf and doesn't allow cascading deletion. Please set allowCascadingDeletion flag or make it a leaf first.", cnm)
 			return deny(metav1.StatusReasonForbidden, msg)
 		}
+
+	default:
+		// nop for updates etc
 	}
 
 	return allow("")

--- a/incubator/hnc/test/e2e/delete_crd_test.go
+++ b/incubator/hnc/test/e2e/delete_crd_test.go
@@ -20,6 +20,11 @@ var _ = Describe("When deleting CRDs", func() {
 	})
 
 	AfterEach(func() {
+		// HNC might be in an arbitrarily bad state - e.g. the CRDs are gone so the reconcilers aren't
+		// running anymore, and the admission webhooks are operating off of bad information (e.g. that a
+		// subnamespace's annotation has been removed). So delete the VWC so we can clean up
+		// effectively; it'll be restored by RecoverHNC anyway.
+		MustRun("kubectl delete validatingwebhookconfigurations hnc-validating-webhook-configuration")
 		CleanupNamespaces(nsParent, nsChild)
 		RecoverHNC()
 	})


### PR DESCRIPTION
While running the e2e tests, the CleanupNamespace command was hanging
because we weren't allowing deletion of anchors in the Conflict state;
we were just checking whether the would-be subnamespace had the correct
parent, but not whether the subnamespace anchor was actually in the 'ok'
state. This was resulting in HNC blocking the deletion of a bad anchor,
which we should always allow (this should have been done as a part of
PR #1151).

I also made three minor fixes to the e2e tests themselves:
1. Turn propagation on for new types with the --force option
2. Skip the network policy demo if we detect that network policies
   aren't enabled on the cluster.
3. Delete the webhook configs when HNC might be in a bad state so that
   they don't try to block cleanup of namespaces.

Tested: the e2e tests hang repeatedly and all the demo tests fail
without this fix; with this fix, they pass.