### PR TITLE
Fixed issues with local development on OSX

### DIFF
--- a/incubator/hnc/Makefile
+++ b/incubator/hnc/Makefile
@@ -54,10 +54,18 @@ else
 	HNC_IMG = ${HNC_IMG_NAME}:${HNC_IMG_TAG}
 endif
 
+# Determine the OS Name, linux/darwin
+OS_NAME := $(shell go env GOOS)
+
 # `make` must be called from the HNC root, or all kinds of things will break
 # (starting with this).
 CURDIR = $(shell pwd)
 KUSTOMIZE ?= ${CURDIR}/hack/kustomize-3.8.1
+
+ifeq ($(OS_NAME),darwin)
+	KUSTOMIZE = $(shell which kustomize)
+endif
+
 CONTROLLER_GEN ?= ${CURDIR}/bin/controller-gen
 
 # Enable CRD per-version validation. As of Kubernetes 1.13, we can have multiple
@@ -107,7 +115,7 @@ clean: krew-uninstall
 
 # Installs the Linux kubectl plugin to $GOPATH/bin, assume that this is in your PATH already.
 kubectl: build
-	cp bin/kubectl/kubectl-hns_linux_amd64 ${GOPATH}/bin/kubectl-hns
+	cp bin/kubectl/kubectl-hns_$(OS_NAME)_amd64 $(GOBIN)/kubectl-hns
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: build

--- a/incubator/hnc/README.md
+++ b/incubator/hnc/README.md
@@ -121,6 +121,12 @@ is configured to use the project containing the registry you want to use, and
 that you've previously run `gcloud auth configure-docker` so that Docker can use
 your GCP credentials.
 
+If you are developing on MacOS, you will need gnu-sed. Instructions are below:
+```
+brew install gnu-sed
+ln -s $(which gsed) /usr/local/bin/sed # sym link sed to gsed
+```
+
 ### Development Workflow
 
 Once HNC is installed via `make deploy` (see next sections), the development


### PR DESCRIPTION
- Kustomize binary path will be infered based on the OS
with default set to the binary in hack dir

- Kubectl target works

- Updated docs on how to install configure sed on OSX

Testing:
- [x] make deploy
- [x] make test

Issue: [#1262 ](https://github.com/kubernetes-sigs/multi-tenancy/issues/1262)