### PR TITLE
HNC: kubectl supports case-insensitive mode

### DIFF
--- a/incubator/hnc/internal/kubectl/configset.go
+++ b/incubator/hnc/internal/kubectl/configset.go
@@ -18,6 +18,7 @@ package kubectl
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -38,7 +39,7 @@ var setResourceCmd = &cobra.Command{
 		flags := cmd.Flags()
 		group, _ := flags.GetString("group")
 		modeStr, _ := flags.GetString("mode")
-		mode := api.SynchronizationMode(modeStr)
+		mode := api.SynchronizationMode(normalizeModeString(modeStr))
 		force, _ := flags.GetBool("force")
 		config := client.getHNCConfig()
 
@@ -72,6 +73,12 @@ var setResourceCmd = &cobra.Command{
 
 		client.updateHNCConfig(config)
 	},
+}
+
+// normalizeModeString corrects format of input Synchronization Mode string
+func normalizeModeString(modeStr string) string {
+	low := strings.ToLower(modeStr)
+	return strings.Title(low)
 }
 
 func newSetResourceCmd() *cobra.Command {


### PR DESCRIPTION
This normalize synchronize mode string format to match with current supported mode: Propagate, Ignore, Remove,

allows synchronize mode input to be case-insensitive.

Tested:
- exec `kubectl` command and set any mode

Closes:  #1238