### PR TITLE
kubectl: enclose non-printing escape sequences with '\[' '\]'

### DIFF
--- a/incubator/virtualcluster/cmd/kubectl-vc/exec.go
+++ b/incubator/virtualcluster/cmd/kubectl-vc/exec.go
@@ -147,7 +147,7 @@ func enterVCShell(kbFilePath, ns, name string) error {
 	c := exec.Command(os.Getenv("SHELL"))
 	c.Env = append(os.Environ(),
 		fmt.Sprintf("KUBECONFIG=%v", kbFilePath),
-		fmt.Sprintf("PS1=[\\u@vc:\033[01;32m%s/%s\033[00m \\W]\\$ ", ns, name),
+		fmt.Sprintf("PS1=[\\u@vc:\\[\033[01;32m\\]%s/%s\\[\033[00m\\] \\W]\\$ ", ns, name),
 	)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout


### PR DESCRIPTION
fixes: #1232 

solution: https://superuser.com/questions/333564/reverse-history-search-in-bash-followed-by-arrow-keys-causes-cursor-to-display-a

Signed-off-by: zhuangqh <zhuangqhc@gmail.com>