### PR TITLE
Check conflict with the selectors

### DIFF
--- a/incubator/hnc/internal/pkg/selectors/selectors.go
+++ b/incubator/hnc/internal/pkg/selectors/selectors.go
@@ -15,6 +15,23 @@ import (
 	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
 )
 
+func ShouldPropagate(inst *unstructured.Unstructured, nsLabels labels.Set) (bool, error) {
+	if sel, err := GetSelector(inst); err != nil {
+		return false, err
+	} else if sel != nil && !sel.Matches(nsLabels) {
+		return false, nil
+	}
+	if sel, err := GetTreeSelector(inst); err != nil {
+		return false, err
+	} else if sel != nil && !sel.Matches(nsLabels) {
+		return false, nil
+	}
+	if none, err := GetNoneSelector(inst); err != nil || none {
+		return false, err
+	}
+	return true, nil
+}
+
 func GetSelectorAnnotation(inst *unstructured.Unstructured) string {
 	annot := inst.GetAnnotations()
 	return annot[api.AnnotationSelector]

--- a/incubator/hnc/internal/validators/object.go
+++ b/incubator/hnc/internal/validators/object.go
@@ -246,7 +246,12 @@ func (o *Object) hasConflict(inst *unstructured.Unstructured) (bool, []string) {
 	// Get a list of conflicting descendants if there's any.
 	for _, desc := range descs {
 		if o.Forest.Get(desc).HasSourceObject(gvk, nm) {
-			conflicts = append(conflicts, desc)
+			// If the user have chosen not to propagate the object to this descendant,
+			// there shouldn't be any conflict reported here
+			nsLabels := o.Forest.Get(inst.GetNamespace()).GetLabels()
+			if ok, _ := selectors.ShouldPropagate(inst, nsLabels); ok {
+				conflicts = append(conflicts, desc)
+			}
 		}
 	}
 

--- a/incubator/hnc/internal/validators/object_test.go
+++ b/incubator/hnc/internal/validators/object_test.go
@@ -471,6 +471,7 @@ func TestCreatingConflictSource(t *testing.T) {
 		conflictNamespace string
 		newInstName       string
 		newInstNamespace  string
+		newInstAnnotation map[string]string
 		fail              bool
 	}{{
 		name:              "Deny creation of source objects with conflict in child",
@@ -492,6 +493,33 @@ func TestCreatingConflictSource(t *testing.T) {
 		name:             "Allow creation of source objects with no conflict",
 		newInstName:      "secret-a",
 		newInstNamespace: "a",
+	}, {
+		name:              "Allow creation of source objects with treeSelector not matching the conflicting child",
+		forest:            "-aa",
+		conflictInstName:  "secret-b",
+		conflictNamespace: "b",
+		newInstName:       "secret-b",
+		newInstNamespace:  "a",
+		newInstAnnotation: map[string]string{api.AnnotationTreeSelector: "c"},
+		fail:              false,
+	}, {
+		name:              "Allow creation of source objects with selector not matching the conflicting child",
+		forest:            "-aa",
+		conflictInstName:  "secret-b",
+		conflictNamespace: "b",
+		newInstName:       "secret-b",
+		newInstNamespace:  "a",
+		newInstAnnotation: map[string]string{api.AnnotationSelector: "c" + api.LabelTreeDepthSuffix},
+		fail:              false,
+	}, {
+		name:              "Allow creation of source objects with noneSelector set",
+		forest:            "-aa",
+		conflictInstName:  "secret-b",
+		conflictNamespace: "b",
+		newInstName:       "secret-b",
+		newInstNamespace:  "a",
+		newInstAnnotation: map[string]string{api.AnnotationNoneSelector: "true"},
+		fail:              false,
 	}}
 
 	for _, tc := range tests {
@@ -507,6 +535,7 @@ func TestCreatingConflictSource(t *testing.T) {
 			inst.SetName(tc.newInstName)
 			inst.SetNamespace(tc.newInstNamespace)
 			inst.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"})
+			inst.SetAnnotations(tc.newInstAnnotation)
 			// Test
 			got := o.handle(context.Background(), l, op, inst, &unstructured.Unstructured{})
 			// Report


### PR DESCRIPTION
If we have an object `A` already existing in child namespace `c1`, and
we are creating a new object also called `A` in the parent namespace,
and only _select_ it to propogate to another child namespace `c2`, we
should allow this operation, because `A` is not propagating to `c1` and
will not cause any conflict.

Test cases are also added in 'object_test.go'

Tested:
```
$ cat << EOF >> test.yaml
> apiVersion: v1
kind: Secret
metadata:
        annotations:
                propagate.hnc.x-k8s.io/treeSelect: c
        name: my-creds
        namespace: a
EOF
$ k delete secret my-creds -n a
$ k create -f test.yaml
```