### PR TITLE
Improve log messages

### DIFF
--- a/incubator/hnc/internal/reconcilers/hnc_config_test.go
+++ b/incubator/hnc/internal/reconcilers/hnc_config_test.go
@@ -122,7 +122,7 @@ var _ = Describe("HNCConfiguration", func() {
 
 		// The first configuration should be applied.
 		Eventually(getHNCConfigCondition(ctx, api.ConditionBadTypeConfiguration, api.ReasonMultipleConfigsForType)).
-			Should(ContainSubstring("secrets has multiple synchronization modes; all but one (%s) will be ignored.", api.Propagate))
+			Should(ContainSubstring("Multiple sync mode settings found for \"secrets\"; all but one (%q) will be ignored", api.Propagate))
 	})
 
 	It("should unset MultipleConfigurationsForType if extra configurations are later removed", func() {
@@ -131,7 +131,7 @@ var _ = Describe("HNCConfiguration", func() {
 		addToHNCConfig(ctx, "", "secrets", api.Remove)
 
 		Eventually(getHNCConfigCondition(ctx, api.ConditionBadTypeConfiguration, api.ReasonMultipleConfigsForType)).
-			Should(ContainSubstring("secrets has multiple synchronization modes; all but one (%s) will be ignored.", api.Propagate))
+			Should(ContainSubstring("Multiple sync mode settings found for \"secrets\"; all but one (%q) will be ignored", api.Propagate))
 
 		removeTypeConfigWithMode(ctx, "", "secrets", api.Remove)
 

--- a/incubator/hnc/internal/validators/anchor.go
+++ b/incubator/hnc/internal/validators/anchor.go
@@ -57,7 +57,11 @@ func (v *Anchor) Handle(ctx context.Context, req admission.Request) admission.Re
 	}
 
 	resp := v.handle(decoded)
-	log.V(1).Info("Handled", "allowed", resp.Allowed, "code", resp.Result.Code, "reason", resp.Result.Reason, "message", resp.Result.Message)
+	if !resp.Allowed {
+		log.Info("Denied", "code", resp.Result.Code, "reason", resp.Result.Reason, "message", resp.Result.Message)
+	} else {
+		log.V(1).Info("Allowed", "message", resp.Result.Message)
+	}
 	return resp
 }
 

--- a/incubator/hnc/internal/validators/hierarchy.go
+++ b/incubator/hnc/internal/validators/hierarchy.go
@@ -94,7 +94,7 @@ func (v *Hierarchy) Handle(ctx context.Context, req admission.Request) admission
 	if !resp.Allowed {
 		log.Info("Denied", "code", resp.Result.Code, "reason", resp.Result.Reason, "message", resp.Result.Message)
 	} else {
-		log.V(1).Info("Allowed")
+		log.V(1).Info("Allowed", "message", resp.Result.Message)
 	}
 	return resp
 }

--- a/incubator/hnc/internal/validators/namespace.go
+++ b/incubator/hnc/internal/validators/namespace.go
@@ -57,7 +57,11 @@ func (v *Namespace) Handle(ctx context.Context, req admission.Request) admission
 	}
 
 	resp := v.handle(decoded)
-	log.V(1).Info("Handled", "allowed", resp.Allowed, "code", resp.Result.Code, "reason", resp.Result.Reason, "message", resp.Result.Message)
+	if !resp.Allowed {
+		log.Info("Denied", "code", resp.Result.Code, "reason", resp.Result.Reason, "message", resp.Result.Message)
+	} else {
+		log.V(1).Info("Allowed", "message", resp.Result.Message)
+	}
 	return resp
 }
 

--- a/incubator/hnc/internal/validators/object.go
+++ b/incubator/hnc/internal/validators/object.go
@@ -85,12 +85,11 @@ func (o *Object) Handle(ctx context.Context, req admission.Request) admission.Re
 
 	// Run the actual logic.
 	resp := o.handle(ctx, log, req.Operation, inst, oldInst)
-
-	level := 1
 	if !resp.Allowed {
-		level = 0
+		log.Info("Denied", "code", resp.Result.Code, "reason", resp.Result.Reason, "message", resp.Result.Message)
+	} else {
+		log.V(1).Info("Allowed", "message", resp.Result.Message)
 	}
-	log.V(level).Info("Handled", "allowed", resp.Allowed, "code", resp.Result.Code, "reason", resp.Result.Reason, "message", resp.Result.Message)
 	return resp
 }
 

--- a/incubator/hnc/test/e2e/delete_crd_test.go
+++ b/incubator/hnc/test/e2e/delete_crd_test.go
@@ -33,9 +33,10 @@ var _ = Describe("When deleting CRDs", func() {
 		// set up
 		MustRun("kubectl create ns", nsParent)
 		MustRun("kubectl hns create", nsChild, "-n", nsParent)
-		// test
+		MustRun("kubectl get ns", nsChild)
+		// delete the CRD
 		MustRun("kubectl delete customresourcedefinition/subnamespaceanchors.hnc.x-k8s.io")
-		// verify
+		// verify that the child wasn't deleted with the CRDs
 		MustRun("kubectl get ns", nsChild)
 	})
 

--- a/incubator/hnc/test/e2e/demo_test.go
+++ b/incubator/hnc/test/e2e/demo_test.go
@@ -250,6 +250,6 @@ spec:
 			nsTeamA + "\n" +
 			"└── [s] " + nsService2
 		RunShouldContain(expected, defTimeout, "kubectl hns tree", nsTeamA)
-		RunShouldContain("ActivitiesHalted (ParentMissing): missing parent", defTimeout, "kubectl hns describe", nsStaging)
+		RunShouldContain("ActivitiesHalted (ParentMissing):", defTimeout, "kubectl hns describe", nsStaging)
 	})
 })


### PR DESCRIPTION
This change comes largely out of watching the TGIK HNC episode where the
user used the log messages to understand what HNC was doing, and I
realized the messages were spammy, unhelpful or misleading in many
cases. So this change tries to fix all those problems.

I closely watched the log messages while running the e2e tests and
either hid or fixed any messages that wouldn't appear to be at least
somewhat useful to an end user.

I also added a unique 64-bit reconcile ID to all log messages from all
reconcilers (except HNC Config, which is being modified in another PR so
we can come back to that). We previously did this only for the hierarchy
config reconciler; now we can track IDs for anchors and objects as well.

Finally, addressed #1220.

Tested: watched the logs as the e2e tests ran and was satisfied that
they're far less useless than they were in the past. All e2e tests pass.

Fixes #1220.