### PR TITLE
correct ipv6 domain name format

### DIFF
--- a/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_native.go
+++ b/incubator/virtualcluster/pkg/controller/virtualcluster/master_provisioner_native.go
@@ -21,7 +21,6 @@ import (
 	"crypto/rsa"
 	"errors"
 	"fmt"
-	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -305,20 +304,15 @@ func (mpn *MasterProvisionerNative) createPKI(vc *tenancyv1alpha1.VirtualCluster
 	}
 	caGroup.APIServer = apiserverCAPair
 
-	finalAPIDomain := apiserverDomain
+	finalAPIAddress := apiserverDomain
 	if clusterIP != "" {
-		if strings.Contains(clusterIP, ":") {
-			// ipv6 domain
-			finalAPIDomain = "[" + clusterIP + "]"
-		} else {
-			finalAPIDomain = clusterIP
-		}
+		finalAPIAddress = clusterIP
 	}
 
 	// create kubeconfig for controller-manager
 	ctrlmgrKbCfg, err := kubeconfig.GenerateKubeconfig(
 		"system:kube-controller-manager",
-		vc.Name, finalAPIDomain, []string{}, rootCAPair)
+		vc.Name, finalAPIAddress, []string{}, rootCAPair)
 	if err != nil {
 		return err
 	}
@@ -326,7 +320,7 @@ func (mpn *MasterProvisionerNative) createPKI(vc *tenancyv1alpha1.VirtualCluster
 
 	// create kubeconfig for admin user
 	adminKbCfg, err := kubeconfig.GenerateKubeconfig(
-		"admin", vc.Name, finalAPIDomain,
+		"admin", vc.Name, finalAPIAddress,
 		[]string{"system:masters"}, rootCAPair)
 	if err != nil {
 		return err


### PR DESCRIPTION
Ipv4 and ipv6 URL domain name is different in format. Make vc-manager compatible with ipv6 only cluster