### PR TITLE
Don't block object deletion in dying namespaces

### DIFF
--- a/incubator/hnc/internal/forest/namespace.go
+++ b/incubator/hnc/internal/forest/namespace.go
@@ -51,6 +51,10 @@ type Namespace struct {
 	// tree label of itself. The key is the tree label without ".tree.hnc.x-k8s.io/depth" suffix.
 	// The value is the depth.
 	ExternalTreeLabels map[string]int
+
+	// IsDeleting is set to true if the namespace has a non-zero deletion timestamp. This allows the
+	// object validators to skip certain checks to allow the objects in a namespace to be emptied out.
+	IsDeleting bool
 }
 
 // Name returns the name of the namespace, of "<none>" if the namespace is nil.

--- a/incubator/hnc/internal/reconcilers/hierarchy_config.go
+++ b/incubator/hnc/internal/reconcilers/hierarchy_config.go
@@ -217,6 +217,9 @@ func (r *HierarchyConfigReconciler) syncWithForest(log logr.Logger, nsInst *core
 	hadCrit := ns.HasLocalCritCondition()
 	ns.ClearConditions()
 
+	// Record whether the namespace is being deleted; this is useful for object validators.
+	ns.IsDeleting = !nsInst.DeletionTimestamp.IsZero()
+
 	// If there are any traces of v1alpha1 still around, fix them now (they'll be written back to the
 	// apiserver after this function's finished). Do this before reconciling anything else so that the
 	// rest of this function can assume that only v1alpha2 is present.
@@ -350,7 +353,7 @@ func (r *HierarchyConfigReconciler) syncSubnamespaceParent(log logr.Logger, inst
 	// We could also add an exception to allow K8s SAs to override the object validator (and we
 	// probably should), but this prevents us from getting into a war with K8s and is sufficient for
 	// v0.5.
-	if pnm != "" && !nsInst.DeletionTimestamp.IsZero() {
+	if pnm != "" && ns.IsDeleting {
 		log.V(1).Info("Subnamespace is being deleted; ignoring SubnamespaceOf annotation", "parent", inst.Spec.Parent, "annotation", pnm)
 		pnm = ""
 	}


### PR DESCRIPTION
See issue #1214. Our e2e tests were occasionally dying when a namespace
got messed up while propagated objects were in it; I *think* this is
because they got into an ActivityHalted state (so propagated objects
weren't cleaned up) but then the object validator would block deletion.
This caused the tests to hang indefinitely, and the objects couldn't
(easily) be removed without disbling the validator.

This change lets the validators know when the namespace is being
deleted, and unblocks deletion of all propagated objects.

Tested: a new e2e test hangs indefinitely without the fix and completes
successfully with it.

Fixes #1214