### PR TITLE
Update HNCConfig API with GR for restmapper lookup

### DIFF
--- a/incubator/hnc/api/v1alpha2/hnc_config.go
+++ b/incubator/hnc/api/v1alpha2/hnc_config.go
@@ -23,6 +23,11 @@ import (
 const (
 	HNCConfigSingleton  = "config"
 	HNCConfigSingletons = "hncconfigurations"
+	RBACGroup           = "rbac.authorization.k8s.io"
+	RoleResource        = "roles"
+	RoleKind            = "Role"
+	RoleBindingResource = "rolebindings"
+	RoleBindingKind     = "RoleBinding"
 )
 
 // SynchronizationMode describes propagation mode of objects of the same kind.
@@ -46,16 +51,19 @@ const (
 // HNCConfigurationCondition codes. *All* codes must also be documented in the
 // comment to HNCConfigurationCondition.Code.
 const (
+	TypeNotFound                     HNCConfigurationCode = "TypeNotFound"
 	ObjectReconcilerCreationFailed   HNCConfigurationCode = "ObjectReconcilerCreationFailed"
 	MultipleConfigurationsForOneType HNCConfigurationCode = "MultipleConfigurationsForOneType"
 )
 
-// TypeSynchronizationSpec defines the desired synchronization state of a specific kind.
+// TypeSynchronizationSpec defines the desired synchronization state of a
+// specific resource.
 type TypeSynchronizationSpec struct {
-	// API version of the kind defined below. This is used to unambiguously identifies the kind.
-	APIVersion string `json:"apiVersion"`
-	// Kind to be configured.
-	Kind string `json:"kind"`
+	// Group of the resource defined below. This is used to unambiguously identify
+	// the resource.
+	Group string `json:"group"`
+	// Resource to be configured.
+	Resource string `json:"resource"`
 	// Synchronization mode of the kind. If the field is empty, it will be treated
 	// as "Propagate".
 	// +optional
@@ -65,10 +73,12 @@ type TypeSynchronizationSpec struct {
 
 // TypeSynchronizationStatus defines the observed synchronization state of a specific kind.
 type TypeSynchronizationStatus struct {
-	// API version of the kind defined below. This is used to unambiguously identifies the kind.
-	APIVersion string `json:"apiVersion"`
-	// Kind to be configured.
-	Kind string `json:"kind"`
+	// Group of the resource defined below.
+	Group string `json:"group"`
+	// Version of the resource defined below.
+	Version string `json:"version"`
+	// Resource to be configured.
+	Resource string `json:"resource"`
 	// Mode describes the synchronization mode of the kind. Typically, it will be the same as the mode
 	// in the spec, except when the reconciler has fallen behind or when the mode is omitted from the
 	// spec and the default is chosen.
@@ -154,10 +164,12 @@ type HNCConfigurationCondition struct {
 	//
 	// Currently, the supported values are:
 	//
-	// - "objectReconcilerCreationFailed": an error exists when creating the object
+	// - "TypeNotFound": the type in the spec is not found in the API server.
+	//
+	// - "ObjectReconcilerCreationFailed": an error exists when creating the object
 	// reconciler for the type specified in Msg.
 	//
-	// - "multipleConfigurationsForOneType": Multiple configurations exist for the type specified
+	// - "MultipleConfigurationsForOneType": Multiple configurations exist for the type specified
 	// in the Msg. One type should only have one configuration.
 	Code HNCConfigurationCode `json:"code"`
 

--- a/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
+++ b/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
@@ -154,13 +154,10 @@ spec:
               types:
                 description: Types indicates the desired synchronization states of kinds, if any.
                 items:
-                  description: TypeSynchronizationSpec defines the desired synchronization state of a specific kind.
+                  description: TypeSynchronizationSpec defines the desired synchronization state of a specific resource.
                   properties:
-                    apiVersion:
-                      description: API version of the kind defined below. This is used to unambiguously identifies the kind.
-                      type: string
-                    kind:
-                      description: Kind to be configured.
+                    group:
+                      description: Group of the resource defined below. This is used to unambiguously identify the resource.
                       type: string
                     mode:
                       description: Synchronization mode of the kind. If the field is empty, it will be treated as "Propagate".
@@ -169,9 +166,12 @@ spec:
                       - Ignore
                       - Remove
                       type: string
+                    resource:
+                      description: Resource to be configured.
+                      type: string
                   required:
-                  - apiVersion
-                  - kind
+                  - group
+                  - resource
                   type: object
                 type: array
             type: object
@@ -184,7 +184,7 @@ spec:
                   description: HNCConfigurationCondition specifies the code and the description of an error condition.
                   properties:
                     code:
-                      description: "Describes the condition in a machine-readable string value. The currently valid values are shown below, but new values may be added over time. This field is always present in a condition. \n Conditions typically indicate some kinds of error that HNC itself can ignore. However, the behaviors of some types might be out-of-sync with the users' expectations. \n Currently, the supported values are: \n - \"objectReconcilerCreationFailed\": an error exists when creating the object reconciler for the type specified in Msg. \n - \"multipleConfigurationsForOneType\": Multiple configurations exist for the type specified in the Msg. One type should only have one configuration."
+                      description: "Describes the condition in a machine-readable string value. The currently valid values are shown below, but new values may be added over time. This field is always present in a condition. \n Conditions typically indicate some kinds of error that HNC itself can ignore. However, the behaviors of some types might be out-of-sync with the users' expectations. \n Currently, the supported values are: \n - \"TypeNotFound\": the type in the spec is not found in the API server. \n - \"ObjectReconcilerCreationFailed\": an error exists when creating the object reconciler for the type specified in Msg. \n - \"MultipleConfigurationsForOneType\": Multiple configurations exist for the type specified in the Msg. One type should only have one configuration."
                       type: string
                     msg:
                       description: A human-readable description of the condition, if the `code` field is not sufficiently clear on their own. If the condition is only for specific types, Msg will include information about the types (e.g., GVK).
@@ -215,11 +215,8 @@ spec:
                 items:
                   description: TypeSynchronizationStatus defines the observed synchronization state of a specific kind.
                   properties:
-                    apiVersion:
-                      description: API version of the kind defined below. This is used to unambiguously identifies the kind.
-                      type: string
-                    kind:
-                      description: Kind to be configured.
+                    group:
+                      description: Group of the resource defined below.
                       type: string
                     mode:
                       description: Mode describes the synchronization mode of the kind. Typically, it will be the same as the mode in the spec, except when the reconciler has fallen behind or when the mode is omitted from the spec and the default is chosen.
@@ -232,9 +229,16 @@ spec:
                       description: Tracks the number of objects that are created by users.
                       minimum: 0
                       type: integer
+                    resource:
+                      description: Resource to be configured.
+                      type: string
+                    version:
+                      description: Version of the resource defined below.
+                      type: string
                   required:
-                  - apiVersion
-                  - kind
+                  - group
+                  - resource
+                  - version
                   type: object
                 type: array
             type: object

--- a/incubator/hnc/internal/config/default_config.go
+++ b/incubator/hnc/internal/config/default_config.go
@@ -21,9 +21,9 @@ var EX = map[string]bool{
 // See details in http://bit.ly/hnc-type-configuration
 
 func GetDefaultRoleSpec() api.TypeSynchronizationSpec {
-	return api.TypeSynchronizationSpec{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Mode: api.Propagate}
+	return api.TypeSynchronizationSpec{Group: api.RBACGroup, Resource: api.RoleResource, Mode: api.Propagate}
 }
 
 func GetDefaultRoleBindingSpec() api.TypeSynchronizationSpec {
-	return api.TypeSynchronizationSpec{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Mode: api.Propagate}
+	return api.TypeSynchronizationSpec{Group: api.RBACGroup, Resource: api.RoleBindingResource, Mode: api.Propagate}
 }

--- a/incubator/hnc/internal/kubectl/configdelete.go
+++ b/incubator/hnc/internal/kubectl/configdelete.go
@@ -24,40 +24,40 @@ import (
 )
 
 var configDeleteCmd = &cobra.Command{
-	Use:   "delete-type --apiVersion X --kind Y",
+	Use:   "delete-type --group X --resource Y",
 	Short: "Delete the HNC configuration of a specific type",
 	Example: fmt.Sprintf("  # Delete configuration of a core type\n" +
-		"  kubectl hns config delete-type --apiVersion v1 --kind Secret\n\n" +
+		"  kubectl hns config delete-type --resource secrets\n\n" +
 		"  # Delete configuration of a custom type\n" +
-		"  kubectl hns config delete-type --apiversion stable.example.com/v1 --kind CronTab"),
+		"  kubectl hns config delete-type --group stable.example.com --resource crontabs"),
 	Run: func(cmd *cobra.Command, args []string) {
 		flags := cmd.Flags()
-		apiVersion, _ := flags.GetString("apiVersion")
-		kind, _ := flags.GetString("kind")
+		group, _ := flags.GetString("group")
+		resource, _ := flags.GetString("resource")
 		config := client.getHNCConfig()
 
 		var newTypes []api.TypeSynchronizationSpec
 		exist := false
 		for _, t := range config.Spec.Types {
-			if t.APIVersion == apiVersion && t.Kind == kind {
+			if t.Group == group && t.Resource == resource {
 				exist = true
 			} else {
 				newTypes = append(newTypes, t)
 			}
 		}
 		if !exist {
-			fmt.Printf("Nothing to delete; No configuration for type with API version: %s, "+
-				"kind: %s\n", apiVersion, kind)
+			fmt.Printf("Nothing to delete; No configuration for type with group: %s, "+
+				"resource: %s\n", group, resource)
 			return
 		}
 		config.Spec.Types = newTypes
 		client.updateHNCConfig(config)
-		fmt.Printf("Configuration for type with API version: %s, kind: %s is deleted\n", apiVersion, kind)
+		fmt.Printf("Configuration for type with group: %s, resource: %s is deleted\n", group, resource)
 	},
 }
 
 func newConfigDeleteCmd() *cobra.Command {
-	configDeleteCmd.Flags().String("apiVersion", "", "API version of the kind")
-	configDeleteCmd.Flags().String("kind", "", "Kind to be configured")
+	configDeleteCmd.Flags().String("group", "", "group of the resource")
+	configDeleteCmd.Flags().String("resource", "", "resource to be configured")
 	return configDeleteCmd
 }

--- a/incubator/hnc/internal/kubectl/configdescribe.go
+++ b/incubator/hnc/internal/kubectl/configdescribe.go
@@ -40,7 +40,7 @@ var configDescribeCmd = &cobra.Command{
 			default:
 				action = "Ignoring"
 			}
-			fmt.Printf("* %s: %s (%s)\n", action, t.Kind, t.APIVersion)
+			fmt.Printf("* %s: %s (%s/%s)\n", action, t.Resource, t.Group, t.Version)
 		}
 		fmt.Print("\nConditions:\n")
 		for _, c := range config.Status.Conditions {

--- a/incubator/hnc/internal/reconcilers/hnc_config.go
+++ b/incubator/hnc/internal/reconcilers/hnc_config.go
@@ -9,6 +9,9 @@ import (
 
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -51,8 +54,12 @@ type ConfigReconciler struct {
 	// not use it.
 	HierarchyConfigUpdates chan event.GenericEvent
 
-	// activeGVKs contains GVKs that are configured in the Spec.
-	activeGVKs gvkSet
+	// activeGVKMode contains GRs that are configured in the Spec and their mapping
+	// GVKs and configured modes.
+	activeGVKMode gr2gvkMode
+
+	// activeGR contains the mapped GVKs of the GRs configured in the Spec.
+	activeGR gvk2gr
 
 	// enqueueReasons maintains the list of reasons we've been asked to update ourselves. Functionally,
 	// it's just a boolean (nil or non-nil), everything else is just for logging.
@@ -60,8 +67,16 @@ type ConfigReconciler struct {
 	enqueueReasonsLock sync.Mutex
 }
 
-// gvkSet keeps track of a group of unique GVKs.
-type gvkSet map[schema.GroupVersionKind]bool
+type gvkMode struct {
+	gvk  schema.GroupVersionKind
+	mode api.SynchronizationMode
+}
+
+// gr2gvkMode keeps track of a group of unique GRs and the mapping GVKs and modes.
+type gr2gvkMode map[schema.GroupResource]gvkMode
+
+// gvk2gr keeps track of a group of unique GVKs with the mapping GRs.
+type gvk2gr map[schema.GroupVersionKind]schema.GroupResource
 
 // checkPeriod is the period that the config reconciler checks if it needs to reconcile the
 // `config` singleton.
@@ -78,6 +93,10 @@ func (r *ConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{}, err
 	}
 	inst.Status.Conditions = nil
+
+	if err := r.reconcileTypes(inst); err != nil {
+		return ctrl.Result{}, err
+	}
 
 	// Create or sync corresponding ObjectReconcilers, if needed.
 	syncErr := r.syncObjectReconcilers(ctx, inst)
@@ -96,6 +115,47 @@ func (r *ConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	// Retry reconciliation if there is a sync error.
 	return ctrl.Result{}, syncErr
+}
+
+// reconcileTypes makes sure there's no dup and the types exist. Update the type
+// set with GR to GVK mappings.
+func (r *ConfigReconciler) reconcileTypes(inst *api.HNCConfiguration) error {
+	// Get all resources for all groups.
+	allRes, err := GetAllResources(r.Manager.GetConfig())
+	if err != nil {
+		r.Log.Error(err, "while trying to get all resources")
+		return err
+	}
+
+	// Get valid settings in the `config` singleton.
+	r.activeGVKMode = gr2gvkMode{}
+	r.activeGR = gvk2gr{}
+	for _, t := range inst.Spec.Types {
+		gr := schema.GroupResource{Group: t.Group, Resource: t.Resource}
+		grm := fmt.Sprintf("Group: %s, Resource: %s, Mode: %s", t.Group, t.Resource, t.Mode)
+		// If there are multiple configurations of the same type, we will follow the
+		// first configuration and ignore the rest.
+		if _, exist := r.activeGVKMode[gr]; exist {
+			msg := fmt.Sprintf("Ignore the configuration: %q because the configuration of the type already exists; "+
+				"only the first configuration will be applied", grm)
+			r.Log.Info(msg)
+			r.writeCondition(inst, api.MultipleConfigurationsForOneType, msg)
+			continue
+		}
+
+		// Look if the resource exists in the API server.
+		gvk, err := GVKFor(gr, allRes)
+		if err != nil {
+			// If the type is not found, log error and write conditions but don't
+			// early exit since the other types can still be reconciled.
+			r.Log.Error(err, "while trying to reconcile the configuration", "configuration", grm)
+			r.writeCondition(inst, api.TypeNotFound, err.Error())
+			continue
+		}
+		r.activeGVKMode[gr] = gvkMode{gvk, t.Mode}
+		r.activeGR[gvk] = gr
+	}
+	return nil
 }
 
 // getSingleton returns the singleton if it exists, or creates a default one if it doesn't.
@@ -163,11 +223,11 @@ func (r *ConfigReconciler) validateRBACTypes(inst *api.HNCConfiguration) {
 }
 
 func (r *ConfigReconciler) isRole(t api.TypeSynchronizationSpec) bool {
-	return t.APIVersion == "rbac.authorization.k8s.io/v1" && t.Kind == "Role"
+	return t.Group == api.RBACGroup && t.Resource == api.RoleResource
 }
 
 func (r *ConfigReconciler) isRoleBinding(t api.TypeSynchronizationSpec) bool {
-	return t.APIVersion == "rbac.authorization.k8s.io/v1" && t.Kind == "RoleBinding"
+	return t.Group == api.RBACGroup && t.Resource == api.RoleBindingResource
 }
 
 // writeSingleton creates a singleton on the apiserver if it does not exist.
@@ -232,71 +292,43 @@ func (r *ConfigReconciler) syncObjectReconcilers(ctx context.Context, inst *api.
 		return err
 	}
 
-	if err := r.syncRemovedReconcilers(ctx, inst); err != nil {
+	if err := r.syncRemovedReconcilers(ctx); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-// syncActiveReconcilers syncs object reconcilers for types that are in the Spec. If an object reconciler exists, it sets
-// its mode according to the Spec; otherwise, it creates the object reconciler.
+// syncActiveReconcilers syncs object reconcilers for types that are in the Spec
+// and exists in the API server. If an object reconciler exists, it sets its
+// mode according to the Spec; otherwise, it creates the object reconciler.
 func (r *ConfigReconciler) syncActiveReconcilers(ctx context.Context, inst *api.HNCConfiguration) error {
-	// exist keeps track of existing types in the `config` singleton.
-	exist := gvkSet{}
-	r.activeGVKs = gvkSet{}
-	for _, t := range inst.Spec.Types {
-		// If there are multiple configurations of the same type, we will follow the first
-		// configuration and ignore the rest.
-		if !r.ensureNoDuplicateTypeConfigurations(inst, t, exist) {
-			continue
-		}
-		gvk := schema.FromAPIVersionAndKind(t.APIVersion, t.Kind)
-		r.activeGVKs[gvk] = true
-		if ts := r.Forest.GetTypeSyncer(gvk); ts != nil {
-			if err := ts.SetMode(ctx, t.Mode, r.Log); err != nil {
+	for _, gvkMode := range r.activeGVKMode {
+		if ts := r.Forest.GetTypeSyncer(gvkMode.gvk); ts != nil {
+			if err := ts.SetMode(ctx, gvkMode.mode, r.Log); err != nil {
 				return err // retry the reconciliation
 			}
 		} else {
-			r.createObjectReconciler(gvk, t.Mode, inst)
+			r.createObjectReconciler(gvkMode.gvk, gvkMode.mode, inst)
 		}
 	}
 	return nil
 }
 
-// ensureNoDuplicateTypeConfigurations checks whether the configuration of a type already exists and sets
-// a condition in the status if the type exists. The method returns true if the type configuration does not exist;
-// otherwise, returns false.
-func (r *ConfigReconciler) ensureNoDuplicateTypeConfigurations(inst *api.HNCConfiguration, t api.TypeSynchronizationSpec,
-	mp gvkSet) bool {
-	gvk := schema.FromAPIVersionAndKind(t.APIVersion, t.Kind)
-	if !mp[gvk] {
-		mp[gvk] = true
-		return true
-	}
-	specMsg := fmt.Sprintf("APIVersion: %s, Kind: %s, Mode: %s", t.APIVersion, t.Kind, t.Mode)
-	r.Log.Info(fmt.Sprintf("Ignoring the configuration: %s", specMsg))
-	condition := api.HNCConfigurationCondition{
-		Code: api.MultipleConfigurationsForOneType,
-		Msg: fmt.Sprintf("Ignore the configuration: %s because the configuration of the type already exists; "+
-			"only the first configuration will be applied", specMsg),
-	}
-	inst.Status.Conditions = append(inst.Status.Conditions, condition)
-	return false
-}
-
-// syncRemovedReconcilers sets object reconcilers to "ignore" mode for types that are removed from the Spec.
-func (r *ConfigReconciler) syncRemovedReconcilers(ctx context.Context, inst *api.HNCConfiguration) error {
-	// If a type exists in the forest but not exists in the Spec, we will
-	// set the mode of corresponding object reconciler to "ignore".
+// syncRemovedReconcilers sets object reconcilers to "ignore" mode for types
+// that are removed from the Spec. No longer existing types in the Spec are also
+// considered as removed.
+func (r *ConfigReconciler) syncRemovedReconcilers(ctx context.Context) error {
+	// If a type exists in the forest but not exists in the latest type set, we
+	// will set the mode of corresponding object reconciler to "ignore".
 	// TODO: Ideally, we should shut down the corresponding object
 	// reconciler. Gracefully terminating an object reconciler is still under
 	// development (https://github.com/kubernetes-sigs/controller-runtime/issues/764).
 	// We will revisit the code below once the feature is released.
 	for _, ts := range r.Forest.GetTypeSyncers() {
 		exist := false
-		for _, t := range inst.Spec.Types {
-			if ts.GetGVK() == schema.FromAPIVersionAndKind(t.APIVersion, t.Kind) {
+		for _, gvkMode := range r.activeGVKMode {
+			if ts.GetGVK() == gvkMode.gvk {
 				exist = true
 				break
 			}
@@ -313,20 +345,14 @@ func (r *ConfigReconciler) syncRemovedReconcilers(ctx context.Context, inst *api
 	return nil
 }
 
-// createObjectReconciler creates an ObjectReconciler for the given GVK and informs forest about the reconciler.
+// createObjectReconciler creates an ObjectReconciler for the given GVK and
+// informs forest about the reconciler.
+// After upgrading sigs.k8s.io/controller-runtime version to v0.5.0, we can
+// create reconciler successfully even when the resource does not exist in the
+// cluster. Therefore, the caller should check if the resource exists before
+// creating the reconciler.
 func (r *ConfigReconciler) createObjectReconciler(gvk schema.GroupVersionKind, mode api.SynchronizationMode, inst *api.HNCConfiguration) {
 	r.Log.Info("Creating an object reconciler", "gvk", gvk, "mode", mode)
-
-	// After upgrading sigs.k8s.io/controller-runtime version to v0.5.0, we can create
-	// reconciler successfully even when the resource does not exist in the cluster.
-	// Therefore, we explicitly check if the resource exists before creating the
-	// reconciler.
-	_, err := r.Manager.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
-	if err != nil {
-		r.Log.Error(err, "Error while trying to get resource", "gvk", gvk)
-		r.writeObjectReconcilerCreationFailedCondition(inst, gvk, err)
-		return
-	}
 
 	or := &ObjectReconciler{
 		Client: r.Client,
@@ -344,7 +370,8 @@ func (r *ConfigReconciler) createObjectReconciler(gvk schema.GroupVersionKind, m
 	// TODO: figure out MaxConcurrentReconciles option - https://github.com/kubernetes-sigs/multi-tenancy/issues/291
 	if err := or.SetupWithManager(r.Manager, 10); err != nil {
 		r.Log.Error(err, "Error while trying to create ObjectReconciler", "gvk", gvk)
-		r.writeObjectReconcilerCreationFailedCondition(inst, gvk, err)
+		msg := fmt.Sprintf("Couldn't create ObjectReconciler for type %s: %s", gvk, err)
+		r.writeCondition(inst, api.ObjectReconcilerCreationFailed, msg)
 		return
 	}
 
@@ -352,18 +379,17 @@ func (r *ConfigReconciler) createObjectReconciler(gvk schema.GroupVersionKind, m
 	r.Forest.AddTypeSyncer(or)
 }
 
-func (r *ConfigReconciler) writeObjectReconcilerCreationFailedCondition(inst *api.HNCConfiguration,
-	gvk schema.GroupVersionKind, err error) {
+func (r *ConfigReconciler) writeCondition(inst *api.HNCConfiguration, code api.HNCConfigurationCode, msg string) {
 	condition := api.HNCConfigurationCondition{
-		Code: api.ObjectReconcilerCreationFailed,
-		Msg:  fmt.Sprintf("Couldn't create ObjectReconciler for type %s: %s", gvk, err),
+		Code: code,
+		Msg:  msg,
 	}
 	inst.Status.Conditions = append(inst.Status.Conditions, condition)
 }
 
-// setTypeStatuses adds Status.Types for types configured in the spec. Only the status of
-// types in `propagate` and `remove` modes will be recorded. The Status.Types
-// is sorted in alphabetical order based on APIVersion and Kind.
+// setTypeStatuses adds Status.Types for types configured in the spec. Only the
+// status of types in `Propagate` and `Remove` modes will be recorded. The
+// Status.Types is sorted in alphabetical order based on Group and Resource.
 func (r *ConfigReconciler) setTypeStatuses(inst *api.HNCConfiguration) {
 	// We lock the forest here so that other reconcilers cannot modify the
 	// forest while we are reading from the forest.
@@ -372,18 +398,20 @@ func (r *ConfigReconciler) setTypeStatuses(inst *api.HNCConfiguration) {
 
 	statuses := []api.TypeSynchronizationStatus{}
 	for _, ts := range r.Forest.GetTypeSyncers() {
-		// Don't output a status for any reconciler that isn't explicitly listed in the spec
+		// Don't output a status for any reconciler that isn't explicitly listed in
+		// the Spec
 		gvk := ts.GetGVK()
-		if !r.activeGVKs[ts.GetGVK()] {
+		gr, exist := r.activeGR[ts.GetGVK()]
+		if !exist {
 			continue
 		}
 
 		// Initialize status
-		apiVersion, kind := gvk.ToAPIVersionAndKind()
 		status := api.TypeSynchronizationStatus{
-			APIVersion: apiVersion,
-			Kind:       kind,
-			Mode:       ts.GetMode(), // may be different from the spec if it's implicit
+			Group:    gr.Group,
+			Version:  gvk.Version,
+			Resource: gr.Resource,
+			Mode:     ts.GetMode(), // may be different from the spec if it's implicit
 		}
 
 		// Only add NumPropagatedObjects if we're not ignoring this type
@@ -409,10 +437,10 @@ func (r *ConfigReconciler) setTypeStatuses(inst *api.HNCConfiguration) {
 
 	// Alphabetize
 	sort.Slice(statuses, func(i, j int) bool {
-		if statuses[i].APIVersion != statuses[j].APIVersion {
-			return statuses[i].APIVersion < statuses[j].APIVersion
+		if statuses[i].Group != statuses[j].Group {
+			return statuses[i].Group < statuses[j].Group
 		}
-		return statuses[i].Kind < statuses[j].Kind
+		return statuses[i].Resource < statuses[j].Resource
 	})
 
 	// Record the final list
@@ -542,4 +570,47 @@ func (r *ConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	go r.periodicTrigger()
 
 	return nil
+}
+
+// GetAllResources creates a discovery client to get all the resources for all
+// groups from the apiserver.
+func GetAllResources(config *rest.Config) ([]*restmapper.APIGroupResources, error) {
+	dc, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return restmapper.GetAPIGroupResources(dc)
+}
+
+// GVKFor searches the GR in apiserver and returns the mapping GVK. If the GR
+// doesn't exist, return an empty GVK and the error.
+func GVKFor(gr schema.GroupResource, allRes []*restmapper.APIGroupResources) (schema.GroupVersionKind, error) {
+	// Look for a matching resource from all resources.
+	for _, groupedResources := range allRes {
+		group := groupedResources.Group
+		// Skip resources from a different group.
+		if group.Name != gr.Group {
+			continue
+		}
+		// Search in the grouped resources by version. We will use the first version
+		// that the resource exists in. It's safe because the resource is supported
+		// in that GroupVersion and apiserver will do the api conversion if needed.
+		for _, version := range group.Versions {
+			for _, resource := range groupedResources.VersionedResources[version.Version] {
+				if resource.Name == gr.Resource {
+					// Please note that we cannot use resource.group or resource.version
+					// here because they are preferred group/version and they are default
+					// to empty to imply this current containing group/version. Therefore,
+					// resource.group and resource.version are always empty in this case.
+					gvk := schema.GroupVersionKind{
+						Group:   gr.Group,
+						Version: version.Version,
+						Kind:    resource.Kind,
+					}
+					return gvk, nil
+				}
+			}
+		}
+	}
+	return schema.GroupVersionKind{}, fmt.Errorf("Resource %q not found", gr)
 }

--- a/incubator/hnc/internal/reconcilers/object_test.go
+++ b/incubator/hnc/internal/reconcilers/object_test.go
@@ -132,18 +132,18 @@ var _ = Describe("Exceptions", func() {
 				tc.treeSelector = replaceStrings(tc.treeSelector, names)
 
 				// Create a Role with the selector and treeSelector annotation
-				makeObjectWithAnnotation(ctx, "Role", names[p], "testrole", map[string]string{
+				makeObjectWithAnnotation(ctx, api.RoleResource, names[p], "testrole", map[string]string{
 					api.AnnotationSelector:     tc.selector,
 					api.AnnotationTreeSelector: tc.treeSelector,
 					api.AnnotationNoneSelector: tc.noneSelector,
 				})
 				for _, ns := range tc.want {
 					ns = replaceStrings(ns, names)
-					Eventually(hasObject(ctx, "Role", ns, "testrole")).Should(BeTrue(), "When propagating testrole to %s", ns)
+					Eventually(hasObject(ctx, api.RoleResource, ns, "testrole")).Should(BeTrue(), "When propagating testrole to %s", ns)
 				}
 				for _, ns := range tc.notWant {
 					ns = replaceStrings(ns, names)
-					Consistently(hasObject(ctx, "Role", ns, "testrole")).Should(BeFalse(), "When propagating testrole to %s", ns)
+					Consistently(hasObject(ctx, api.RoleResource, ns, "testrole")).Should(BeFalse(), "When propagating testrole to %s", ns)
 				}
 			})
 		}
@@ -199,13 +199,13 @@ var _ = Describe("Exceptions", func() {
 				tc.treeSelector = replaceStrings(tc.treeSelector, names)
 
 				// Create a Role and verify it's propagated
-				makeObject(ctx, "Role", names[p], "testrole")
+				makeObject(ctx, api.RoleResource, names[p], "testrole")
 				for _, ns := range names {
-					Eventually(hasObject(ctx, "Role", ns, "testrole")).Should(BeTrue(), "When propagating testrole to %s", ns)
+					Eventually(hasObject(ctx, api.RoleResource, ns, "testrole")).Should(BeTrue(), "When propagating testrole to %s", ns)
 				}
 
 				// update the role with the selector and treeSelector annotation
-				updateObjectWithAnnotation(ctx, "Role", names[p], "testrole", map[string]string{
+				updateObjectWithAnnotation(ctx, api.RoleResource, names[p], "testrole", map[string]string{
 					api.AnnotationSelector:     tc.selector,
 					api.AnnotationTreeSelector: tc.treeSelector,
 					api.AnnotationNoneSelector: tc.noneSelector,
@@ -213,18 +213,18 @@ var _ = Describe("Exceptions", func() {
 				// make sure the changes are propagated
 				for _, ns := range tc.notWant {
 					ns = replaceStrings(ns, names)
-					Eventually(hasObject(ctx, "Role", ns, "testrole")).Should(BeFalse(), "When propagating testrole to %s", ns)
+					Eventually(hasObject(ctx, api.RoleResource, ns, "testrole")).Should(BeFalse(), "When propagating testrole to %s", ns)
 				}
 				// then check that the objects are kept in these namespaces
 				for _, ns := range tc.want {
 					ns = replaceStrings(ns, names)
-					Consistently(hasObject(ctx, "Role", ns, "testrole")).Should(BeTrue(), "When propagating testrole to %s", ns)
+					Consistently(hasObject(ctx, api.RoleResource, ns, "testrole")).Should(BeTrue(), "When propagating testrole to %s", ns)
 				}
 
 				// remove the annotation and verify that the object is back for every namespace
-				updateObjectWithAnnotation(ctx, "Role", names[p], "testrole", map[string]string{})
+				updateObjectWithAnnotation(ctx, api.RoleResource, names[p], "testrole", map[string]string{})
 				for _, ns := range names {
-					Eventually(hasObject(ctx, "Role", ns, "testrole")).Should(BeTrue(), "When propagating testrole to %s", ns)
+					Eventually(hasObject(ctx, api.RoleResource, ns, "testrole")).Should(BeTrue(), "When propagating testrole to %s", ns)
 				}
 			})
 		}
@@ -249,9 +249,9 @@ var _ = Describe("Secret", func() {
 		cleanupObjects(ctx)
 
 		// Give them each a role.
-		makeObject(ctx, "Role", fooName, "foo-role")
-		makeObject(ctx, "Role", barName, "bar-role")
-		makeObject(ctx, "Role", bazName, "baz-role")
+		makeObject(ctx, api.RoleResource, fooName, "foo-role")
+		makeObject(ctx, api.RoleResource, barName, "bar-role")
+		makeObject(ctx, api.RoleResource, bazName, "baz-role")
 	})
 
 	AfterEach(func() {
@@ -263,46 +263,46 @@ var _ = Describe("Secret", func() {
 		setParent(ctx, barName, fooName)
 		setParent(ctx, bazName, barName)
 
-		Eventually(hasObject(ctx, "Role", barName, "foo-role")).Should(BeTrue())
-		Expect(objectInheritedFrom(ctx, "Role", barName, "foo-role")).Should(Equal(fooName))
+		Eventually(hasObject(ctx, api.RoleResource, barName, "foo-role")).Should(BeTrue())
+		Expect(objectInheritedFrom(ctx, api.RoleResource, barName, "foo-role")).Should(Equal(fooName))
 
-		Eventually(hasObject(ctx, "Role", bazName, "foo-role")).Should(BeTrue())
-		Expect(objectInheritedFrom(ctx, "Role", bazName, "foo-role")).Should(Equal(fooName))
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "foo-role")).Should(BeTrue())
+		Expect(objectInheritedFrom(ctx, api.RoleResource, bazName, "foo-role")).Should(Equal(fooName))
 
-		Eventually(hasObject(ctx, "Role", bazName, "bar-role")).Should(BeTrue())
-		Expect(objectInheritedFrom(ctx, "Role", bazName, "bar-role")).Should(Equal(barName))
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "bar-role")).Should(BeTrue())
+		Expect(objectInheritedFrom(ctx, api.RoleResource, bazName, "bar-role")).Should(Equal(barName))
 	})
 
 	It("should be copied to descendents when source object is empty", func() {
 		setParent(ctx, barName, fooName)
 		// Creates an empty ConfigMap. We use ConfigMap for this test because the apiserver will not
 		// add additional fields to an empty ConfigMap object to make it non-empty.
-		makeObject(ctx, "ConfigMap", fooName, "foo-config")
-		addToHNCConfig(ctx, "v1", "ConfigMap", api.Propagate)
+		makeObject(ctx, "configmaps", fooName, "foo-config")
+		addToHNCConfig(ctx, "", "configmaps", api.Propagate)
 
 		// "foo-config" should now be propagated from foo to bar.
-		Eventually(hasObject(ctx, "ConfigMap", barName, "foo-config")).Should(BeTrue())
-		Expect(objectInheritedFrom(ctx, "ConfigMap", barName, "foo-config")).Should(Equal(fooName))
+		Eventually(hasObject(ctx, "configmaps", barName, "foo-config")).Should(BeTrue())
+		Expect(objectInheritedFrom(ctx, "configmaps", barName, "foo-config")).Should(Equal(fooName))
 	})
 
 	It("should be removed if the hierarchy changes", func() {
 		setParent(ctx, barName, fooName)
 		setParent(ctx, bazName, barName)
-		Eventually(hasObject(ctx, "Role", bazName, "foo-role")).Should(BeTrue())
-		Eventually(hasObject(ctx, "Role", bazName, "bar-role")).Should(BeTrue())
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "foo-role")).Should(BeTrue())
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "bar-role")).Should(BeTrue())
 		setParent(ctx, bazName, fooName)
-		Eventually(hasObject(ctx, "Role", bazName, "bar-role")).Should(BeFalse())
-		Eventually(hasObject(ctx, "Role", bazName, "foo-role")).Should(BeTrue())
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "bar-role")).Should(BeFalse())
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "foo-role")).Should(BeTrue())
 		setParent(ctx, bazName, "")
-		Eventually(hasObject(ctx, "Role", bazName, "bar-role")).Should(BeFalse())
-		Eventually(hasObject(ctx, "Role", bazName, "foo-role")).Should(BeFalse())
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "bar-role")).Should(BeFalse())
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "foo-role")).Should(BeFalse())
 	})
 
 	It("should not be propagated if modified", func() {
 		// Set tree as bar -> foo and make sure the first-time propagation of foo-role
 		// is finished before modifying the foo-role in bar namespace
 		setParent(ctx, barName, fooName)
-		Eventually(hasObject(ctx, "Role", barName, "foo-role")).Should(BeTrue())
+		Eventually(hasObject(ctx, api.RoleResource, barName, "foo-role")).Should(BeTrue())
 
 		// Wait 1 second to make sure all enqueued fooName hiers are successfully reconciled
 		// in case the manual modification is overridden by the unfinished propagation.
@@ -314,32 +314,32 @@ var _ = Describe("Secret", func() {
 		// that if the other one *isn't* copied, this is because we decided not to, and
 		// not that we just haven't gotten to it yet.
 		setParent(ctx, bazName, barName)
-		Eventually(hasObject(ctx, "Role", bazName, "bar-role")).Should(BeTrue())
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "bar-role")).Should(BeTrue())
 
 		// Make sure the bad one got overwritte.
-		Eventually(hasObject(ctx, "Role", bazName, "foo-role")).Should(BeTrue())
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "foo-role")).Should(BeTrue())
 	})
 
 	It("should be removed if the source no longer exists", func() {
 		setParent(ctx, barName, fooName)
 		setParent(ctx, bazName, barName)
-		Eventually(hasObject(ctx, "Role", barName, "foo-role")).Should(BeTrue())
-		Eventually(hasObject(ctx, "Role", bazName, "foo-role")).Should(BeTrue())
+		Eventually(hasObject(ctx, api.RoleResource, barName, "foo-role")).Should(BeTrue())
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "foo-role")).Should(BeTrue())
 
 		removeRole(ctx, fooName, "foo-role")
-		Eventually(hasObject(ctx, "Role", fooName, "foo-role")).Should(BeFalse())
-		Eventually(hasObject(ctx, "Role", barName, "foo-role")).Should(BeFalse())
-		Eventually(hasObject(ctx, "Role", bazName, "foo-role")).Should(BeFalse())
+		Eventually(hasObject(ctx, api.RoleResource, fooName, "foo-role")).Should(BeFalse())
+		Eventually(hasObject(ctx, api.RoleResource, barName, "foo-role")).Should(BeFalse())
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "foo-role")).Should(BeFalse())
 	})
 
 	It("should overwrite the propagated ones if the source is updated", func() {
 		setParent(ctx, barName, fooName)
 		setParent(ctx, bazName, barName)
-		Eventually(hasObject(ctx, "Role", fooName, "foo-role")).Should(BeTrue())
+		Eventually(hasObject(ctx, api.RoleResource, fooName, "foo-role")).Should(BeTrue())
 		Eventually(isModified(ctx, fooName, "foo-role")).Should(BeFalse())
-		Eventually(hasObject(ctx, "Role", barName, "foo-role")).Should(BeTrue())
+		Eventually(hasObject(ctx, api.RoleResource, barName, "foo-role")).Should(BeTrue())
 		Eventually(isModified(ctx, barName, "foo-role")).Should(BeFalse())
-		Eventually(hasObject(ctx, "Role", bazName, "foo-role")).Should(BeTrue())
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "foo-role")).Should(BeTrue())
 		Eventually(isModified(ctx, bazName, "foo-role")).Should(BeFalse())
 
 		modifyRole(ctx, fooName, "foo-role")
@@ -351,49 +351,49 @@ var _ = Describe("Secret", func() {
 	It("should overwrite the conflicting source in the descedants", func() {
 		setParent(ctx, barName, fooName)
 		setParent(ctx, bazName, barName)
-		Eventually(hasObject(ctx, "Role", barName, "bar-role")).Should(BeTrue())
-		Eventually(hasObject(ctx, "Role", bazName, "bar-role")).Should(BeTrue())
-		Expect(objectInheritedFrom(ctx, "Role", bazName, "bar-role")).Should(Equal(barName))
+		Eventually(hasObject(ctx, api.RoleResource, barName, "bar-role")).Should(BeTrue())
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "bar-role")).Should(BeTrue())
+		Expect(objectInheritedFrom(ctx, api.RoleResource, bazName, "bar-role")).Should(Equal(barName))
 
-		makeObject(ctx, "Role", fooName, "bar-role")
+		makeObject(ctx, api.RoleResource, fooName, "bar-role")
 		// Add a 500-millisecond gap here to allow updating the cached bar-roles in bar
 		// and baz namespaces. Without this, even having 20 seconds in the "Eventually()"
 		// funcs below, the test failed with timeout. Guess the reason is that it's
 		// constantly getting the cached object.
 		time.Sleep(500 * time.Millisecond)
-		Eventually(hasObject(ctx, "Role", bazName, "bar-role")).Should(BeTrue())
-		Eventually(objectInheritedFrom(ctx, "Role", bazName, "bar-role")).Should(Equal(fooName))
-		Eventually(hasObject(ctx, "Role", barName, "bar-role")).Should(BeTrue())
-		Eventually(objectInheritedFrom(ctx, "Role", barName, "bar-role")).Should(Equal(fooName))
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "bar-role")).Should(BeTrue())
+		Eventually(objectInheritedFrom(ctx, api.RoleResource, bazName, "bar-role")).Should(Equal(fooName))
+		Eventually(hasObject(ctx, api.RoleResource, barName, "bar-role")).Should(BeTrue())
+		Eventually(objectInheritedFrom(ctx, api.RoleResource, barName, "bar-role")).Should(Equal(fooName))
 	})
 
 	It("should overwrite conflicting source with the top source that can propagate", func() {
 		// Create a 'baz-role' in 'foo' that cannot propagate because of the finalizer.
-		makeObject(ctx, "Role", fooName, "baz-role")
-		Eventually(hasObject(ctx, "Role", fooName, "baz-role")).Should(BeTrue())
+		makeObject(ctx, api.RoleResource, fooName, "baz-role")
+		Eventually(hasObject(ctx, api.RoleResource, fooName, "baz-role")).Should(BeTrue())
 		setFinalizer(ctx, fooName, "baz-role", true)
 		// Create a 'baz-role' in 'bar' that can propagate.
-		makeObject(ctx, "Role", barName, "baz-role")
+		makeObject(ctx, api.RoleResource, barName, "baz-role")
 
 		// Before the tree is constructed, 'baz-role' shouldn't be overwritten.
-		Eventually(hasObject(ctx, "Role", bazName, "baz-role")).Should(BeTrue())
-		Expect(objectInheritedFrom(ctx, "Role", bazName, "baz-role")).Should(Equal(""))
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "baz-role")).Should(BeTrue())
+		Expect(objectInheritedFrom(ctx, api.RoleResource, bazName, "baz-role")).Should(Equal(""))
 
 		// Construct the tree: foo (root) <- bar <- baz.
 		setParent(ctx, barName, fooName)
 		setParent(ctx, bazName, barName)
-		Eventually(hasObject(ctx, "Role", bazName, "baz-role")).Should(BeTrue())
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "baz-role")).Should(BeTrue())
 		// The 'baz-role' in 'baz' should be overwritten by the conflicting one in
 		// 'bar' but not 'foo', since the one in 'foo' cannot propagate with
 		// finalizer. Add a 500-millisecond gap to allow overwriting the object.
 		time.Sleep(500 * time.Millisecond)
-		Eventually(objectInheritedFrom(ctx, "Role", bazName, "baz-role")).Should(Equal(barName))
+		Eventually(objectInheritedFrom(ctx, api.RoleResource, bazName, "baz-role")).Should(Equal(barName))
 	})
 
 	It("should have deletions propagated after crit conditions are removed", func() {
 		// Create tree: bar -> foo (root) and make sure foo-role is propagated
 		setParent(ctx, barName, fooName)
-		Eventually(hasObject(ctx, "Role", barName, "foo-role")).Should(BeTrue())
+		Eventually(hasObject(ctx, api.RoleResource, barName, "foo-role")).Should(BeTrue())
 
 		// Create a critical condition on foo (and also bar by extension)
 		brumpfName := createNSName("brumpf")
@@ -406,16 +406,16 @@ var _ = Describe("Secret", func() {
 		// Delete the object from `foo`, wait until we're sure that it's gone, and then wait a while
 		// longer and verify it *isn't* deleted from `bar`, because the critical condition has paused
 		// deletions.
-		deleteObject(ctx, "Role", fooName, "foo-role")
-		Eventually(hasObject(ctx, "Role", fooName, "foo-role")).Should(BeFalse())
+		deleteObject(ctx, api.RoleResource, fooName, "foo-role")
+		Eventually(hasObject(ctx, api.RoleResource, fooName, "foo-role")).Should(BeFalse())
 		time.Sleep(1 * time.Second) // todo: merge with similar constants elsewhere
-		Expect(hasObject(ctx, "Role", barName, "foo-role")()).Should(BeTrue())
+		Expect(hasObject(ctx, api.RoleResource, barName, "foo-role")()).Should(BeTrue())
 
 		// Resolve the critical condition and verify that the object is deleted
 		fooHier = newOrGetHierarchy(ctx, fooName)
 		fooHier.Spec.Parent = ""
 		updateHierarchy(ctx, fooHier)
-		Eventually(hasObject(ctx, "Role", barName, "foo-role")).Should(BeFalse())
+		Eventually(hasObject(ctx, api.RoleResource, barName, "foo-role")).Should(BeFalse())
 	})
 
 	It("shouldn't propagate/delete if the namespace has Crit condition", func() {
@@ -423,13 +423,13 @@ var _ = Describe("Secret", func() {
 		setParent(ctx, barName, fooName)
 		setParent(ctx, bazName, barName)
 
-		Eventually(hasObject(ctx, "Role", barName, "foo-role")).Should(BeTrue())
-		Expect(objectInheritedFrom(ctx, "Role", barName, "foo-role")).Should(Equal(fooName))
+		Eventually(hasObject(ctx, api.RoleResource, barName, "foo-role")).Should(BeTrue())
+		Expect(objectInheritedFrom(ctx, api.RoleResource, barName, "foo-role")).Should(Equal(fooName))
 
-		Eventually(hasObject(ctx, "Role", bazName, "foo-role")).Should(BeTrue())
-		Expect(objectInheritedFrom(ctx, "Role", bazName, "foo-role")).Should(Equal(fooName))
-		Eventually(hasObject(ctx, "Role", bazName, "bar-role")).Should(BeTrue())
-		Expect(objectInheritedFrom(ctx, "Role", bazName, "bar-role")).Should(Equal(barName))
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "foo-role")).Should(BeTrue())
+		Expect(objectInheritedFrom(ctx, api.RoleResource, bazName, "foo-role")).Should(Equal(fooName))
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "bar-role")).Should(BeTrue())
+		Expect(objectInheritedFrom(ctx, api.RoleResource, bazName, "bar-role")).Should(Equal(barName))
 
 		// Set foo's parent to a non-existent namespace.
 		brumpfName := createNSName("brumpf")
@@ -442,20 +442,20 @@ var _ = Describe("Secret", func() {
 
 		// Set baz's parent to foo and add a new role in foo.
 		setParent(ctx, bazName, fooName)
-		makeObject(ctx, "Role", fooName, "foo-role-2")
+		makeObject(ctx, api.RoleResource, fooName, "foo-role-2")
 
 		// Since the sync is frozen, baz should still have bar-role (no deleting).
-		Eventually(hasObject(ctx, "Role", bazName, "bar-role")).Should(BeTrue())
-		Expect(objectInheritedFrom(ctx, "Role", bazName, "bar-role")).Should(Equal(barName))
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "bar-role")).Should(BeTrue())
+		Expect(objectInheritedFrom(ctx, api.RoleResource, bazName, "bar-role")).Should(Equal(barName))
 		// baz and bar shouldn't have foo-role-2 (no propagating).
-		Eventually(hasObject(ctx, "Role", bazName, "foo-role-2")).Should(BeFalse())
-		Eventually(hasObject(ctx, "Role", barName, "foo-role-2")).Should(BeFalse())
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "foo-role-2")).Should(BeFalse())
+		Eventually(hasObject(ctx, api.RoleResource, barName, "foo-role-2")).Should(BeFalse())
 
 		// Create the missing parent namespace with one object.
 		brumpfNS := &corev1.Namespace{}
 		brumpfNS.Name = brumpfName
 		Expect(k8sClient.Create(ctx, brumpfNS)).Should(Succeed())
-		makeObject(ctx, "Role", brumpfName, "brumpf-role")
+		makeObject(ctx, api.RoleResource, brumpfName, "brumpf-role")
 
 		// The Crit conditions should be gone.
 		Eventually(hasCondition(ctx, fooName, api.CritParentMissing)).Should(Equal(false))
@@ -463,42 +463,42 @@ var _ = Describe("Secret", func() {
 		Eventually(hasCondition(ctx, bazName, api.CritAncestor)).Should(Equal(false))
 
 		// Everything should be up to date after the Crit conditions are gone.
-		Eventually(hasObject(ctx, "Role", fooName, "brumpf-role")).Should(BeTrue())
-		Expect(objectInheritedFrom(ctx, "Role", fooName, "brumpf-role")).Should(Equal(brumpfName))
+		Eventually(hasObject(ctx, api.RoleResource, fooName, "brumpf-role")).Should(BeTrue())
+		Expect(objectInheritedFrom(ctx, api.RoleResource, fooName, "brumpf-role")).Should(Equal(brumpfName))
 
-		Eventually(hasObject(ctx, "Role", barName, "foo-role")).Should(BeTrue())
-		Expect(objectInheritedFrom(ctx, "Role", barName, "foo-role")).Should(Equal(fooName))
-		Eventually(hasObject(ctx, "Role", barName, "foo-role-2")).Should(BeTrue())
-		Expect(objectInheritedFrom(ctx, "Role", barName, "foo-role-2")).Should(Equal(fooName))
-		Eventually(hasObject(ctx, "Role", barName, "brumpf-role")).Should(BeTrue())
-		Expect(objectInheritedFrom(ctx, "Role", barName, "brumpf-role")).Should(Equal(brumpfName))
+		Eventually(hasObject(ctx, api.RoleResource, barName, "foo-role")).Should(BeTrue())
+		Expect(objectInheritedFrom(ctx, api.RoleResource, barName, "foo-role")).Should(Equal(fooName))
+		Eventually(hasObject(ctx, api.RoleResource, barName, "foo-role-2")).Should(BeTrue())
+		Expect(objectInheritedFrom(ctx, api.RoleResource, barName, "foo-role-2")).Should(Equal(fooName))
+		Eventually(hasObject(ctx, api.RoleResource, barName, "brumpf-role")).Should(BeTrue())
+		Expect(objectInheritedFrom(ctx, api.RoleResource, barName, "brumpf-role")).Should(Equal(brumpfName))
 
-		Eventually(hasObject(ctx, "Role", bazName, "foo-role")).Should(BeTrue())
-		Expect(objectInheritedFrom(ctx, "Role", bazName, "foo-role")).Should(Equal(fooName))
-		Eventually(hasObject(ctx, "Role", bazName, "foo-role-2")).Should(BeTrue())
-		Expect(objectInheritedFrom(ctx, "Role", bazName, "foo-role-2")).Should(Equal(fooName))
-		Eventually(hasObject(ctx, "Role", bazName, "brumpf-role")).Should(BeTrue())
-		Expect(objectInheritedFrom(ctx, "Role", bazName, "brumpf-role")).Should(Equal(brumpfName))
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "foo-role")).Should(BeTrue())
+		Expect(objectInheritedFrom(ctx, api.RoleResource, bazName, "foo-role")).Should(Equal(fooName))
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "foo-role-2")).Should(BeTrue())
+		Expect(objectInheritedFrom(ctx, api.RoleResource, bazName, "foo-role-2")).Should(Equal(fooName))
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "brumpf-role")).Should(BeTrue())
+		Expect(objectInheritedFrom(ctx, api.RoleResource, bazName, "brumpf-role")).Should(Equal(brumpfName))
 
-		Eventually(hasObject(ctx, "Role", bazName, "bar-role")).Should(BeFalse())
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "bar-role")).Should(BeFalse())
 	})
 
 	It("should generate CannotPropagate event if it's excluded from being propagated", func() {
 		// Set tree as baz -> bar -> foo(root) and make sure the secret gets propagated.
 		setParent(ctx, barName, fooName)
 		setParent(ctx, bazName, barName)
-		Eventually(hasObject(ctx, "Role", barName, "foo-role")).Should(BeTrue())
-		Expect(objectInheritedFrom(ctx, "Role", barName, "foo-role")).Should(Equal(fooName))
-		Eventually(hasObject(ctx, "Role", bazName, "foo-role")).Should(BeTrue())
-		Expect(objectInheritedFrom(ctx, "Role", bazName, "foo-role")).Should(Equal(fooName))
+		Eventually(hasObject(ctx, api.RoleResource, barName, "foo-role")).Should(BeTrue())
+		Expect(objectInheritedFrom(ctx, api.RoleResource, barName, "foo-role")).Should(Equal(fooName))
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "foo-role")).Should(BeTrue())
+		Expect(objectInheritedFrom(ctx, api.RoleResource, bazName, "foo-role")).Should(Equal(fooName))
 
 		// Verify there's no CannotPropagate event before introducing the error.
 		Eventually(hasEvent(ctx, fooName, "foo-role", api.EventCannotPropagate)).Should(Equal(false))
 
 		// Make the secret unpropagateable and verify that it disappears.
 		setFinalizer(ctx, fooName, "foo-role", true)
-		Eventually(hasObject(ctx, "Role", barName, "foo-role")).Should(BeFalse())
-		Eventually(hasObject(ctx, "Role", bazName, "foo-role")).Should(BeFalse())
+		Eventually(hasObject(ctx, api.RoleResource, barName, "foo-role")).Should(BeFalse())
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "foo-role")).Should(BeFalse())
 
 		// Verify the CannotPropagate event from source object.
 		Eventually(hasEvent(ctx, fooName, "foo-role", api.EventCannotPropagate)).Should(Equal(true))
@@ -507,27 +507,27 @@ var _ = Describe("Secret", func() {
 		// that events are removed one hour after the last occurrence. Therefore, we
 		// should still see the CannotPropagate event after fixing the issue.
 		setFinalizer(ctx, fooName, "foo-role", false)
-		Eventually(hasObject(ctx, "Role", barName, "foo-role")).Should(BeTrue())
-		Expect(objectInheritedFrom(ctx, "Role", barName, "foo-role")).Should(Equal(fooName))
-		Eventually(hasObject(ctx, "Role", bazName, "foo-role")).Should(BeTrue())
-		Expect(objectInheritedFrom(ctx, "Role", bazName, "foo-role")).Should(Equal(fooName))
+		Eventually(hasObject(ctx, api.RoleResource, barName, "foo-role")).Should(BeTrue())
+		Expect(objectInheritedFrom(ctx, api.RoleResource, barName, "foo-role")).Should(Equal(fooName))
+		Eventually(hasObject(ctx, api.RoleResource, bazName, "foo-role")).Should(BeTrue())
+		Expect(objectInheritedFrom(ctx, api.RoleResource, bazName, "foo-role")).Should(Equal(fooName))
 		Eventually(hasEvent(ctx, fooName, "foo-role", api.EventCannotPropagate)).Should(Equal(true))
 	})
 
 	It("shouldn't delete a descendant source object with the same name if the sync mode is 'Remove'", func() {
-		addToHNCConfig(ctx, "v1", "Secret", api.Remove)
+		addToHNCConfig(ctx, "", "secrets", api.Remove)
 		// Set tree as bar -> foo(root).
 		setParent(ctx, barName, fooName)
-		makeObject(ctx, "Secret", barName, "bar-sec")
-		Eventually(hasObject(ctx, "Secret", barName, "bar-sec")).Should(BeTrue())
+		makeObject(ctx, "secrets", barName, "bar-sec")
+		Eventually(hasObject(ctx, "secrets", barName, "bar-sec")).Should(BeTrue())
 
 		// Create an object with the same name in the parent.
-		makeObject(ctx, "Secret", fooName, "bar-sec")
-		Eventually(hasObject(ctx, "Secret", fooName, "bar-sec")).Should(BeTrue())
+		makeObject(ctx, "secrets", fooName, "bar-sec")
+		Eventually(hasObject(ctx, "secrets", fooName, "bar-sec")).Should(BeTrue())
 		// Give the reconciler some time to remove the object if it's going to.
 		time.Sleep(500 * time.Millisecond)
 		// The source object in the child shouldn't be deleted since the type has 'Remove' mode.
-		Eventually(hasObject(ctx, "Secret", barName, "bar-sec")).Should(BeTrue())
+		Eventually(hasObject(ctx, "secrets", barName, "bar-sec")).Should(BeTrue())
 	})
 })
 

--- a/incubator/hnc/internal/validators/hncconfig.go
+++ b/incubator/hnc/internal/validators/hncconfig.go
@@ -7,13 +7,12 @@ import (
 
 	"github.com/go-logr/logr"
 	"k8s.io/api/admission/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/forest"
+	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/reconcilers"
 
 	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
 )
@@ -30,20 +29,21 @@ const (
 // +kubebuilder:webhook:path=/validate-hnc-x-k8s-io-v1alpha2-hncconfigurations,mutating=false,failurePolicy=fail,groups="hnc.x-k8s.io",resources=hncconfigurations,verbs=create;update;delete,versions=v1alpha2,name=hncconfigurations.hnc.x-k8s.io
 
 type HNCConfig struct {
-	Log       logr.Logger
-	Forest    *forest.Forest
-	validator gvkValidator
-	decoder   *admission.Decoder
+	Log        logr.Logger
+	Forest     *forest.Forest
+	translator grTranslator
+	decoder    *admission.Decoder
 }
 
-// gvkValidator checks if a resource exists. The check should typically be performed against the apiserver,
-// but need to be stubbed out during unit testing.
-type gvkValidator interface {
-	// Exists takes a GVK and returns an error if the GVK does not exist in the apiserver.
-	Exists(ctx context.Context, gvk schema.GroupVersionKind) error
+// grTranslator checks if a resource exists. The check should typically be
+// performed against the apiserver, but need to be stubbed out in unit testing.
+type grTranslator interface {
+	// GVKFor returns the mapping GVK for a GR if it exists in the apiserver. If
+	// it doesn't exist, return the error.
+	GVKFor(gr schema.GroupResource) (schema.GroupVersionKind, error)
 }
 
-type gvkSet map[schema.GroupVersionKind]bool
+type gvkSet map[schema.GroupVersionKind]api.SynchronizationMode
 
 func (c *HNCConfig) Handle(ctx context.Context, req admission.Request) admission.Response {
 	if isHNCServiceAccount(&req.AdmissionRequest.UserInfo) {
@@ -76,83 +76,73 @@ func (c *HNCConfig) Handle(ctx context.Context, req admission.Request) admission
 // handle implements the validation logic of this validator for Create and Update operations,
 // allowing it to be more easily unit tested (ie without constructing a full admission.Request).
 func (c *HNCConfig) handle(ctx context.Context, inst *api.HNCConfiguration) admission.Response {
+	ts := gvkSet{}
+	// Convert all valid types from GR to GVK. If any type is invalid, e.g. not
+	// exist in the apiserver, wrong configuration, deny the request.
+	if rp := c.validateTypes(inst, ts); !rp.Allowed {
+		return rp
+	}
+
+	// Lastly, check if changing a type to "Propagate" mode would cause
+	// overwriting user-created objects.
+	return c.checkForest(inst, ts)
+}
+
+func (c *HNCConfig) validateTypes(inst *api.HNCConfiguration, ts gvkSet) admission.Response {
 	roleExist := false
 	roleBindingExist := false
-	ts := gvkSet{}
 	for _, t := range inst.Spec.Types {
-		if rp := c.isTypeConfigured(t, ts); !rp.Allowed {
-			return rp
+		// Validate the type exists in the apiserver. If yes, convert GR to GVK. We
+		// use GVK because we will need to checkForest() later to avoid source
+		// overwriting conflict (forest uses GVK as the key for object reconcilers).
+		gr := schema.GroupResource{Group: t.Group, Resource: t.Resource}
+		gvk, err := c.translator.GVKFor(gr)
+		if err != nil {
+			return deny(metav1.StatusReasonInvalid,
+				fmt.Sprintf("Cannot find the %s in the apiserver with error: %s", gr, err.Error()))
 		}
 
-		if c.isRBAC(t, "Role") {
-			if rp := c.validateRBAC(t.Mode, "Role"); !rp.Allowed {
-				return rp
-			}
+		// Validate if the configuration of a type already exists. Each type should
+		// only have one configuration.
+		if _, exists := ts[gvk]; exists {
+			return deny(metav1.StatusReasonInvalid, fmt.Sprintf("Duplicate configurations for %s", gvk))
+		}
+		ts[gvk] = t.Mode
+
+		// ValidateThe mode of Role and RoleBinding should be either unset or set to
+		// the propagate mode.
+		if t.Group == api.RBACGroup && t.Resource == api.RoleResource {
 			roleExist = true
-		} else if c.isRBAC(t, "RoleBinding") {
-			if rp := c.validateRBAC(t.Mode, "RoleBinding"); !rp.Allowed {
-				return rp
+			if t.Mode != api.Propagate && t.Mode != "" {
+				return deny(metav1.StatusReasonInvalid, fmt.Sprintf("Invalid mode of %s; current mode: %s; expected mode %s", t.Resource, t.Mode, api.Propagate))
 			}
+		}
+
+		if t.Group == api.RBACGroup && t.Resource == api.RoleBindingResource {
 			roleBindingExist = true
-		} else {
-			if rp := c.validateType(ctx, t, ts); !rp.Allowed {
-				return rp
+			if t.Mode != api.Propagate && t.Mode != "" {
+				return deny(metav1.StatusReasonInvalid, fmt.Sprintf("Invalid mode of %s; current mode: %s; expected mode %s", t.Resource, t.Mode, api.Propagate))
 			}
 		}
 	}
+	// Validate Role and RoleBinding exists in the Spec.
+	// TODO this validation will be removed when we remove the configuration from
+	//  Spec and only show them in the status.
 	if !roleExist {
 		return deny(metav1.StatusReasonInvalid, "Configuration for Role is missing")
 	}
 	if !roleBindingExist {
 		return deny(metav1.StatusReasonInvalid, "Configuration for RoleBinding is missing")
 	}
-
-	// Lastly, check if changing a type to "Propagate" mode would cause
-	// overwriting user-created objects.
-	return c.checkForest(inst)
-}
-
-// Validate if the configuration of a type already exists. Each type should only have one configuration.
-func (c *HNCConfig) isTypeConfigured(t api.TypeSynchronizationSpec, ts gvkSet) admission.Response {
-	gvk := schema.FromAPIVersionAndKind(t.APIVersion, t.Kind)
-	if exists := ts[gvk]; exists {
-		return deny(metav1.StatusReasonInvalid, fmt.Sprintf("Duplicate configurations for %s", gvk))
-	}
-	ts[gvk] = true
 	return allow("")
 }
 
-func (c *HNCConfig) isRBAC(t api.TypeSynchronizationSpec, kind string) bool {
-	return t.APIVersion == "rbac.authorization.k8s.io/v1" && t.Kind == kind
-}
-
-// The mode of Role and RoleBinding should be either unset or set to the propagate mode.
-func (c *HNCConfig) validateRBAC(mode api.SynchronizationMode, kind string) admission.Response {
-	if mode == api.Propagate || mode == "" {
-		return allow("")
-	}
-	return deny(metav1.StatusReasonInvalid, fmt.Sprintf("Invalid mode of %s; current mode: %s; expected mode %s", kind, mode, api.Propagate))
-}
-
-// validateType validates a non-RBAC type.
-func (c *HNCConfig) validateType(ctx context.Context, t api.TypeSynchronizationSpec, ts gvkSet) admission.Response {
-	gvk := schema.FromAPIVersionAndKind(t.APIVersion, t.Kind)
-
-	// Validate if the GVK exists in the apiserver.
-	if err := c.validator.Exists(ctx, gvk); err != nil {
-		return deny(metav1.StatusReasonInvalid,
-			fmt.Sprintf("Cannot find the %s in the apiserver with error: %s", gvk, err.Error()))
-	}
-
-	return allow("")
-}
-
-func (c *HNCConfig) checkForest(inst *api.HNCConfiguration) admission.Response {
+func (c *HNCConfig) checkForest(inst *api.HNCConfiguration, ts gvkSet) admission.Response {
 	c.Forest.Lock()
 	defer c.Forest.Unlock()
 
 	// Get types that are changed from other modes to "Propagate" mode.
-	gvks := c.getNewPropagateTypes(inst)
+	gvks := c.getNewPropagateTypes(ts)
 
 	// Check if user-created objects would be overwritten by these mode changes.
 	for gvk, _ := range gvks {
@@ -203,19 +193,19 @@ func (c *HNCConfig) checkConflictsForTree(gvk schema.GroupVersionKind, ao ancest
 
 // getNewPropagateTypes returns a set of types that are changed from other modes
 // to `Propagate` mode.
-func (c *HNCConfig) getNewPropagateTypes(inst *api.HNCConfiguration) gvkSet {
+func (c *HNCConfig) getNewPropagateTypes(ts gvkSet) gvkSet {
 	// Get all "Propagate" mode types in the new configuration.
 	newPts := gvkSet{}
-	for _, t := range inst.Spec.Types {
-		if t.Mode == api.Propagate {
-			gvk := schema.FromAPIVersionAndKind(t.APIVersion, t.Kind)
-			newPts[gvk] = true
+	for gvk, mode := range ts {
+		if mode == api.Propagate {
+			newPts[gvk] = api.Propagate
 		}
 	}
 
 	// Remove all existing "Propagate" mode types in the forest (current configuration).
 	for _, t := range c.Forest.GetTypeSyncers() {
-		if t.GetMode() == api.Propagate && newPts[t.GetGVK()] {
+		_, exist := newPts[t.GetGVK()]
+		if t.GetMode() == api.Propagate && exist {
 			delete(newPts, t.GetGVK())
 		}
 	}
@@ -247,40 +237,24 @@ func (a ancestorObjects) top(onm string) string {
 	return a[onm][0]
 }
 
-// realGVKValidator implements gvkValidator, and is not used during unit tests.
-type realGVKValidator struct {
+// realGRTranslator implements grTranslator, and is not used during unit tests.
+type realGRTranslator struct {
 	config *rest.Config
 }
 
-// Exists validates if a given GVK exists in the apiserver. The function uses a
-// discovery client to find a matching resource for the GVK. It returns an error
-// if it doesn't exist and returns nil if it does exist.
-func (r *realGVKValidator) Exists(ctx context.Context, gvk schema.GroupVersionKind) error {
-	dc, err := discovery.NewDiscoveryClientForConfig(r.config)
+// GVKFor searches a given GR in the apiserver and returns the mapping GVK. It
+// returns an empty GVK and an error if the GR doesn't exist.
+func (r *realGRTranslator) GVKFor(gr schema.GroupResource) (schema.GroupVersionKind, error) {
+	allRes, err := reconcilers.GetAllResources(r.config)
 	if err != nil {
-		// Fail close if we cannot create discovery client.
-		return err
+		return schema.GroupVersionKind{}, err
 	}
 
-	resources, err := dc.ServerResourcesForGroupVersion(gvk.GroupVersion().String())
-	if err != nil {
-		// No matching GV found.
-		return err
-	}
-
-	// The GV exists. Look for the matching kind now.
-	for _, resource := range resources.APIResources {
-		if resource.Kind == gvk.Kind {
-			return nil
-		}
-	}
-
-	// No matching kind. Use the same error message when the GV is not found above.
-	return errors.NewBadRequest("the server could not find the requested resource")
+	return reconcilers.GVKFor(gr, allRes)
 }
 
 func (c *HNCConfig) InjectConfig(cf *rest.Config) error {
-	c.validator = &realGVKValidator{config: cf}
+	c.translator = &realGRTranslator{config: cf}
 	return nil
 }
 

--- a/incubator/hnc/test/e2e/demo_test.go
+++ b/incubator/hnc/test/e2e/demo_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Demo", func() {
 
 	It("Should propagate different types", func() {
 		// ignore Secret in case this demo is run twice and the secret has been set to 'Propagate'
-		MustRun("kubectl hns config set-type --apiVersion v1 --kind Secret Ignore")
+		MustRun("kubectl hns config set-type --resource secrets Ignore")
 		MustRun("kubectl create ns", nsOrg)
 		MustRun("kubectl hns create", nsTeamA, "-n", nsOrg)
 		MustRun("kubectl hns create", nsTeamB, "-n", nsOrg)
@@ -87,7 +87,7 @@ var _ = Describe("Demo", func() {
 		time.Sleep(2 * time.Second)
 		// secret does not show up in service-1 because we haven’t configured HNC to propagate secrets in HNCConfiguration.
 		RunShouldNotContain("my-creds", defTimeout, "kubectl -n", nsService1, "get secrets")
-		MustRun("kubectl hns config set-type --apiVersion v1 --kind Secret Propagate --force")
+		MustRun("kubectl hns config set-type --resource secrets Propagate --force")
 		// this command is not needed here, just to check that user can run it without error
 		MustRun("kubectl get hncconfiguration config -oyaml")
 		RunShouldContain("my-creds", defTimeout, "kubectl -n", nsService1, "get secrets")
@@ -136,7 +136,7 @@ spec:
 		defer RemoveFile(filename)
 		MustRun("kubectl apply -f", filename)
 		// ensure this policy can be propagated to its descendants
-		MustRun("kubectl hns config set-type --apiVersion networking.k8s.io/v1 --kind NetworkPolicy Propagate --force")
+		MustRun("kubectl hns config set-type --group networking.k8s.io --resource networkpolicies Propagate --force")
 		expected := "deny-from-other-namespaces"
 		RunShouldContain(expected, defTimeout, "kubectl get netpol -n", nsOrg)
 		RunShouldContain(expected, defTimeout, "kubectl get netpol -n", nsTeamA)

--- a/incubator/hnc/test/e2e/kubectl_test.go
+++ b/incubator/hnc/test/e2e/kubectl_test.go
@@ -7,10 +7,10 @@ import (
 
 var _ = Describe("HNS set-config", func() {
 	It("Should use '--force' flag to change from 'Ignore' to 'Propagate'", func() {
-		MustRun("kubectl hns config set-type --apiVersion v1 --kind Secret Ignore")
-		MustNotRun("kubectl hns config set-type --apiVersion v1 --kind Secret Propagate")
-		MustRun("kubectl hns config set-type --apiVersion v1 --kind Secret Propagate --force")
+		MustRun("kubectl hns config set-type --resource secrets Ignore")
+		MustNotRun("kubectl hns config set-type --resource secrets Propagate")
+		MustRun("kubectl hns config set-type --resource secrets Propagate --force")
 		// check that we don't need '--force' flag when changing it back
-		MustRun("kubectl hns config set-type --apiVersion v1 --kind Secret Ignore")
+		MustRun("kubectl hns config set-type --resource secrets Ignore")
 	})
 })


### PR DESCRIPTION
In v1alpha2, we will replace the `apiVersion` and `kind` fields in the
hncconfig spec with `group` and `resource` to use restmapper lookup to
see if the type exists and remove version in the spec.

Still keep the object reconcilers and in-memory forest to use GVK. In
HNCConfig reconciler and validator, always get the mapping from GR to
GVK first so it can check forest or create object reconcilers with GVK.

Add `version` field in the HNCConfig status to show users which version
is picked. Add `TypeNotFound` condition for HNCConfig when the type is
not found, which was previously reported with
`ObjectReconcilerCreationFailed`. `ObjectReconcilerCreationFailed` will
only be for errors happened when creating the reconciler.

Hack the CRD conversion with string manipulation from `apiVersion` to
`group` and `kind` to `resource`.

Tested by manual testing on GKE cluster, `make test` and `make
test-conversion`. `make test-e2e` passed eventually (had some failure
when running all tests and then `FIt` the failed tests and they all
passed).

Part of #868 