### PR TITLE
Better debug and error logging

### DIFF
--- a/incubator/hnc/go.mod
+++ b/incubator/hnc/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/open-policy-agent/cert-controller v0.0.0-20200921224206-24b87bbc4b6e
 	github.com/spf13/cobra v0.0.5
 	go.opencensus.io v0.22.3
+	go.uber.org/zap v1.10.0
 	k8s.io/api v0.18.6
 	k8s.io/apiextensions-apiserver v0.18.6
 	k8s.io/apimachinery v0.18.6

--- a/incubator/hnc/vendor/modules.txt
+++ b/incubator/hnc/vendor/modules.txt
@@ -281,6 +281,7 @@ go.uber.org/atomic
 # go.uber.org/multierr v1.1.0
 go.uber.org/multierr
 # go.uber.org/zap v1.10.0
+## explicit
 go.uber.org/zap
 go.uber.org/zap/buffer
 go.uber.org/zap/internal/bufferpool


### PR DESCRIPTION
This change reduces the differences between regular and debug logging
(it simply changes the logging level, as opposed to also the format) and
also gets rid of the (largely useless) stack traces that are printed out
during an error.

Tested: observed the better logging behaviour with the new switches.