### PR TITLE
Fix netpol e2e test (cherry-pick to master)

### DIFF
--- a/incubator/hnc/pkg/testutils/testutils.go
+++ b/incubator/hnc/pkg/testutils/testutils.go
@@ -202,8 +202,8 @@ func runShouldNotContainMultiple(offset int, substrs []string, seconds float64, 
 }
 
 func MustApplyYAML(s string){
-	filename := WriteTempFile(s)
-	defer RemoveFile(filename)
+	filename := writeTempFile(s)
+	defer removeFile(filename)
 	MustRun("kubectl apply -f", filename)
 }
 
@@ -336,7 +336,7 @@ func RecoverHNC() {
 	CleanupNamespaces(a, b)
 }
 
-func WriteTempFile(cxt string) string {
+func writeTempFile(cxt string) string {
 	f, err := ioutil.TempFile(os.TempDir(), "e2e-test-*.yaml")
 	Expect(err).Should(BeNil())
 	defer f.Close()
@@ -344,7 +344,7 @@ func WriteTempFile(cxt string) string {
 	return f.Name()
 }
 
-func RemoveFile(path string) {
+func removeFile(path string) {
 	Expect(os.Remove(path)).Should(BeNil())
 }
 


### PR DESCRIPTION
The test was failing incorrectly; it now passes if netpols are enabled
and is skipped if they're not.

Tested: on GKE with netpol enabled and on Kind with them disabled.