### PR TITLE
CleanupNamespaces shouldn't require an explicit list of namespaces

### DIFF
--- a/incubator/hnc/test/e2e/delete_crd_test.go
+++ b/incubator/hnc/test/e2e/delete_crd_test.go
@@ -16,7 +16,7 @@ var _ = Describe("When deleting CRDs", func() {
 
 	BeforeEach(func() {
 		CheckHNCPath()
-		CleanupNamespaces(nsParent, nsChild)
+		CleanupTestNamespaces()
 	})
 
 	AfterEach(func() {
@@ -27,15 +27,14 @@ var _ = Describe("When deleting CRDs", func() {
 		if HasHNCPath() {
 			MustRun("kubectl delete validatingwebhookconfigurations hnc-validating-webhook-configuration")
 		}
-
-		CleanupNamespaces(nsParent, nsChild)
+		CleanupTestNamespaces()
 		RecoverHNC()
 	})
 
 	It("should not delete subnamespaces", func() {
 		// set up
-		MustRun("kubectl create ns", nsParent)
-		MustRun("kubectl hns create", nsChild, "-n", nsParent)
+		CreateNamespace(nsParent)
+		CreateSubnamespace(nsChild, nsParent)
 		MustRun("kubectl get ns", nsChild)
 		// delete the CRD
 		MustRun("kubectl delete customresourcedefinition/subnamespaceanchors.hnc.x-k8s.io")
@@ -45,8 +44,8 @@ var _ = Describe("When deleting CRDs", func() {
 
 	It("should create a rolebinding in parent and propagate to child", func() {
 		// set up
-		MustRun("kubectl create ns", nsParent)
-		MustRun("kubectl create ns", nsChild)
+		CreateNamespace(nsParent)
+		CreateNamespace(nsChild)
 		MustRun("kubectl hns set", nsChild, "--parent", nsParent)
 		// test
 		MustRun("kubectl create rolebinding --clusterrole=view --serviceaccount=default:default -n", nsParent, "foo")
@@ -63,8 +62,8 @@ var _ = Describe("When deleting CRDs", func() {
 
 	It("should fully delete all CRDs", func() {
 		// set up
-		MustRun("kubectl create ns", nsParent)
-		MustRun("kubectl hns create", nsChild, "-n", nsParent)
+		CreateNamespace(nsParent)
+		CreateSubnamespace(nsChild, nsParent)
 		// test
 		MustRun("kubectl delete crd hierarchyconfigurations.hnc.x-k8s.io")
 		time.Sleep(1 * time.Second)

--- a/incubator/hnc/test/e2e/namespace_test.go
+++ b/incubator/hnc/test/e2e/namespace_test.go
@@ -16,16 +16,16 @@ var _ = Describe("Namespace", func() {
 	)
 
 	BeforeEach(func() {
-		CleanupNamespaces(nsA, nsB)
+		CleanupTestNamespaces()
 	})
 
 	AfterEach(func() {
-		CleanupNamespaces(nsA, nsB)
+		CleanupTestNamespaces()
 	})
 
 	It("should create and delete a namespace", func() {
 		// set up
-		MustRun("kubectl create ns", nsA)
+		CreateNamespace(nsA)
 		MustRun("kubectl get ns", nsA)
 
 		// test
@@ -37,8 +37,8 @@ var _ = Describe("Namespace", func() {
 
 	It("should have 'ParentMissing' condition on orphaned namespace", func() {
 		// set up
-		MustRun("kubectl create ns", nsA)
-		MustRun("kubectl create ns", nsB)
+		CreateNamespace(nsA)
+		CreateNamespace(nsB)
 		MustRun("kubectl hns set", nsB, "--parent", nsA)
 		MustRun("kubectl delete ns", nsA)
 

--- a/incubator/hnc/test/e2e/rolebinding_test.go
+++ b/incubator/hnc/test/e2e/rolebinding_test.go
@@ -16,11 +16,11 @@ var _ = Describe("HNC should delete and create a new Rolebinding instead of upda
 
 	BeforeEach(func() {
 		CheckHNCPath()
-		CleanupNamespaces(nsParent, nsChild)
+		CleanupTestNamespaces()
 	})
 
 	AfterEach(func() {
-		CleanupNamespaces(nsParent, nsChild)
+		CleanupTestNamespaces()
 		RecoverHNC()
 	})
 
@@ -29,8 +29,8 @@ var _ = Describe("HNC should delete and create a new Rolebinding instead of upda
 		// After recovering HNC, if nsChild gets reconciled first, the 'admin' rolebinding will
 		// be deleted, and the 'edit' rolebinding will be created when nsParent gets reconciled.
 		// In this case the rolebinding would not be considered as 'updated' and the test will pass
-		MustRun("kubectl create ns", nsParent)
-		MustRun("kubectl hns create", nsChild, "-n", nsParent)
+		CreateNamespace(nsParent)
+		CreateSubnamespace(nsChild, nsParent)
 		MustRun("kubectl create rolebinding test --clusterrole=admin --serviceaccount=default:default -n", nsParent)
 		FieldShouldContain("rolebinding", nsChild, "test", ".roleRef.name", "admin")
 
@@ -40,7 +40,7 @@ var _ = Describe("HNC should delete and create a new Rolebinding instead of upda
 		// 5s fairly arbitrarily, but it works well. Feel free to try lower values it you like.
 		//   - aludwin, Sep 2020
 		MustRun("kubectl delete deployment --all -n hnc-system")
-		time.Sleep(5*time.Second)
+		time.Sleep(5 * time.Second)
 
 		// Replace the source rolebinding
 		MustRun("kubectl delete rolebinding test -n", nsParent)

--- a/incubator/hnc/test/e2e/subnamespace_test.go
+++ b/incubator/hnc/test/e2e/subnamespace_test.go
@@ -13,18 +13,18 @@ var _ = Describe("Subnamespaces", func() {
 	)
 
 	BeforeEach(func() {
-		CleanupNamespaces(nsA, nsB)
+		CleanupTestNamespaces()
 	})
 
 	AfterEach(func() {
-		CleanupNamespaces(nsA, nsB)
+		CleanupTestNamespaces()
 	})
 
 	It("should create and delete a subnamespace", func() {
 		// set up
-		MustRun("kubectl create ns", nsA)
+		CreateNamespace(nsA)
 		MustRun("kubectl get ns", nsA)
-		MustRun("kubectl hns create", nsB, "-n", nsA)
+		CreateSubnamespace(nsB, nsA)
 
 		// verify
 		FieldShouldContain("ns", "", nsB, ".metadata.annotations", "subnamespace-of:"+nsA)


### PR DESCRIPTION
See issue #1043. Added functions Createnamespace,Createsubnamespace,
CreateNamespaceWithLabels,CleanupTestNamespaces. The create functions
mark all the namespaces with a test label. Refactored all e2e test
cases to utilize the new functions. Preserved the older CleanupNamespace
function if it is useful for specific namespace deletion use case

Tested: Ran the e2e tests on k3d with k8s version v1.17.12. All tests passed
except the network policies test which was skipped.