### PR TITLE
Update namespace deletion validator

### DIFF
--- a/incubator/hnc/internal/validators/namespace_test.go
+++ b/incubator/hnc/internal/validators/namespace_test.go
@@ -100,9 +100,9 @@ func TestDeleteOwnerNamespace(t *testing.T) {
 		c.UpdateAllowCascadingDeletion(true)
 		// Test
 		got = vns.handle(req)
-		// Report - Should allow deleting the parent namespace since both subnamespaces allow cascading deletion.
+		// Report - Shouldn't allow deleting the parent namespace since parent namespace is not set to allow cascading deletion.
 		logResult(t, got.AdmissionResponse.Result)
-		g.Expect(got.AdmissionResponse.Allowed).Should(BeTrue())
+		g.Expect(got.AdmissionResponse.Allowed).Should(BeFalse())
 
 		// Unset allowCascadingDeletion on one child but set allowCascadingDeletion on the parent itself.
 		c.UpdateAllowCascadingDeletion(false)


### PR DESCRIPTION
The 'allowCascadingDelete' flag has to be set if the namespace to be 
deleted has any child namespace. If the namespace to be deleted has 
no child namespace, then no flag is required.

Tested: make test

Fix #876