### PR TITLE
[vc] adding support for custom vn-agent ports

### DIFF
--- a/incubator/virtualcluster/cmd/syncer/app/options/options.go
+++ b/incubator/virtualcluster/cmd/syncer/app/options/options.go
@@ -81,6 +81,7 @@ func NewResourceSyncerOptions() (*ResourceSyncerOptions, error) {
 			DisableServiceAccountToken: true,
 			DefaultOpaqueMetaDomains:   []string{"kubernetes.io", "k8s.io"},
 			ExtraSyncingResources:      []string{},
+			VNAgentPort:                int32(10550),
 		},
 		Address:  "",
 		Port:     "80",
@@ -98,6 +99,7 @@ func (o *ResourceSyncerOptions) Flags() cliflag.NamedFlagSets {
 	fs.BoolVar(&o.ComponentConfig.DisableServiceAccountToken, "disable-service-account-token", o.ComponentConfig.DisableServiceAccountToken, "DisableServiceAccountToken indicates whether disable service account token automatically mounted.")
 	fs.StringSliceVar(&o.ComponentConfig.DefaultOpaqueMetaDomains, "default-opaque-meta-domains", o.ComponentConfig.DefaultOpaqueMetaDomains, "DefaultOpaqueMetaDomains is the default opaque meta configuration for each Virtual Cluster.")
 	fs.StringSliceVar(&o.ComponentConfig.ExtraSyncingResources, "extra-syncing-resources", o.ComponentConfig.ExtraSyncingResources, "ExtraSyncingResources defines additional resources that need to be synced for each Virtual Cluster. (priorityclass, ingress)")
+	fs.Int32Var(&o.ComponentConfig.VNAgentPort, "vn-agent-port", 10550, "Port the vn-agent listens on")
 
 	serverFlags := fss.FlagSet("metricsServer")
 	serverFlags.StringVar(&o.Address, "address", o.Address, "The server address.")

--- a/incubator/virtualcluster/pkg/syncer/apis/config/types.go
+++ b/incubator/virtualcluster/pkg/syncer/apis/config/types.go
@@ -51,6 +51,9 @@ type SyncerConfiguration struct {
 	// DisableServiceAccountToken indicates whether disable service account token automatically mounted.
 	DisableServiceAccountToken bool
 
+	// VNAgentPort defines the port that the VN Agent is running on per host
+	VNAgentPort int32
+
 	// Super master rest config
 	RestConfig *rest.Config
 }

--- a/incubator/virtualcluster/pkg/syncer/resources/node/util.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/node/util.go
@@ -36,7 +36,7 @@ var wellKnownNodeLabelsMap = map[string]struct{}{
 	v1.LabelHostname:   {},
 }
 
-func NewVirtualNode(superMasterNode *v1.Node) *v1.Node {
+func NewVirtualNode(superMasterNode *v1.Node, vnAgentPort int32) *v1.Node {
 	now := metav1.Now()
 	n := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -68,8 +68,7 @@ func NewVirtualNode(superMasterNode *v1.Node) *v1.Node {
 	n.Status.NodeInfo.OperatingSystem = "Linux"
 	n.Status.DaemonEndpoints = v1.NodeDaemonEndpoints{
 		KubeletEndpoint: v1.DaemonEndpoint{
-			// vn-agent service port. Hard coded for now.
-			Port: 10550,
+			Port: vnAgentPort,
 		},
 	}
 

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/uws.go
@@ -106,7 +106,7 @@ func (c *controller) BackPopulate(key string) error {
 			if !errors.IsNotFound(err) {
 				return err
 			}
-			_, err = tenantClient.CoreV1().Nodes().Create(context.TODO(), node.NewVirtualNode(n), metav1.CreateOptions{})
+			_, err = tenantClient.CoreV1().Nodes().Create(context.TODO(), node.NewVirtualNode(n, c.config.VNAgentPort), metav1.CreateOptions{})
 			if err != nil && !errors.IsAlreadyExists(err) {
 				return fmt.Errorf("failed to create virtual node %s in cluster %s with err: %v", pPod.Spec.NodeName, clusterName, err)
 			}


### PR DESCRIPTION
This adds a flag to the syncer to allow you to set a "non-standard" vn-agent port with the syncer. You could previously supply a custom port to the vn-agent but it wouldn't work with how it was hardcoded when syncing.

Signed-off-by: Chris Hein <me@chrishein.com>