### PR TITLE
Make 'group' field in config.status.resources omitempty

### DIFF
--- a/incubator/hnc/api/v1alpha2/hnc_config.go
+++ b/incubator/hnc/api/v1alpha2/hnc_config.go
@@ -100,7 +100,7 @@ type ResourceSpec struct {
 // ResourceStatus defines the actual synchronization state of a specific resource.
 type ResourceStatus struct {
 	// The API group of the resource being synchronized.
-	Group string `json:"group"`
+	Group string `json:"group,omitempty"`
 
 	// The API version used by HNC when propagating this resource.
 	Version string `json:"version"`

--- a/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
+++ b/incubator/hnc/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
@@ -247,7 +247,6 @@ spec:
                       description: The API version used by HNC when propagating this resource.
                       type: string
                   required:
-                  - group
                   - resource
                   - version
                   type: object


### PR DESCRIPTION
We have the 'group' field in the config.spec.resources omitempty for K8s
core resources. This PR makes the field in status matches what in the
spec. For K8s core resources, the group will be omitted.

Tested manually by configuring 'secrets', which is a K8s core resource
with empty group and the group field is omitted in both spec and status.

The issue was:
```
spec:
  resources:
  - mode: Propagate
    resource: secrets
status:
  resources:
  - group: ""                       <<<<<<<<< not  omit empty
    mode: Propagate
    numPropagatedObjects: 1
    numSourceObjects: 5
    resource: secrets
    version: v1
  - group: rbac.authorization.k8s.io
    mode: Propagate
    numPropagatedObjects: 1
    numSourceObjects: 1
    resource: rolebindings
    version: v1
  - group: rbac.authorization.k8s.io
    mode: Propagate
    numPropagatedObjects: 1
    numSourceObjects: 1
    resource: roles
    version: v1
```

Part of #868