### PR TITLE
Omit enforced RBAC resources in the HNCConfig spec

### DIFF
--- a/incubator/hnc/api/v1alpha1/hnc_config_conversion.go
+++ b/incubator/hnc/api/v1alpha1/hnc_config_conversion.go
@@ -62,7 +62,12 @@ func (src *HNCConfiguration) ConvertTo(dstRaw conversion.Hub) error {
 			dtm = v1a2.Ignore
 		}
 		dr.Mode = dtm
-		dstSpecRscs = append(dstSpecRscs, dr)
+		// We will only convert non-enforced types since in v1a2 we removed the
+		// enforced types from spec. Having enforced types configured in the spec
+		// would cause 'MultipleConfigurationsForType' condition.
+		if !v1a2.IsEnforcedType(dr) {
+			dstSpecRscs = append(dstSpecRscs, dr)
+		}
 	}
 	dst.Spec.Resources = dstSpecRscs
 

--- a/incubator/hnc/api/v1alpha2/hnc_config.go
+++ b/incubator/hnc/api/v1alpha2/hnc_config.go
@@ -61,8 +61,25 @@ const (
 	ReasonUnknown = "Unknown"
 )
 
-// ResourceSpec defines the desired synchronization state of a
-// specific resource.
+// EnforcedTypes are the types enforced by HNC that they should not show up in
+// the spec and only in the status. Any configurations of the enforced types in
+// the spec would cause 'MultipleConfigurationsForType' condition.
+var EnforcedTypes = []ResourceSpec{
+	{Group: RBACGroup, Resource: RoleResource, Mode: Propagate},
+	{Group: RBACGroup, Resource: RoleBindingResource, Mode: Propagate},
+}
+
+// IsEnforcedType returns true if configuration is on an enforced type.
+func IsEnforcedType(grm ResourceSpec) bool {
+	for _, tp := range EnforcedTypes {
+		if tp.Group == grm.Group && tp.Resource == grm.Resource {
+			return true
+		}
+	}
+	return false
+}
+
+// ResourceSpec defines the desired synchronization state of a specific resource.
 type ResourceSpec struct {
 	// Group of the resource defined below. This is used to unambiguously identify
 	// the resource. It may be omitted for core resources (e.g. "secrets").
@@ -130,7 +147,10 @@ type HNCConfiguration struct {
 
 // HNCConfigurationSpec defines the desired state of HNC configuration.
 type HNCConfigurationSpec struct {
-	// Resources defines the cluster-wide settings for resource synchronization. To learn more, see
+	// Resources defines the cluster-wide settings for resource synchronization.
+	// Note that 'roles' and 'rolebindings' are pre-configured by HNC with
+	// 'Propagate' mode and are omitted in the spec. Any configuration of 'roles'
+	// or 'rolebindings' are not allowed. To learn more, see
 	// https://github.com/kubernetes-sigs/multi-tenancy/blob/master/incubator/hnc/docs/user-guide/how-to.md#admin-types
 	Resources []ResourceSpec `json:"resources,omitempty"`
 }

--- a/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
+++ b/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
@@ -152,7 +152,7 @@ spec:
             description: HNCConfigurationSpec defines the desired state of HNC configuration.
             properties:
               resources:
-                description: Resources defines the cluster-wide settings for resource synchronization. To learn more, see https://github.com/kubernetes-sigs/multi-tenancy/blob/master/incubator/hnc/docs/user-guide/how-to.md#admin-types
+                description: Resources defines the cluster-wide settings for resource synchronization. Note that 'roles' and 'rolebindings' are pre-configured by HNC with 'Propagate' mode and are omitted in the spec. Any configuration of 'roles' or 'rolebindings' are not allowed. To learn more, see https://github.com/kubernetes-sigs/multi-tenancy/blob/master/incubator/hnc/docs/user-guide/how-to.md#admin-types
                 items:
                   description: ResourceSpec defines the desired synchronization state of a specific resource.
                   properties:

--- a/incubator/hnc/internal/config/default_config.go
+++ b/incubator/hnc/internal/config/default_config.go
@@ -1,9 +1,5 @@
 package config
 
-import (
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
-)
-
 // The EX map is used by reconcilers and validators to exclude
 // namespaces that shouldn't be reconciled or validated. We explicitly
 // exclude some default namespaces with constantly changing objects.
@@ -13,17 +9,4 @@ var EX = map[string]bool{
 	"kube-public":  true,
 	"hnc-system":   true,
 	"cert-manager": true,
-}
-
-// GetDefaultRoleSpec and GetDefaultRoleBindingSpec create the default
-// configuration for Roles and RoleBindings respectively.
-// By default, HNC configuration should always propagate Roles and RoleBindings.
-// See details in http://bit.ly/hnc-type-configuration
-
-func GetDefaultRoleSpec() api.ResourceSpec {
-	return api.ResourceSpec{Group: api.RBACGroup, Resource: api.RoleResource, Mode: api.Propagate}
-}
-
-func GetDefaultRoleBindingSpec() api.ResourceSpec {
-	return api.ResourceSpec{Group: api.RBACGroup, Resource: api.RoleBindingResource, Mode: api.Propagate}
 }

--- a/incubator/hnc/internal/reconcilers/test_helpers_test.go
+++ b/incubator/hnc/internal/reconcilers/test_helpers_test.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/config"
 )
 
 // GVKs maps a resource to its corresponding GVK.
@@ -201,9 +200,7 @@ func resetHNCConfigToDefault(ctx context.Context) {
 		if err != nil {
 			return err
 		}
-		c.Spec = api.HNCConfigurationSpec{Resources: []api.ResourceSpec{
-			config.GetDefaultRoleSpec(),
-			config.GetDefaultRoleBindingSpec()}}
+		c.Spec.Resources = nil
 		c.Status.Resources = nil
 		c.Status.Conditions = nil
 		return k8sClient.Update(ctx, c)

--- a/incubator/hnc/internal/validators/hncconfig_test.go
+++ b/incubator/hnc/internal/validators/hncconfig_test.go
@@ -70,62 +70,15 @@ func TestRBACTypes(t *testing.T) {
 		allow   bool
 	}{
 		{
-			name: "Correct RBAC config with Propagate mode",
-			configs: []api.ResourceSpec{
-				{Group: api.RBACGroup, Resource: api.RoleResource, Mode: "Propagate"},
-				{Group: api.RBACGroup, Resource: api.RoleBindingResource, Mode: "Propagate"},
-			},
-			allow: true,
+			name:    "No redundant enforced resources configured",
+			configs: []api.ResourceSpec{},
+			allow:   true,
 		},
 		{
-			name: "Correct RBAC config with unset mode",
+			name: "Configure redundant enforced resources",
 			configs: []api.ResourceSpec{
-				{Group: api.RBACGroup, Resource: api.RoleResource},
-				{Group: api.RBACGroup, Resource: api.RoleBindingResource},
-			},
-			allow: true,
-		},
-		{
-			name: "Missing role",
-			configs: []api.ResourceSpec{
-				{Group: api.RBACGroup, Resource: api.RoleBindingResource, Mode: "Propagate"},
-			},
-			allow: false,
-		}, {
-			name: "Missing rolebinding",
-			configs: []api.ResourceSpec{
-				{Group: api.RBACGroup, Resource: api.RoleResource, Mode: "Propagate"},
-			},
-			allow: false,
-		}, {
-			name: "Incorrect role mode",
-			configs: []api.ResourceSpec{
-				{Group: api.RBACGroup, Resource: api.RoleResource, Mode: "Ignore"},
-				{Group: api.RBACGroup, Resource: api.RoleBindingResource, Mode: "Propagate"},
-			},
-			allow: false,
-		}, {
-			name: "Incorrect rolebinding mode",
-			configs: []api.ResourceSpec{
-				{Group: api.RBACGroup, Resource: api.RoleResource, Mode: "Propagate"},
-				{Group: api.RBACGroup, Resource: api.RoleBindingResource, Mode: "Ignore"},
-			},
-			allow: false,
-		}, {
-			name: "Duplicate RBAC resources with different modes",
-			configs: []api.ResourceSpec{
-				{Group: api.RBACGroup, Resource: api.RoleResource, Mode: "Propagate"},
-				{Group: api.RBACGroup, Resource: api.RoleResource},
-				{Group: api.RBACGroup, Resource: api.RoleBindingResource, Mode: "Propagate"},
-			},
-			allow: false,
-		},
-		{
-			name: "Duplicate RBAC resources with the same mode",
-			configs: []api.ResourceSpec{
-				{Group: api.RBACGroup, Resource: api.RoleResource, Mode: "Propagate"},
-				{Group: api.RBACGroup, Resource: api.RoleResource, Mode: "Propagate"},
-				{Group: api.RBACGroup, Resource: api.RoleBindingResource, Mode: "Propagate"},
+				{Group: api.RBACGroup, Resource: api.RoleResource, Mode: api.Propagate},
+				{Group: api.RBACGroup, Resource: api.RoleBindingResource, Mode: api.Propagate},
 			},
 			allow: false,
 		},
@@ -156,8 +109,6 @@ func TestNonRBACTypes(t *testing.T) {
 		{
 			name: "Correct Non-RBAC resources config",
 			configs: []api.ResourceSpec{
-				{Group: api.RBACGroup, Resource: api.RoleResource, Mode: "Propagate"},
-				{Group: api.RBACGroup, Resource: api.RoleBindingResource, Mode: "Propagate"},
 				{Group: "", Resource: "secrets", Mode: "Ignore"},
 				{Group: "", Resource: "resourcequotas"},
 			},
@@ -167,8 +118,6 @@ func TestNonRBACTypes(t *testing.T) {
 		{
 			name: "Resource does not exist",
 			configs: []api.ResourceSpec{
-				{Group: api.RBACGroup, Resource: api.RoleResource, Mode: "Propagate"},
-				{Group: api.RBACGroup, Resource: api.RoleBindingResource, Mode: "Propagate"},
 				// "crontabs" resource does not exist in ""
 				{Group: "", Resource: "crontabs", Mode: "Ignore"},
 			},
@@ -177,8 +126,6 @@ func TestNonRBACTypes(t *testing.T) {
 		}, {
 			name: "Duplicate resources with different modes",
 			configs: []api.ResourceSpec{
-				{Group: api.RBACGroup, Resource: api.RoleResource, Mode: "Propagate"},
-				{Group: api.RBACGroup, Resource: api.RoleBindingResource, Mode: "Propagate"},
 				{Group: "", Resource: "secrets", Mode: "Ignore"},
 				{Group: "", Resource: "secrets", Mode: "Propagate"},
 			},
@@ -187,8 +134,6 @@ func TestNonRBACTypes(t *testing.T) {
 		}, {
 			name: "Duplicate resources with the same mode",
 			configs: []api.ResourceSpec{
-				{Group: api.RBACGroup, Resource: api.RoleResource, Mode: "Propagate"},
-				{Group: api.RBACGroup, Resource: api.RoleBindingResource, Mode: "Propagate"},
 				{Group: "", Resource: "secrets", Mode: "Ignore"},
 				{Group: "", Resource: "secrets", Mode: "Ignore"},
 			},
@@ -230,8 +175,6 @@ func TestPropagateConflict(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 			configs := []api.ResourceSpec{
-				{Group: api.RBACGroup, Resource: api.RoleResource, Mode: "Propagate"},
-				{Group: api.RBACGroup, Resource: api.RoleBindingResource, Mode: "Propagate"},
 				{Group: "", Resource: "secrets", Mode: "Propagate"}}
 			c := &api.HNCConfiguration{Spec: api.HNCConfigurationSpec{Resources: configs}}
 			c.Name = api.HNCConfigSingleton


### PR DESCRIPTION
Removed the roles and rolebindings resources from the HNCConfig spec,
and only show them in the status.

Remove the RBAC validation in the validator and the default RBAC
configurtion in the HNCConfig reconciler.

Update validator unit tests, reconciler integration tests and conversion
tests.

Tested manually on GKE and by 'make test' and 'make test-conversion'.

Fixes #1213 
Part of #868