### PR TITLE
Add validator check for `treeSelect`

### DIFF
--- a/incubator/hnc/internal/validators/object_test.go
+++ b/incubator/hnc/internal/validators/object_test.go
@@ -336,6 +336,79 @@ func TestUserChanges(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		name: "Deny creation of object with invalid treeSelect annotation",
+		fail: true,
+		inst: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						api.AnnotationTreeSelector: "foo, $bar",
+					},
+				},
+			},
+		},
+	}, {
+		name: "Allow creation of object with valid treeSelect annotation",
+		fail: false,
+		inst: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						api.AnnotationTreeSelector: "foo, !bar",
+					},
+				},
+			},
+		},
+	}, {
+		name: "Deny creation of object with invalid selector and valid treeSelect annotation",
+		fail: true,
+		inst: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						api.AnnotationSelector:     "$foo",
+						api.AnnotationTreeSelector: "!bar",
+					},
+				},
+			},
+		},
+	}, {
+		name: "Deny creation of object with valid selector and invalid treeSelect annotation",
+		fail: true,
+		inst: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						api.AnnotationSelector:     "foo",
+						api.AnnotationTreeSelector: "$bar",
+					},
+				},
+			},
+		},
+	}, {
+		name: "Allow creation of object with valid selector and treeSelect annotation",
+		fail: false,
+		inst: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						api.AnnotationSelector:     "foo",
+						api.AnnotationTreeSelector: "!bar",
+					},
+				},
+			},
+		},
 	}}
 
 	for _, tc := range tests {


### PR DESCRIPTION
We check if the raw string input from user is a valid DNS label. If this
is a valid DNS label but couldn't be parsed as a selector for some
reason, we will show user that it's an internal error, so that user can
reach us for help. In theory this should never happen.

Tested:
```
$k delete role test -n a
k create role test -n a --verb=update --resource=deployments
k annotate role test -n a "propagate.hnc.x-k8s.io/treeSelect"="1234567890123456789012345678901234567890123456789012345678901234567890"

role.rbac.authorization.k8s.io "test" deleted
role.rbac.authorization.k8s.io/test created
Error from server (BadRequest): admission webhook "objects.hnc.x-k8s.io" denied the request: Invalid HNC "propagate.hnc.x-k8s.io/treeSelect" value: 1234567890123456789012345678901234567890123456789012345678901234567890 is not a valid namespace name, must be no more than 63 characters
```