### PR TITLE
kubectl hns config set-type example: `Error: unknown flag:` failed due to case sensitive

### DIFF
--- a/incubator/hnc/internal/kubectl/configset.go
+++ b/incubator/hnc/internal/kubectl/configset.go
@@ -29,9 +29,9 @@ var setTypeCmd = &cobra.Command{
 		api.Propagate, api.Remove, api.Ignore),
 	Short: "Sets the HNC configuration of a specific resources type",
 	Example: fmt.Sprintf("  # Set configuration of a core type\n" +
-		"  kubectl hns config set-type --apiVersion v1 --kind Secret ignore\n\n" +
+		"  kubectl hns config set-type --apiVersion v1 --kind Secret Ignore\n\n" +
 		"  # Set configuration of a custom type\n" +
-		"  kubectl hns config set-type --apiversion stable.example.com/v1 --kind CronTab propagate"),
+		"  kubectl hns config set-type --apiVersion stable.example.com/v1 --kind CronTab Propagate"),
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		mode := api.SynchronizationMode(args[0])


### PR DESCRIPTION

This PR fix kubectl hns config set-type's example case-sensitive issue. 
```
✘ bee@thebees  ~   kubectl hns config set-type --apiversion stable.example.com/v1 --kind CronTab propagate
Error: unknown flag: --apiversion
Usage:
  kubectl-hns config set-type --apiVersion X --kind Y <Propagate|Remove|Ignore> [flags]

Examples:
  # Set configuration of a core type
  kubectl hns config set-type --apiVersion v1 --kind Secret ignore

  # Set configuration of a custom type
  kubectl hns config set-type --apiversion stable.example.com/v1 --kind CronTab propagate

Flags:
      --apiVersion string   API version of the kind
  -f, --force               Force to set the propagation mode
  -h, --help                help for set-type
      --kind string         Kind to be configured
...
```