### PR TITLE
Add newline before subns footnote

### DIFF
--- a/incubator/hnc/internal/kubectl/tree.go
+++ b/incubator/hnc/internal/kubectl/tree.go
@@ -68,7 +68,7 @@ var treeCmd = &cobra.Command{
 		}
 
 		if hasSubnamespace {
-			fmt.Printf("[s] indicates subnamespaces.\n")
+			fmt.Printf("\n[s] indicates subnamespaces\n")
 		}
 
 		if len(footnotes) > 0 {


### PR DESCRIPTION
Without this change, the subnamespace footnote looks like a slightly
misformatted part of the tree:

```
default
└── [s] sub
[s] indicates subnamespaces.
```

By adding a newline, there's a nice visual separation from the tree
while also emphasizing the footnote:

```
default
└── [s] sub

[s] indicates subnamespaces
```

I also removed the period since this isn't a full sentence. If there are
any conditions, a blank line will be printed between the subnamespace
and condition footnote.

Tested: ran `kubectl hns tree` as shown above.