### PR TITLE
[VC] Fix an enqueobject bug

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/handler/enqueue_object.go
+++ b/incubator/virtualcluster/pkg/syncer/handler/enqueue_object.go
@@ -33,7 +33,7 @@ func (e *EnqueueRequestForObject) enqueue(obj interface{}) {
 		return
 	}
 
-	r := &reconciler.Request{}
+	r := reconciler.Request{}
 	r.ClusterName = e.ClusterName
 	r.Namespace = o.GetNamespace()
 	r.Name = o.GetName()

--- a/incubator/virtualcluster/pkg/syncer/handler/enqueue_object_test.go
+++ b/incubator/virtualcluster/pkg/syncer/handler/enqueue_object_test.go
@@ -79,7 +79,7 @@ func TestEnqueueRequestForObject(t *testing.T) {
 		},
 	}
 
-	expectedEnqueuedRequest := &reconciler.Request{
+	expectedEnqueuedRequest := reconciler.Request{
 		ClusterName: clusterName,
 		NamespacedName: types.NamespacedName{
 			Name:      "n1",

--- a/incubator/virtualcluster/pkg/syncer/resources/register.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/register.go
@@ -50,7 +50,6 @@ func init() {
 		configmap.NewConfigMapController,
 		endpoints.NewEndpointsController,
 		event.NewEventController,
-		ingress.NewIngressController,
 		namespace.NewNamespaceController,
 		node.NewNodeController,
 		persistentvolume.NewPVController,


### PR DESCRIPTION
The object added to mccontroller fairqueue cannot be a pointer. Otherwise, the dws will break. 

This change also removes ingress from default registry list.
