### PR TITLE
Reenable test for #1155

### DIFF
--- a/incubator/hnc/internal/forest/namespace.go
+++ b/incubator/hnc/internal/forest/namespace.go
@@ -111,9 +111,14 @@ func (ns *Namespace) clean() {
 	delete(ns.forest.namespaces, ns.name)
 }
 
-// UpdateAllowCascadingDeletion updates if this namespace allows cascading deletion.
-func (ns *Namespace) UpdateAllowCascadingDeletion(acd bool) {
+// UpdateAllowCascadingDeletion updates if this namespace allows cascading deletion. It returns true
+// if the value has changed, false otherwise.
+func (ns *Namespace) UpdateAllowCascadingDeletion(acd bool) bool {
+	if ns.allowCascadingDeletion == acd {
+		return false
+	}
 	ns.allowCascadingDeletion = acd
+	return true
 }
 
 // AllowsCascadingDeletion returns true if the namespace's or any of the ancestors'

--- a/incubator/hnc/internal/reconcilers/hierarchy_config.go
+++ b/incubator/hnc/internal/reconcilers/hierarchy_config.go
@@ -228,7 +228,10 @@ func (r *HierarchyConfigReconciler) syncWithForest(log logr.Logger, nsInst *core
 
 	// Sync other spec and spec-like info
 	r.syncAnchors(log, ns, anms)
-	ns.UpdateAllowCascadingDeletion(inst.Spec.AllowCascadingDeletion)
+	if ns.UpdateAllowCascadingDeletion(inst.Spec.AllowCascadingDeletion) {
+		// Added to help debug #1155 if it ever reoccurs
+		log.Info("Updated allowCascadingDeletion", "newValue", inst.Spec.AllowCascadingDeletion)
+	}
 
 	// Sync the status
 	inst.Status.Children = ns.ChildNames()

--- a/incubator/hnc/test/e2e/issues_test.go
+++ b/incubator/hnc/test/e2e/issues_test.go
@@ -245,7 +245,7 @@ var _ = Describe("Issues", func() {
 		MustRun("kubectl get rolebinding foo -n", nsChild, "-oyaml")
 	})
 
-	PIt("should reset allowCascadingDeletion value after the namespace is deleted and recreated - issue #1155", func() {
+	It("should reset allowCascadingDeletion value after the namespace is deleted and recreated - issue #1155", func() {
 		// Create a parent namespace and a subnamespace for it.
 		MustRun("kubectl create ns", nsParent)
 		MustRun("kubectl get ns", nsParent)
@@ -263,8 +263,10 @@ var _ = Describe("Issues", func() {
 		// Now recreate the parent again.
 		MustRun("kubectl create ns", nsParent)
 
-		// Verify the default is not set to "allowCascadingDeletion:true".
-		FieldShouldNotContain("hierarchyconfigurations.hnc.x-k8s.io", nsParent, "hierarchy", ".spec", "allowCascadingDeletion:true")
+		// Since nsParent is new, it should not have any kind of hierarchy config in it. So let's ensure
+		// that a 'get' fails. We'll get the full YAML so that if it succees, the _contents_ of the
+		// config will be in the failure log and we can see what's happened.
+		MustNotRun("kubectl get -oyaml hierarchyconfiguration hierarchy -n", nsParent)
 	})
 })
 


### PR DESCRIPTION
I wasn't able to get the original problem to reproduce itself, but I
added a log message and improve the test so that we can catch #1155 if
it ever reoccurs.

Tested: the newly enabled test passes with HNC as-is; if I break HNC to
manually re-enable allowCascadingDeletion, then the test fails as
expected. I also manually verified that the new log message is displayed
as expected.

Fixed #1155