### PR TITLE
Fix E2E tests and namespace deletion validation

### DIFF
--- a/incubator/hnc/pkg/testutils/testutils.go
+++ b/incubator/hnc/pkg/testutils/testutils.go
@@ -287,11 +287,16 @@ func TearDownHNC(hncVersion string) {
 	runShouldNotContain(1, ".hnc.x-k8s.io", 10, "kubectl get crd")
 }
 
-// CheckHNCPath return true if we'll be able to successfully call RecoverHNC, and false otherwise.
+// CheckHNCPath skips the test if we are not able to successfully call RecoverHNC
 func CheckHNCPath() {
 	if hncRecoverPath == "" {
 		Skip("Environment variable HNC_REPAIR not set. Skipping tests that require repairing HNC.")
 	}
+}
+
+// HasHNCPath returns true if we'll be able to successfully call RecoverHNC, and false otherwise. 
+func HasHNCPath() bool {
+	return hncRecoverPath != ""
 }
 
 // RecoverHNC assumes that HNC has been damaged in some way and repairs by re-applying its manifest

--- a/incubator/hnc/test/e2e/delete_crd_test.go
+++ b/incubator/hnc/test/e2e/delete_crd_test.go
@@ -24,7 +24,10 @@ var _ = Describe("When deleting CRDs", func() {
 		// running anymore, and the admission webhooks are operating off of bad information (e.g. that a
 		// subnamespace's annotation has been removed). So delete the VWC so we can clean up
 		// effectively; it'll be restored by RecoverHNC anyway.
-		MustRun("kubectl delete validatingwebhookconfigurations hnc-validating-webhook-configuration")
+		if HasHNCPath() {
+			MustRun("kubectl delete validatingwebhookconfigurations hnc-validating-webhook-configuration")
+		}
+
 		CleanupNamespaces(nsParent, nsChild)
 		RecoverHNC()
 	})

--- a/incubator/hnc/test/e2e/issues_test.go
+++ b/incubator/hnc/test/e2e/issues_test.go
@@ -161,18 +161,6 @@ var _ = Describe("Issues", func() {
 		RunShouldContain("ActivitiesHalted (ParentMissing)", defTimeout, "kubectl hns describe", nsChild)
 	})
 
-	It("Should delete namespace with ParentMissing condition - issue #716", func() {
-		// Setting up a 2-level tree with 'a' as the root and 'b' as a child of 'a'"
-		MustRun("kubectl create ns", nsParent)
-		MustRun("kubectl create ns", nsChild)
-		MustRun("kubectl hns set", nsChild, "--parent", nsParent)
-		// create and verify ParentMissing condition
-		MustRun("kubectl delete ns", nsParent)
-		RunShouldContain("ActivitiesHalted (ParentMissing)", defTimeout, "kubectl hns describe", nsChild)
-		// test: delete namespace
-		MustRun("kubectl delete ns", nsChild)
-	})
-
 	It("Should not delete a parent of a subnamespace if allowCascadingDeletion is not set -issue #716", func() {
 		// Setting up a 2-level tree
 		MustRun("kubectl create ns", nsParent)


### PR DESCRIPTION
When deleting a parent namespace, we should allow it if none of its
children are sub-namespace.

In the E2E test, I moved the webhook deletion out of AfterEach, so that
if the user doesn't have HNC_REPAIR path set, it won't delete the
webhook.

Since we changed the deletion validator, one of the tests for issue #716
does not apply anymore. I deleted it in this PR.

Fix #1269

Tested: make test-e2e