### PR TITLE
Fix e2e tests after conditions updates

### DIFF
--- a/incubator/hnc/pkg/testutils/testutils.go
+++ b/incubator/hnc/pkg/testutils/testutils.go
@@ -193,7 +193,7 @@ func runShouldNotContainMultiple(offset int, substrs []string, seconds float64, 
 
 		for _, substr := range substrs {
 			if strings.Contains(stdout, substr) == true {
-				return "produced the undesired output: "+substr
+				return fmt.Sprintf("included the undesired output %q:\n%s", substr, stdout)
 			}
 		}
 

--- a/incubator/hnc/test/e2e/issues_test.go
+++ b/incubator/hnc/test/e2e/issues_test.go
@@ -146,8 +146,8 @@ var _ = Describe("Issues", func() {
 		MustNotRun("kubectl hns tree", nsParent)
 		MustNotRun("kubectl hns tree", nsSub1)
 		MustNotRun("kubectl hns tree", nsSub2)
-		RunShouldContain("ActivitiesHalted: ParentMissing", defTimeout, "kubectl hns tree", nsChild)
-		RunShouldContain("ActivitiesHalted: AncestorHaltActivities", defTimeout, "kubectl hns describe", nsSubChild)
+		RunShouldContain("ActivitiesHalted (ParentMissing)", defTimeout, "kubectl hns tree", nsChild)
+		RunShouldContain("ActivitiesHalted (AncestorHaltActivities)", defTimeout, "kubectl hns describe", nsSubChild)
 	})
 
 	It("Should have ParentMissing condition when parent namespace is deleted - issue #716", func() {
@@ -158,7 +158,7 @@ var _ = Describe("Issues", func() {
 		// Test: Remove parent namespace 'a'
 		// Expected: b should have 'ParentMissing' condition
 		MustRun("kubectl delete ns", nsParent)
-		RunShouldContain("ActivitiesHalted: ParentMissing", defTimeout, "kubectl hns describe", nsChild)
+		RunShouldContain("ActivitiesHalted (ParentMissing)", defTimeout, "kubectl hns describe", nsChild)
 	})
 
 	It("Should delete namespace with ParentMissing condition - issue #716", func() {
@@ -168,7 +168,7 @@ var _ = Describe("Issues", func() {
 		MustRun("kubectl hns set", nsChild, "--parent", nsParent)
 		// create and verify ParentMissing condition
 		MustRun("kubectl delete ns", nsParent)
-		RunShouldContain("ActivitiesHalted: ParentMissing", defTimeout, "kubectl hns describe", nsChild)
+		RunShouldContain("ActivitiesHalted (ParentMissing)", defTimeout, "kubectl hns describe", nsChild)
 		// test: delete namespace
 		MustRun("kubectl delete ns", nsChild)
 	})


### PR DESCRIPTION
kubectl-hns was changed in #1184 but the e2e tests were still expecting
the old output; this change updates the e2e tests. In addition, #1171
moved object conditions to events, and those events included names from
an old ancestor, confusing the demo test that was expecting the old
ancestor to _not_ appear; this change fixes that too.

Tested: e2e tests failed but now pass