### PR TITLE
Update "inheritedFrom" label to "inherited-from"

### DIFF
--- a/incubator/hnc/api/v1alpha2/hierarchy_types.go
+++ b/incubator/hnc/api/v1alpha2/hierarchy_types.go
@@ -32,7 +32,7 @@ const (
 // Constants for labels and annotations
 const (
 	MetaGroup                 = "hnc.x-k8s.io"
-	LabelInheritedFrom        = MetaGroup + "/inheritedFrom"
+	LabelInheritedFrom        = MetaGroup + "/inherited-from"
 	FinalizerHasSubnamespace  = MetaGroup + "/hasSubnamespace"
 	LabelTreeDepthSuffix      = ".tree." + MetaGroup + "/depth"
 	AnnotationManagedBy       = MetaGroup + "/managed-by"

--- a/incubator/hnc/internal/reconcilers/test_helpers_test.go
+++ b/incubator/hnc/internal/reconcilers/test_helpers_test.go
@@ -320,7 +320,7 @@ func objectInheritedFrom(ctx context.Context, kind string, nsName, name string) 
 	if inst.GetLabels() == nil {
 		return ""
 	}
-	lif, _ := inst.GetLabels()["hnc.x-k8s.io/inheritedFrom"]
+	lif, _ := inst.GetLabels()[api.LabelInheritedFrom]
 	return lif
 }
 

--- a/incubator/hnc/test/e2e/demo_test.go
+++ b/incubator/hnc/test/e2e/demo_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Demo", func() {
 		RunShouldContain(nsService1, propogationTimeout, "kubectl hns describe", nsTeamA)
 
 		// Now, if we check service-1 again, we’ll see all the rolebindings we expect:
-		RunShouldContainMultiple([]string{"hnc.x-k8s.io/inheritedFrom=acme-org", "hnc.x-k8s.io/inheritedFrom=team-a"},
+		RunShouldContainMultiple([]string{"hnc.x-k8s.io/inherited-from=acme-org", "hnc.x-k8s.io/inherited-from=team-a"},
 			propogationTimeout, "kubectl -n", nsService1, "describe roles")
 		RunShouldContainMultiple([]string{"acme-org-sre", "team-a-sre"}, propogationTimeout, "kubectl -n", nsService1, "get rolebindings")
 


### PR DESCRIPTION
Update the inheritedFrom label added to all propagated objects by HNC.

The object reconcilers don't need to update the label on each
propagated objects because they will be treated as conflicting source
and get overwritten.

Add conversion tests and some corner cases. Refactor some applying of
manifests.

Tested by 'make test', focused 'make test-e2e' and 'make
test-conversion' on the label change. Tested manually that after
upgrading, all the labels got overwritten with the new label.

Part of #868 