### PR TITLE
Cap the backoff for the object reconciler to 10s

### DIFF
--- a/incubator/hnc/internal/reconcilers/object.go
+++ b/incubator/hnc/internal/reconcilers/object.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -29,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -765,6 +767,18 @@ func (r *ObjectReconciler) SetupWithManager(mgr ctrl.Manager, maxReconciles int)
 	target.SetGroupVersionKind(r.GVK)
 	opts := controller.Options{
 		MaxConcurrentReconciles: maxReconciles,
+
+		// Unlike the other HNC reconcilers, the object reconciler can easily be affected by objects
+		// that do not directly cause reconciliations when they're modified - see, e.g.,
+		// https://github.com/kubernetes-sigs/multi-tenancy/issues/1154. To address this, replace the
+		// default exponential backoff with one with a 10s cap.
+		//
+		// I wanted to pick five seconds since I feel like that's about how much time it would take you to check
+		// to see if something's wrong, realize it hasn't been propagated, and then try again. However,
+		// the default etcd timeout is 10s, which apparently is a more realistic measure of how K8s can
+		// behave under heavy load, so I raised it to 10s during the PR review. The _average_ delay seen
+		// by users should still be about 5s though.
+		RateLimiter: workqueue.NewItemExponentialFailureRateLimiter(250*time.Millisecond, 10*time.Second),
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(target).


### PR DESCRIPTION
See issue #1154. In some cases, objects cannot be propagated due to
conflicts with other objects - in the case of a rolebinding, because its
role doesn't already exist. By default, controller-runtime will retry
errors in such circumstances with an exponential backoff with a 1000s
cap, which could lead users to believe that HNC is broken and will never
propagate their objects even after the problem is fixed.

This change caps the backoff at 10s, which is probably high enough that
it won't flood HNC with retries and low enough that the problem will
likely be fixed within the next one or two checks.

Tested: create a rolebinding without a role and watched the logs.
Without this change, observed that the time between attempts doubled
continuously (I saw it get to about a minute) before I created the role,
and verified that the RB was _eventually_ propagated. With this change,
I observed that the time between events increased until it hit 5s and
then saw a new event every 5s, and after the role was create, the RB was
propagated very soon after that. (I later changed the timeout to 10s
during PR review but didn't retest).

Fixed #1154 