### PR TITLE
Validate only one non-negated namespace for treeSelect

### DIFF
--- a/incubator/hnc/internal/validators/object_test.go
+++ b/incubator/hnc/internal/validators/object_test.go
@@ -351,6 +351,34 @@ func TestUserChanges(t *testing.T) {
 			},
 		},
 	}, {
+		name: "Deny creation of object with multiple non-negated treeSelect annotation",
+		fail: true,
+		inst: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						api.AnnotationTreeSelector: "foo, bar",
+					},
+				},
+			},
+		},
+	}, {
+		name: "Allow creation of object with multiple negated treeSelect annotation",
+		fail: false,
+		inst: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						api.AnnotationTreeSelector: "!foo, !bar",
+					},
+				},
+			},
+		},
+	}, {
 		name: "Allow creation of object with valid treeSelect annotation",
 		fail: false,
 		inst: &unstructured.Unstructured{


### PR DESCRIPTION
If multiple non-negated namespaces are set for treeSelect, this object
will not be propagated to anywhere, in which case the user should use
none selector instead.

Tested: make test