### PR TITLE
Add validator for none selector

### DIFF
--- a/incubator/hnc/internal/pkg/selectors/selectors.go
+++ b/incubator/hnc/internal/pkg/selectors/selectors.go
@@ -4,6 +4,7 @@ package selectors
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,6 +23,11 @@ func GetSelectorAnnotation(inst *unstructured.Unstructured) string {
 func GetTreeSelectorAnnotation(inst *unstructured.Unstructured) string {
 	annot := inst.GetAnnotations()
 	return annot[api.AnnotationTreeSelector]
+}
+
+func GetNoneSelectorAnnotation(inst *unstructured.Unstructured) string {
+	annot := inst.GetAnnotations()
+	return annot[api.AnnotationNoneSelector]
 }
 
 // GetTreeSelector is similar to a regular selector, except that it adds the LabelTreeDepthSuffix to every string
@@ -96,4 +102,25 @@ func getSelectorFromString(str string) (labels.Selector, error) {
 		return nil, err
 	}
 	return selector, nil
+}
+
+// GetNoneSelector returns true indicates that user do not want this object to be propagated
+func GetNoneSelector(inst *unstructured.Unstructured) (bool, error) {
+	noneSelectorStr := GetNoneSelectorAnnotation(inst)
+	// Empty string is treated as 'false'. In other selector cases, the empty string is auto converted to
+	// a selector that matches everything.
+	if noneSelectorStr == "" {
+		return false, nil
+	}
+	noneSelector, err := strconv.ParseBool(noneSelectorStr)
+	if err != nil {
+		// Returning false here in accordance to the Go standard
+		return false,
+			fmt.Errorf("invalid %s value: %w",
+				api.AnnotationNoneSelector,
+				err,
+			)
+
+	}
+	return noneSelector, nil
 }

--- a/incubator/hnc/internal/reconcilers/object_test.go
+++ b/incubator/hnc/internal/reconcilers/object_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Exceptions", func() {
 			// we choose not to propagate this object to any child namespace to protect any object in the child
 			// namespaces to be overwritten. Same for treeSelectors and noneSelector.
 			name:     "not propagate to any namespace with a bad selector",
-			selector: "random",
+			selector: "$foo",
 			want:     []string{},
 			notWant:  []string{c1, c2, c3},
 		}, {
@@ -73,7 +73,7 @@ var _ = Describe("Exceptions", func() {
 			notWant:      []string{c1, c2},
 		}, {
 			name:         "not propagate to any namespace with a bad treeSelector",
-			treeSelector: "random",
+			treeSelector: "$foo",
 			want:         []string{},
 			notWant:      []string{c1, c2, c3},
 		}, {
@@ -100,7 +100,7 @@ var _ = Describe("Exceptions", func() {
 			notWant:      []string{},
 		}, {
 			name:         "not propagate to any child namespace with a bad noneSelector",
-			noneSelector: "random",
+			noneSelector: "$foo",
 			want:         []string{},
 			notWant:      []string{c1, c2, c3},
 		}, {

--- a/incubator/hnc/internal/validators/object_test.go
+++ b/incubator/hnc/internal/validators/object_test.go
@@ -365,6 +365,34 @@ func TestUserChanges(t *testing.T) {
 			},
 		},
 	}, {
+		name: "Deny creation of object with invalid noneSelect annotation",
+		fail: true,
+		inst: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						api.AnnotationNoneSelector: "foo",
+					},
+				},
+			},
+		},
+	}, {
+		name: "Allow creation of object with valid noneSelect annotation",
+		fail: false,
+		inst: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						api.AnnotationNoneSelector: "true",
+					},
+				},
+			},
+		},
+	}, {
 		name: "Deny creation of object with invalid selector and valid treeSelect annotation",
 		fail: true,
 		inst: &unstructured.Unstructured{


### PR DESCRIPTION
Tested: go test -v ./internal/validator

```
=== RUN   TestUserChanges/Deny_creation_of_object_with_invalid_noneSelect_annotation
    object_test.go:387: Got code 400, reason "BadRequest", message "invalid propagate.hnc.x-k8s.io/none value, strconv.ParseBool: parsing \"foo\": invalid syntax"
=== RUN   TestUserChanges/Allow_creation_of_object_with_valid_noneSelect_annotation
    object_test.go:387: Got code 0, reason "", message "source object"
```