### PR TITLE
Update how-to.md for HNCConfig schema change

### DIFF
--- a/incubator/hnc/docs/user-guide/how-to.md
+++ b/incubator/hnc/docs/user-guide/how-to.md
@@ -518,7 +518,6 @@ For example:
 
 ```
 # Starting from HNC v0.6:
-# "--group" can be omitted if the resource is a core K8s resource
 kubectl hns config set-resource secrets --mode Propagate
 
 # Before HNC v0.6:


### PR DESCRIPTION
Update how-to.md to reflect both `kubectl hns config set-type` and `kubectl hns config set-resource` before and after HNC v0.6,
and schema/field changes.

Fixes #1207 