### PR TITLE
[VirtualCluster] Fix `clusterversions` CRD, add `kind` support and review the demo flow

### DIFF
--- a/incubator/virtualcluster/config/sampleswithspec/tenancy.x-k8s.io_clusterversions.yaml
+++ b/incubator/virtualcluster/config/sampleswithspec/tenancy.x-k8s.io_clusterversions.yaml
@@ -1,0 +1,70 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: clusterversions.tenancy.x-k8s.io
+spec:
+  group: tenancy.x-k8s.io
+  names:
+    kind: ClusterVersion
+    listKind: ClusterVersionList
+    plural: clusterversions
+    shortNames:
+    - cv
+    singular: clusterversion
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            apiServer:
+              properties:
+                metadata:
+                  type: object
+                service:
+                  type: object
+                statefulset:
+                  type: object
+              type: object
+            controllerManager:
+              properties:
+                metadata:
+                  type: object
+                service:
+                  type: object
+                statefulset:
+                  type: object
+              type: object
+            etcd:
+              properties:
+                metadata:
+                  type: object
+                service:
+                  type: object
+                statefulset:
+                  type: object
+              type: object
+          type: object
+        status:
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/incubator/virtualcluster/doc/demo.md
+++ b/incubator/virtualcluster/doc/demo.md
@@ -3,7 +3,7 @@
 This demo illustrates how to setup a VirtualCluster in an existing lightweight environment, 
 be it [`minikube`](https://minikube.sigs.k8s.io/) or [`kind`](https://kind.sigs.k8s.io/docs/) Kubernetes cluster.
 
-It should work exactly the same if you were working on any other Kubernetes distrubitions too.
+It should work exactly the same if you were working on any other Kubernetes distributions too.
 
 For example, to spin up a `minukube` cluster:
 

--- a/incubator/virtualcluster/doc/demo.md
+++ b/incubator/virtualcluster/doc/demo.md
@@ -3,7 +3,7 @@
 This demo illustrates how to setup a VirtualCluster in an existing lightweight environment, 
 be it [`minikube`](https://minikube.sigs.k8s.io/) or [`kind`](https://kind.sigs.k8s.io/docs/) Kubernetes cluster.
 
-It should work exactly the same if you're working on any other Kubernetes distrubitions too.
+It should work exactly the same if you were working on any other Kubernetes distrubitions too.
 
 For example, to spin up a `minukube` cluster:
 
@@ -69,7 +69,7 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy
 Let's check out what we've installed:
 
 ```bash
-# a dedicated namespace named "vc-manager" is created
+# A dedicated namespace named "vc-manager" is created
 $ kubectl get ns
 NAME              STATUS   AGE
 default           Active   14m
@@ -78,7 +78,7 @@ kube-public       Active   14m
 kube-system       Active   14m
 vc-manager        Active   74s
 
-# and the components, including vc-manager, vc-syncer and vn-agent are installed within namespace `vc-manager`
+# And the components, including vc-manager, vc-syncer and vn-agent are installed within namespace `vc-manager`
 $ kubectl get all -n vc-manager
 NAME                              READY   STATUS    RESTARTS   AGE
 pod/vc-manager-76c5878465-mv4nv   1/1     Running   0          92s
@@ -111,8 +111,7 @@ Please note that we need to make sure the client cert/key files are imported as 
 ### Create `kubelet` client secrete in `minikube` cluster
 
 If you're using `minikube`, the client PKI files are located in `~/.minikube/`.
-
-So we can create `vc-kubelet-client` secert using the following cmd:
+So we can create `vc-kubelet-client` secret using the following commands:
 
 ```bash
 # Copy the files over
@@ -123,7 +122,8 @@ kubectl create secret generic vc-kubelet-client --from-file=client.crt --from-fi
 
 ### Create `kubelet` client secrete in `kind` cluster:
 
-If you're using `kind`, the client PKI files are located in its control plane Docker container, so we can retrieve it back and create `vc-kubelet-client` secert using the following cmd:
+If you're using `kind`, the client PKI files are located in its control plane Docker container.
+So we can retrieve them back and create `vc-kubelet-client` secret using the following commands:
 
 ```bash
 # Retrieve the kubelet client key/cert files
@@ -135,14 +135,14 @@ kubectl create secret generic vc-kubelet-client --from-file=client.crt --from-fi
 
 ### Update `vn-agent`
 
-To apply this secret to `vn-agent` Pod, one can patch the `vn-agent` DaemonSet to change the secret name of the `kubelet-client-cert` volume to newly created `vc-kubelet-client`:
+To apply this secret to `vn-agent` Pod(s), one can patch the `vn-agent` DaemonSet to change the secret name of the `kubelet-client-cert` volume to the newly created `vc-kubelet-client`:
 
 ```bash
 $ kubectl -n vc-manager patch daemonset/vn-agent --type json \
     -p='[{"op": "replace", "path": "/spec/template/spec/volumes/0/secret/secretName", "value":"vc-kubelet-client"}]'
 ```
 
-The `vn-agent` Pod will be recreated in every node and `vn-agent` can directly talk with `kubelet` from now onwards.
+The `vn-agent` Pod(s) will be recreated in every node to talk with `kubelet` directly from now onwards.
 
 
 ## Create ClusterVersion
@@ -164,7 +164,7 @@ $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenan
 
 We can now create a `VirtualCluster` CR, which refers to the `ClusterVersion` that we just created.
 
-The `vc-manager` will create a tenant master, where its tenant apiserver is exposed through nodeport service.
+The `vc-manager` will create a tenant master, where its tenant apiserver can be exposed through nodeport, or load balancer.
 
 ```bash
 $ kubectl vc create -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/sampleswithspec/virtualcluster_1_nodeport.yaml -o vc-1.kubeconfig
@@ -174,7 +174,7 @@ $ kubectl vc create -f https://raw.githubusercontent.com/kubernetes-sigs/multi-t
 2020/11/15 11:14:12 VirtualCluster default/vc-sample-1 setup successfully
 ```
 
-The command will create a tenant master named `vc-sample-1`.
+The command will create a tenant master named `vc-sample-1`, exposed by NotePort.
 
 Once it's created, a kubeconfig file specified by `-o`, namely `vc-1.kubeconfig`, will be created in the current directory.
 
@@ -183,7 +183,7 @@ Once it's created, a kubeconfig file specified by `-o`, namely `vc-1.kubeconfig`
 
 The generated `vc-1.kubeconfig` can be used as a normal `kubeconfig` to access the tenant virtual cluster.
 
-Please note that if you're working on `kind` cluster, which, by default, exposes one random host port pointing to Kubernetes' default `6443`. In this case, we need to work around it and the simplest way is to deploy a "sidecar" container as the proxy to route management traffic to the service:
+Please note that if you're working on `kind` cluster which, by default, exposes one random host port pointing to Kubernetes' default API Server port `6443`. In this case, we need to work around it and the simplest way is to deploy a "sidecar" container as the proxy to route management traffic to the service:
 
 ```bash
 # Do this only when you're wroking in `kind`:
@@ -233,10 +233,10 @@ $ kubectl get namespace
 NAME                                         STATUS   AGE
 default                                      Active   30m
 default-532c0e-vc-sample-1                   Active   10m
-default-532c0e-vc-sample-1-default           Active   8m53s
-default-532c0e-vc-sample-1-kube-node-lease   Active   8m53s
-default-532c0e-vc-sample-1-kube-public       Active   8m53s
-default-532c0e-vc-sample-1-kube-system       Active   8m53s
+default-532c0e-vc-sample-1-default           Active   9m53s
+default-532c0e-vc-sample-1-kube-node-lease   Active   9m53s
+default-532c0e-vc-sample-1-kube-public       Active   9m53s
+default-532c0e-vc-sample-1-kube-system       Active   9m53s
 kube-node-lease                              Active   30m
 kube-public                                  Active   30m
 kube-system                                  Active   30m
@@ -283,7 +283,7 @@ test-deploy-5f4bcd8c-9thn7   1/1     Running   0          4m44s
 $ VC_NAMESPACE="$(kubectl get VirtualCluster vc-sample-1 -o json | jq -r '.status.clusterNamespace')"
 $ kubectl get pod -n "${VC_NAMESPACE}-default"
 NAME                         READY   STATUS    RESTARTS   AGE
-test-deploy-5f4bcd8c-9thn7   1/1     Running   0          4m56
+test-deploy-5f4bcd8c-9thn7   1/1     Running   0          4m56s
 
 # Also, a new virtual node is created in the tenant master and tenant cannot schedule Pod on it.
 $ kubectl get node --kubeconfig vc-1.kubeconfig

--- a/incubator/virtualcluster/doc/demo.md
+++ b/incubator/virtualcluster/doc/demo.md
@@ -5,7 +5,7 @@ be it [`minikube`](https://minikube.sigs.k8s.io/) or [`kind`](https://kind.sigs.
 
 It should work exactly the same if you were working on any other Kubernetes distributions too.
 
-For example, to spin up a `minukube` cluster:
+For example, to spin up a `minikube` cluster:
 
 ```bash
 minikube start --driver=virtualbox --cpus=4 --memory='6g' --disk-size='10g'
@@ -108,7 +108,7 @@ A more efficient method is to communicate with `kubelet` directly using the clie
 The location of the client PKI files may vary based on the local setup.
 Please note that we need to make sure the client cert/key files are imported as `client.crt` and `client.key` so that they can be referenced to.
 
-### Create `kubelet` client secrete in `minikube` cluster
+### Create `kubelet` client secret in `minikube` cluster
 
 If you're using `minikube`, the client PKI files are located in `~/.minikube/`.
 So we can create `vc-kubelet-client` secret using the following commands:
@@ -186,7 +186,7 @@ The generated `vc-1.kubeconfig` can be used as a normal `kubeconfig` to access t
 Please note that if you're working on `kind` cluster which, by default, exposes one random host port pointing to Kubernetes' default API Server port `6443`. In this case, we need to work around it and the simplest way is to deploy a "sidecar" container as the proxy to route management traffic to the service:
 
 ```bash
-# Do this only when you're wroking in `kind`:
+# Do this only when you're working in `kind`:
 
 # Retrieve the tenant namespace
 $ VC_NAMESPACE="$(kubectl get VirtualCluster vc-sample-1 -o json | jq -r '.status.clusterNamespace')"

--- a/incubator/virtualcluster/doc/demo.md
+++ b/incubator/virtualcluster/doc/demo.md
@@ -174,7 +174,7 @@ $ kubectl vc create -f https://raw.githubusercontent.com/kubernetes-sigs/multi-t
 2020/11/15 11:14:12 VirtualCluster default/vc-sample-1 setup successfully
 ```
 
-The command will create a tenant master named `vc-sample-1`, exposed by NotePort.
+The command will create a tenant master named `vc-sample-1`, exposed by NodePort.
 
 Once it's created, a kubeconfig file specified by `-o`, namely `vc-1.kubeconfig`, will be created in the current directory.
 
@@ -327,7 +327,7 @@ Load average: 0.45 0.47 0.54 1/1308 23
   PID  PPID USER     STAT   VSZ %VSZ CPU %CPU COMMAND
 ```
 
-## Cleanup
+## Clean Up
 
 By deleting the VirtualCluster CR, all the tenant resources created in the super master will be deleted.
 

--- a/incubator/virtualcluster/doc/demo.md
+++ b/incubator/virtualcluster/doc/demo.md
@@ -1,118 +1,256 @@
-# VirtualCluster Demo
+# VirtualCluster Walkthrough Demo
 
-This demo illustrates how to setup a virtualcluster in an existing `minikube` Kubernetes cluster.
+This demo illustrates how to setup a VirtualCluster in an existing lightweight environment, 
+be it [`minikube`](https://minikube.sigs.k8s.io/) or [`kind`](https://kind.sigs.k8s.io/docs/) Kubernetes cluster.
 
-All virtualcluster related API resources (CRD, Secret, Configmap etc.) are created in an
-"admin namespace" for the rest of this demo we'll use the `default` namespace.
+It should work exactly the same if you're working on any other Kubernetes distrubitions too.
+
+For example, to spin up a `minukube` cluster:
+
+```bash
+minikube start --driver=virtualbox --cpus=4 --memory='6g' --disk-size='10g'
+```
+
+Or a `kind` cluster:
+
+```bash
+export CLUSTER_NAME="virtual-cluster" && \
+kind create cluster --name ${CLUSTER_NAME} --config - <<EOF
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker
+EOF
+```
 
 ## Build and install `kubectl-vc`
+
+VirtualCluster offers a handy `kubectl` plugin, we can build and use it by following this process.
+
 ```bash
-# build
+# Clone the repo && cd to virtualcluster folder
+git clone https://github.com/kubernetes-sigs/multi-tenancy.git
+cd multi-tenancy/incubator/virtualcluster
+
+# Build it
 make build WHAT=cmd/kubectl-vc
-# build on macOS
+# Or build on specific OS like macOS
 make build WHAT=cmd/kubectl-vc GOOS=darwin
-# install
+
+# Install it by simply copying it over to $PATH
 cp -f _output/bin/kubectl-vc /usr/local/bin
 ```
 
-And then you can manage virtualcluster by `kubectl vc` command tool.
+And then you can manage VirtualCluster by `kubectl vc` command tool.
 
-## Install CRDs and all components
-Running following cmds will install all CRDs and create all virtualcluster components.
+
+## Install VirtualCluster CRDs and components
+
+To install VirtualCluster CRDs:
+
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/crds/tenancy.x-k8s.io_clusterversions.yaml
+# There is known controller runtime code gen problem so the generated CRD for clusterversions doesn't work for now
+# So temporarily we use a simplified one.
+# Slack conversation: https://kubernetes.slack.com/archives/C8E6YA9S7/p1604903060089400
+#kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/crds/tenancy.x-k8s.io_clusterversions.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/sampleswithspec/tenancy.x-k8s.io_clusterversions.yaml
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/crds/tenancy.x-k8s.io_virtualclusters.yaml
+```
+
+To create all VirtualCluster components:
+
+```bash
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/setup/all_in_one.yaml
 ```
 
-For example, vc-manager, syncer Deployments and vn-agent DaemonSet can be found in namespace `vc-manager`.
-```
-kubectl get all -n vc-manager
-NAME                             READY   STATUS    RESTARTS   AGE
-pod/vc-manager-d7945f957-nh6th   1/1     Running   0          1d
-pod/vc-syncer-5c6848d79f-p6wd5   1/1     Running   0          1d
-pod/vn-agent-2z5zv               1/1     Running   0          1d
+Let's check out what we've installed:
+
+```bash
+# a dedicated namespace named "vc-manager" is created
+$ kubectl get ns
+NAME              STATUS   AGE
+default           Active   14m
+kube-node-lease   Active   14m
+kube-public       Active   14m
+kube-system       Active   14m
+vc-manager        Active   74s
+
+# and the components, including vc-manager, vc-syncer and vn-agent are installed within namespace `vc-manager`
+$ kubectl get all -n vc-manager
+NAME                              READY   STATUS    RESTARTS   AGE
+pod/vc-manager-76c5878465-mv4nv   1/1     Running   0          92s
+pod/vc-syncer-55c5bc5898-v4hv5    1/1     Running   0          92s
+pod/vn-agent-d9dp2                1/1     Running   0          92s
+
+NAME                                     TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
+service/virtualcluster-webhook-service   ClusterIP   10.106.26.51   <none>        9443/TCP   76s
 
 NAME                      DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
-daemonset.apps/vn-agent   1         1         1       1            1           <none>          1d
+daemonset.apps/vn-agent   1         1         1       1            1           <none>          92s
 
 NAME                         READY   UP-TO-DATE   AVAILABLE   AGE
-deployment.apps/vc-manager   1/1     1            1           1d
-deployment.apps/vc-syncer    1/1     1            1           1d
+deployment.apps/vc-manager   1/1     1            1           92s
+deployment.apps/vc-syncer    1/1     1            1           92s
 
-NAME                                   DESIRED   CURRENT   READY   AGE
-replicaset.apps/vc-manager-d7945f957   1         1         1       1d
-replicaset.apps/vc-syncer-5c6848d79f   1         1         1       1d
+NAME                                    DESIRED   CURRENT   READY   AGE
+replicaset.apps/vc-manager-76c5878465   1         1         1       92s
+replicaset.apps/vc-syncer-55c5bc5898    1         1         1       92s
 ```
 
-## (Optional) Update client CA secret
-By default, vn-agent works in a suboptimal mode by forwarding all kubelet API requests to super master.
-A more efficient method is to communicate with kubelet directly using the client CA used by the super master.
-The location of the client ca may vary based on the local setup.
-For example, in `minikube`, the client CA files (i.e., client.crt and client.key) are located in `~/.minikube/`.
-If the client CA files can be found in local setup, one can create 'vc-kubelet-client' secert using
-the following cmd.
+## (Optional) Create `kubelet` client secrete and update `vn-agent`
+
+By default, `vn-agent` works in a suboptimal mode by forwarding all `kubelet` API requests to super master.
+A more efficient method is to communicate with `kubelet` directly using the client cert/key used by the super master.
+
+The location of the client PKI files may vary based on the local setup.
+Please note that we need to make sure the client cert/key files are imported as `client.crt` and `client.key` so that they can be referenced to.
+
+### Create `kubelet` client secrete in `minikube` cluster
+
+If you're using `minikube`, the client PKI files are located in `~/.minikube/`.
+
+So we can create `vc-kubelet-client` secert using the following cmd:
+
 ```bash
-cp $PATH_TO_CA/client.crt $PATH_TO_CA/client.key .
-kubectl create secret generic vc-kubelet-client --from-file=./client.crt --from-file=./client.key --namespace vc-manager
+# Copy the files over
+cp ~/.minikube/cert.pem client.crt && cp ~/.minikube/key.pem client.key
+# Create a new secret
+kubectl create secret generic vc-kubelet-client --from-file=client.crt --from-file=client.key --namespace vc-manager
 ```
 
-To use this secret in vn-agent Pod, one can edit the `vn-agent` DaemonSet and
-change the secret name of the `kubelet-client-cert` volume to `vc-kubelet-client`.
-The vn-agent Pod will be recreated in every node and vn-agent can directly talk with kubelet.
+### Create `kubelet` client secrete in `kind` cluster:
 
-## Create clusterversion CR
-A clusterversion CR specifies one tenant master configuration, which can be used by vc-manager to
-create the tenant master components. The following cmd will create a `cv-sample-np` clusterversion CR
-which specifies three StatefulSets for Kubernetes 1.15 apiserver, etcd and controller manager respectively.
+If you're using `kind`, the client PKI files are located in its control plane Docker container, so we can retrieve it back and create `vc-kubelet-client` secert using the following cmd:
+
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/sampleswithspec/clusterversion_v1_nodeport.yaml
+# Retrieve the kubelet client key/cert files
+docker cp ${CLUSTER_NAME}-control-plane:/etc/kubernetes/pki/apiserver-kubelet-client.crt client.crt
+docker cp ${CLUSTER_NAME}-control-plane:/etc/kubernetes/pki/apiserver-kubelet-client.key client.key
+# Create a new secret
+kubectl create secret generic vc-kubelet-client --from-file=client.crt --from-file=client.key --namespace vc-manager
 ```
 
-Note that tenant master does not have scheduler installed. The Pods are scheduled in super master.
+### Update `vn-agent`
 
-## Create virtualcluster
-We can use the following cmd to create a virtualcluster CR `vc-sample-1` in `tenant1admin` namespace.
-The vc-manager will create a Kubernetes 1.15 tenant master. The tenant apiserver is exposed through nodeport service
-in `minikube` node.
+To apply this secret to `vn-agent` Pod, one can patch the `vn-agent` DaemonSet to change the secret name of the `kubelet-client-cert` volume to newly created `vc-kubelet-client`:
+
 ```bash
-kubectl vc create -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/sampleswithspec/virtualcluster_1_nodeport.yaml -o vc-1.kubeconfig
+$ kubectl -n vc-manager patch daemonset/vn-agent --type json \
+    -p='[{"op": "replace", "path": "/spec/template/spec/volumes/0/secret/secretName", "value":"vc-kubelet-client"}]'
 ```
 
-Once the tenant master is created, a kubeconfig file `vc-1.kubeconfig` will be created in the current directory.
-One can use the `vc-1.kubeconfig` to access the tenant master. For example,
+The `vn-agent` Pod will be recreated in every node and `vn-agent` can directly talk with `kubelet` from now onwards.
+
+
+## Create ClusterVersion
+
+A `ClusterVersion` CR specifies how the tenant master(s) will be configured, as a template for tenant masters' components.
+
+The following cmd will create a `ClusterVersion` named `cv-sample-np`, which specifies the tenant master components as:
+- `etcd`: a StatefulSet with `virtualcluster/etcd-v3.4.0` image, 1 replica;
+- `apiServer`: a StatefulSet with `virtualcluster/apiserver-v1.16.2` image, 1 replica;
+- `controllerManager`: a StatefulSet with `virtualcluster/controller-manager-v1.16.2` image, 1 replica.
+
+```bash
+$ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/sampleswithspec/clusterversion_v1_nodeport.yaml
 ```
+
+> Note that tenant master does not have scheduler installed. The Pods are still scheduled as usual in super master.
+
+## Create VirtualCluster
+
+We can now create a `VirtualCluster` CR, which refers to the `ClusterVersion` that we just created.
+
+The `vc-manager` will create a tenant master, where its tenant apiserver is exposed through nodeport service.
+
+```bash
+$ kubectl vc create -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/sampleswithspec/virtualcluster_1_nodeport.yaml -o vc-1.kubeconfig
+2020/11/15 11:13:26 etcd is ready
+2020/11/15 11:13:46 apiserver is ready
+2020/11/15 11:14:12 controller-manager is ready
+2020/11/15 11:14:12 VirtualCluster default/vc-sample-1 setup successfully
+```
+
+The command will create a tenant master named `vc-sample-1`.
+
+Once it's created, a kubeconfig file specified by `-o`, namely `vc-1.kubeconfig`, will be created in the current directory.
+
+
+## Access Virtual Cluster
+
+The generated `vc-1.kubeconfig` can be used as a normal `kubeconfig` to access the tenant virtual cluster.
+
+Please note that if you're working on `kind` cluster, which, by default, exposes one random host port pointing to Kubernetes' default `6443`. In this case, we need to work around it and the simplest way is to deploy a "sidecar" container as the proxy to route management traffic to the service:
+
+```bash
+# Do this only when you're wroking in `kind`:
+
+# Retrieve the tenant namespace
+$ VC_NAMESPACE="$(kubectl get VirtualCluster vc-sample-1 -o json | jq -r '.status.clusterNamespace')"
+
+# The svc node port exposed
+$ VS_SVC_PORT="$(kubectl get -n ${VC_NAMESPACE} svc/apiserver-svc -o json | jq '.spec.ports[0].nodePort')"
+
+# Remove the container if there is any
+#$ docker rm -f ${CLUSTER_NAME}-kind-proxy-${VS_SVC_PORT} || true
+# Create this sidecar container
+$ docker run -d --restart always \
+    --name ${CLUSTER_NAME}-kind-proxy-${VS_SVC_PORT} \
+    --publish 127.0.0.1:${VS_SVC_PORT}:${VS_SVC_PORT} \
+    --link ${CLUSTER_NAME}-control-plane:target \
+    --network kind \
+    alpine/socat -dd \
+    tcp-listen:${VS_SVC_PORT},fork,reuseaddr tcp-connect:target:${VS_SVC_PORT}
+  
+# And update the vc-1.kubeconfig
+$ sed -i".bak" "s|.*server:.*|    server: https://127.0.0.1:${VS_SVC_PORT}|" vc-1.kubeconfig
+```
+
+Now let's take a look how Virtual Cluster looks like:
+
+```bash
+# A dedicated API Server, of course the <IP>:<PORT> may vary
 $ kubectl cluster-info --kubeconfig vc-1.kubeconfig
-Kubernetes master is running at https://XXX.XXX.XX.XXX:XXXXX
+Kubernetes master is running at https://192.168.99.106:31501  # in minikube cluster
+Kubernetes master is running at https://127.0.0.1:30998       # or in kind cluster
+
+# Looks exactly like a vanilla Kubernetes
+$ kubectl get namespace --kubeconfig vc-1.kubeconfig
+NAME              STATUS   AGE
+default           Active   9m11s
+kube-node-lease   Active   9m13s
+kube-public       Active   9m13s
+kube-system       Active   9m13s
 ```
 
-or
-```
-$ kubectl get node --kubeconfig vc-1.kubeconfig
-No resources found in default namespace.
-```
+But from the super master angle, we can see something different:
 
-You can also observe that a few new namespaces are created in super master by the syncer controller.
 ```bash
-$ kubectl get ns
-NAME                                              STATUS   AGE
-default                                           Active   1d
-kube-node-lease                                   Active   1d
-kube-public                                       Active   1d
-kube-system                                       Active   1d
-tenant1admin                                      Active   1d
-tenant1admin-41f609-vc-sample-1                   Active   2m
-tenant1admin-41f609-vc-sample-1-default           Active   2m
-tenant1admin-41f609-vc-sample-1-kube-node-lease   Active   2m
-tenant1admin-41f609-vc-sample-1-kube-public       Active   2m
-tenant1admin-41f609-vc-sample-1-kube-system       Active   2m
-vc-manager                                        Active   1d
+$ kubectl get namespace
+NAME                                         STATUS   AGE
+default                                      Active   30m
+default-532c0e-vc-sample-1                   Active   10m
+default-532c0e-vc-sample-1-default           Active   8m53s
+default-532c0e-vc-sample-1-kube-node-lease   Active   8m53s
+default-532c0e-vc-sample-1-kube-public       Active   8m53s
+default-532c0e-vc-sample-1-kube-system       Active   8m53s
+kube-node-lease                              Active   30m
+kube-public                                  Active   30m
+kube-system                                  Active   30m
+local-path-storage                           Active   30m
+vc-manager                                   Active   20m
 ```
 
-## Experiments
-We can create a test Deployment in the tenant master by running
+## Let's do some experiments
+
+From now on, we can view the virtual cluster as a normal cluster to work with.
+
 ```bash
-kubectl apply --kubeconfig vc-1.kubeconfig -f - <<EOF
+# Let's create a deployment
+$ kubectl apply --kubeconfig vc-1.kubeconfig -f - <<EOF
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -135,39 +273,59 @@ spec:
         command:
         - top
 EOF
-```
 
-Upon successful creation, there are newly created Pods in
-both tenant master and super master.
-
-```
+# Upon successful creation, there are newly created Pods in both tenant master and super master.
+# a view from the tenant master
 $ kubectl get pod --kubeconfig vc-1.kubeconfig
-NAME                          READY   STATUS    RESTARTS   AGE
-test-deploy-f5dbf6b69-vcwf6   1/1     Running   0          33s
+NAME                         READY   STATUS    RESTARTS   AGE
+test-deploy-5f4bcd8c-9thn7   1/1     Running   0          4m44s
+# a view from the super master
+$ VC_NAMESPACE="$(kubectl get VirtualCluster vc-sample-1 -o json | jq -r '.status.clusterNamespace')"
+$ kubectl get pod -n "${VC_NAMESPACE}-default"
+NAME                         READY   STATUS    RESTARTS   AGE
+test-deploy-5f4bcd8c-9thn7   1/1     Running   0          4m56
 
-$ kubectl get pod -n tenant1admin-41f609-vc-sample-1-default
-NAME                          READY   STATUS    RESTARTS   AGE
-test-deploy-f5dbf6b69-vcwf6   1/1     Running   0          35s
-```
-
-Also, a new virtual node is created in the tenant master and tenant cannot schedule Pod on it.
-```
+# Also, a new virtual node is created in the tenant master and tenant cannot schedule Pod on it.
 $ kubectl get node --kubeconfig vc-1.kubeconfig
-NAME       STATUS                     ROLES    AGE     VERSION
-minikube   Ready,SchedulingDisabled   <none>   5m40s   v1.17.2
-```
+NAME       STATUS                     ROLES    AGE   VERSION
+minikube   Ready,SchedulingDisabled   <none>   16m   v1.19.4                    # we see this in minikube cluster
+virtual-cluster-worker   NotReady,SchedulingDisabled   <none>   5m8s   v1.19.1  # and this in kind cluster
 
-The kubelet APIs such as `logs` or `exec` should work in the tenant master.
-```
-$ kubectl exec test-deploy-f5dbf6b69-vcwf --kubeconfig vc-1.kubeconfig -it /bin/sh
+# The kubelet APIs such as `logs` or `exec` should work in the tenant master.
+$ VC_POD="$(kubectl get pod -l app='vc-test' --kubeconfig vc-1.kubeconfig -o jsonpath="{.items[0].metadata.name}")"
+
+# Let's try kubectl exec
+$ kubectl exec -it "${VC_POD}" --kubeconfig vc-1.kubeconfig -- /bin/sh
 / # ls
 bin   dev   etc   home  proc  root  sys   tmp   usr   var
 
+# And kubectl logs, yes we can see the logs from output of container's command "top"
+$ kubectl logs "${VC_POD}" --kubeconfig vc-1.kubeconfig
+Mem: 5349052K used, 739760K free, 35912K shrd, 203292K buff, 3140872K cached
+CPU:  7.0% usr  5.9% sys  0.0% nic 86.5% idle  0.0% io  0.0% irq  0.3% sirq
+Load average: 0.45 0.47 0.54 1/1308 23
+  PID  PPID USER     STAT   VSZ %VSZ CPU %CPU COMMAND
 ```
 
 ## Cleanup
 
-By deleting the virtualcluster CR, all the tenant resources created in the super master will be
-deleted.
+By deleting the VirtualCluster CR, all the tenant resources created in the super master will be deleted.
 
+```bash
+# The VirtualCluster
+$ kubectl delete VirtualCluster vc-sample-1
+```
 
+Of course, you can delete all others VirtualCluster objects too to clean up everything:
+
+```bash
+# The ClusterVersion
+$ kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/sampleswithspec/clusterversion_v1_nodeport.yaml
+
+# The Virtual Cluster components
+$ kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/setup/all_in_one.yaml
+
+# The CRDs
+$ kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/crds/tenancy.x-k8s.io_virtualclusters.yaml
+$ kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/sampleswithspec/tenancy.x-k8s.io_clusterversions.yaml
+```


### PR DESCRIPTION
This PR introduces 3 major updates for VirtualCluster:

1. Fix the CRD as the generated one for `clusterversions` doesn't work
2. Add `kind` support, together with existing `minikube`
3. Review the demo flow with more comments for users to better understand VirtualCluster through the process