### PR TITLE
[VirtualCluster] patch to correct the CRDs generated by controller-gen and use them in demo

### DIFF
--- a/incubator/virtualcluster/Makefile
+++ b/incubator/virtualcluster/Makefile
@@ -82,6 +82,24 @@ deploy: manifests
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role paths="./..." output:crd:artifacts:config=config/crds
 	hack/make-rules/replace-null.sh
+# To work around a known controller gen issue
+# https://github.com/kubernetes-sigs/kubebuilder/issues/1544
+ifeq (, $(shell which yq))
+	@echo "Please install yq for yaml patching. Get it from here: https://github.com/mikefarah/yq"
+	@exit
+else
+	@{ \
+	yq w -i config/crds/tenancy.x-k8s.io_clusterversions.yaml "spec.validation.openAPIV3Schema.properties.spec.properties.apiServer.properties.statefulset.properties.spec.properties.template.properties.spec.properties.containers.items.properties.ports.items.required[1]" protocol;\
+	yq w -i config/crds/tenancy.x-k8s.io_clusterversions.yaml "spec.validation.openAPIV3Schema.properties.spec.properties.controllerManager.properties.statefulset.properties.spec.properties.template.properties.spec.properties.containers.items.properties.ports.items.required[1]" protocol;\
+	yq w -i config/crds/tenancy.x-k8s.io_clusterversions.yaml "spec.validation.openAPIV3Schema.properties.spec.properties.etcd.properties.statefulset.properties.spec.properties.template.properties.spec.properties.containers.items.properties.ports.items.required[1]" protocol;\
+	yq w -i config/crds/tenancy.x-k8s.io_clusterversions.yaml "spec.validation.openAPIV3Schema.properties.spec.properties.apiServer.properties.statefulset.properties.spec.properties.template.properties.spec.properties.initContainers.items.properties.ports.items.required[1]" protocol;\
+	yq w -i config/crds/tenancy.x-k8s.io_clusterversions.yaml "spec.validation.openAPIV3Schema.properties.spec.properties.controllerManager.properties.statefulset.properties.spec.properties.template.properties.spec.properties.initContainers.items.properties.ports.items.required[1]" protocol;\
+	yq w -i config/crds/tenancy.x-k8s.io_clusterversions.yaml "spec.validation.openAPIV3Schema.properties.spec.properties.etcd.properties.statefulset.properties.spec.properties.template.properties.spec.properties.initContainers.items.properties.ports.items.required[1]" protocol;\
+	yq w -i config/crds/tenancy.x-k8s.io_clusterversions.yaml "spec.validation.openAPIV3Schema.properties.spec.properties.apiServer.properties.service.properties.spec.properties.ports.items.required[1]" protocol;\
+	yq w -i config/crds/tenancy.x-k8s.io_clusterversions.yaml "spec.validation.openAPIV3Schema.properties.spec.properties.controllerManager.properties.service.properties.spec.properties.ports.items.required[1]" protocol;\
+	yq w -i config/crds/tenancy.x-k8s.io_clusterversions.yaml "spec.validation.openAPIV3Schema.properties.spec.properties.etcd.properties.service.properties.spec.properties.ports.items.required[1]" protocol;\
+	}
+endif
 
 # Run go fmt against code
 fmt:

--- a/incubator/virtualcluster/config/crds/tenancy.x-k8s.io_clusterversions.yaml
+++ b/incubator/virtualcluster/config/crds/tenancy.x-k8s.io_clusterversions.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -14,7 +12,7 @@ spec:
     listKind: ClusterVersionList
     plural: clusterversions
     shortNames:
-    - cv
+      - cv
     singular: clusterversion
   scope: Cluster
   validation:
@@ -80,16 +78,17 @@ spec:
                                 type: string
                               targetPort:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 x-kubernetes-int-or-string: true
                             required:
-                            - port
+                              - port
+                              - protocol
                             type: object
                           type: array
                           x-kubernetes-list-map-keys:
-                          - port
-                          - protocol
+                            - port
+                            - protocol
                           x-kubernetes-list-type: map
                         publishNotReadyAddresses:
                           type: boolean
@@ -164,8 +163,8 @@ spec:
                                       type: string
                                     type: array
                                 required:
-                                - key
-                                - operator
+                                  - key
+                                  - operator
                                 type: object
                               type: array
                             matchLabels:
@@ -205,8 +204,8 @@ spec:
                                                             type: string
                                                           type: array
                                                       required:
-                                                      - key
-                                                      - operator
+                                                        - key
+                                                        - operator
                                                       type: object
                                                     type: array
                                                   matchFields:
@@ -221,8 +220,8 @@ spec:
                                                             type: string
                                                           type: array
                                                       required:
-                                                      - key
-                                                      - operator
+                                                        - key
+                                                        - operator
                                                       type: object
                                                     type: array
                                                 type: object
@@ -230,8 +229,8 @@ spec:
                                                 format: int32
                                                 type: integer
                                             required:
-                                            - preference
-                                            - weight
+                                              - preference
+                                              - weight
                                             type: object
                                           type: array
                                         requiredDuringSchedulingIgnoredDuringExecution:
@@ -251,8 +250,8 @@ spec:
                                                             type: string
                                                           type: array
                                                       required:
-                                                      - key
-                                                      - operator
+                                                        - key
+                                                        - operator
                                                       type: object
                                                     type: array
                                                   matchFields:
@@ -267,14 +266,14 @@ spec:
                                                             type: string
                                                           type: array
                                                       required:
-                                                      - key
-                                                      - operator
+                                                        - key
+                                                        - operator
                                                       type: object
                                                     type: array
                                                 type: object
                                               type: array
                                           required:
-                                          - nodeSelectorTerms
+                                            - nodeSelectorTerms
                                           type: object
                                       type: object
                                     podAffinity:
@@ -298,8 +297,8 @@ spec:
                                                                 type: string
                                                               type: array
                                                           required:
-                                                          - key
-                                                          - operator
+                                                            - key
+                                                            - operator
                                                           type: object
                                                         type: array
                                                       matchLabels:
@@ -314,14 +313,14 @@ spec:
                                                   topologyKey:
                                                     type: string
                                                 required:
-                                                - topologyKey
+                                                  - topologyKey
                                                 type: object
                                               weight:
                                                 format: int32
                                                 type: integer
                                             required:
-                                            - podAffinityTerm
-                                            - weight
+                                              - podAffinityTerm
+                                              - weight
                                             type: object
                                           type: array
                                         requiredDuringSchedulingIgnoredDuringExecution:
@@ -341,8 +340,8 @@ spec:
                                                             type: string
                                                           type: array
                                                       required:
-                                                      - key
-                                                      - operator
+                                                        - key
+                                                        - operator
                                                       type: object
                                                     type: array
                                                   matchLabels:
@@ -357,7 +356,7 @@ spec:
                                               topologyKey:
                                                 type: string
                                             required:
-                                            - topologyKey
+                                              - topologyKey
                                             type: object
                                           type: array
                                       type: object
@@ -382,8 +381,8 @@ spec:
                                                                 type: string
                                                               type: array
                                                           required:
-                                                          - key
-                                                          - operator
+                                                            - key
+                                                            - operator
                                                           type: object
                                                         type: array
                                                       matchLabels:
@@ -398,14 +397,14 @@ spec:
                                                   topologyKey:
                                                     type: string
                                                 required:
-                                                - topologyKey
+                                                  - topologyKey
                                                 type: object
                                               weight:
                                                 format: int32
                                                 type: integer
                                             required:
-                                            - podAffinityTerm
-                                            - weight
+                                              - podAffinityTerm
+                                              - weight
                                             type: object
                                           type: array
                                         requiredDuringSchedulingIgnoredDuringExecution:
@@ -425,8 +424,8 @@ spec:
                                                             type: string
                                                           type: array
                                                       required:
-                                                      - key
-                                                      - operator
+                                                        - key
+                                                        - operator
                                                       type: object
                                                     type: array
                                                   matchLabels:
@@ -441,7 +440,7 @@ spec:
                                               topologyKey:
                                                 type: string
                                             required:
-                                            - topologyKey
+                                              - topologyKey
                                             type: object
                                           type: array
                                       type: object
@@ -477,7 +476,7 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   required:
-                                                  - key
+                                                    - key
                                                   type: object
                                                 fieldRef:
                                                   properties:
@@ -486,7 +485,7 @@ spec:
                                                     fieldPath:
                                                       type: string
                                                   required:
-                                                  - fieldPath
+                                                    - fieldPath
                                                   type: object
                                                 resourceFieldRef:
                                                   properties:
@@ -494,14 +493,14 @@ spec:
                                                       type: string
                                                     divisor:
                                                       anyOf:
-                                                      - type: integer
-                                                      - type: string
+                                                        - type: integer
+                                                        - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
                                                       type: string
                                                   required:
-                                                  - resource
+                                                    - resource
                                                   type: object
                                                 secretKeyRef:
                                                   properties:
@@ -512,11 +511,11 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   required:
-                                                  - key
+                                                    - key
                                                   type: object
                                               type: object
                                           required:
-                                          - name
+                                            - name
                                           type: object
                                         type: array
                                       envFrom:
@@ -567,21 +566,21 @@ spec:
                                                         value:
                                                           type: string
                                                       required:
-                                                      - name
-                                                      - value
+                                                        - name
+                                                        - value
                                                       type: object
                                                     type: array
                                                   path:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                   scheme:
                                                     type: string
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                               tcpSocket:
                                                 properties:
@@ -589,11 +588,11 @@ spec:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                             type: object
                                           preStop:
@@ -617,21 +616,21 @@ spec:
                                                         value:
                                                           type: string
                                                       required:
-                                                      - name
-                                                      - value
+                                                        - name
+                                                        - value
                                                       type: object
                                                     type: array
                                                   path:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                   scheme:
                                                     type: string
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                               tcpSocket:
                                                 properties:
@@ -639,11 +638,11 @@ spec:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                             type: object
                                         type: object
@@ -671,21 +670,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -702,11 +701,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -730,12 +729,13 @@ spec:
                                             protocol:
                                               type: string
                                           required:
-                                          - containerPort
+                                            - containerPort
+                                            - protocol
                                           type: object
                                         type: array
                                         x-kubernetes-list-map-keys:
-                                        - containerPort
-                                        - protocol
+                                          - containerPort
+                                          - protocol
                                         x-kubernetes-list-type: map
                                       readinessProbe:
                                         properties:
@@ -761,21 +761,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -792,11 +792,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -807,16 +807,16 @@ spec:
                                           limits:
                                             additionalProperties:
                                               anyOf:
-                                              - type: integer
-                                              - type: string
+                                                - type: integer
+                                                - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             type: object
                                           requests:
                                             additionalProperties:
                                               anyOf:
-                                              - type: integer
-                                              - type: string
+                                                - type: integer
+                                                - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             type: object
@@ -895,21 +895,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -926,11 +926,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -954,8 +954,8 @@ spec:
                                             name:
                                               type: string
                                           required:
-                                          - devicePath
-                                          - name
+                                            - devicePath
+                                            - name
                                           type: object
                                         type: array
                                       volumeMounts:
@@ -974,14 +974,14 @@ spec:
                                             subPathExpr:
                                               type: string
                                           required:
-                                          - mountPath
-                                          - name
+                                            - mountPath
+                                            - name
                                           type: object
                                         type: array
                                       workingDir:
                                         type: string
                                     required:
-                                    - name
+                                      - name
                                     type: object
                                   type: array
                                 dnsConfig:
@@ -1037,7 +1037,7 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   required:
-                                                  - key
+                                                    - key
                                                   type: object
                                                 fieldRef:
                                                   properties:
@@ -1046,7 +1046,7 @@ spec:
                                                     fieldPath:
                                                       type: string
                                                   required:
-                                                  - fieldPath
+                                                    - fieldPath
                                                   type: object
                                                 resourceFieldRef:
                                                   properties:
@@ -1054,14 +1054,14 @@ spec:
                                                       type: string
                                                     divisor:
                                                       anyOf:
-                                                      - type: integer
-                                                      - type: string
+                                                        - type: integer
+                                                        - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
                                                       type: string
                                                   required:
-                                                  - resource
+                                                    - resource
                                                   type: object
                                                 secretKeyRef:
                                                   properties:
@@ -1072,11 +1072,11 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   required:
-                                                  - key
+                                                    - key
                                                   type: object
                                               type: object
                                           required:
-                                          - name
+                                            - name
                                           type: object
                                         type: array
                                       envFrom:
@@ -1127,21 +1127,21 @@ spec:
                                                         value:
                                                           type: string
                                                       required:
-                                                      - name
-                                                      - value
+                                                        - name
+                                                        - value
                                                       type: object
                                                     type: array
                                                   path:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                   scheme:
                                                     type: string
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                               tcpSocket:
                                                 properties:
@@ -1149,11 +1149,11 @@ spec:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                             type: object
                                           preStop:
@@ -1177,21 +1177,21 @@ spec:
                                                         value:
                                                           type: string
                                                       required:
-                                                      - name
-                                                      - value
+                                                        - name
+                                                        - value
                                                       type: object
                                                     type: array
                                                   path:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                   scheme:
                                                     type: string
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                               tcpSocket:
                                                 properties:
@@ -1199,11 +1199,11 @@ spec:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                             type: object
                                         type: object
@@ -1231,21 +1231,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -1262,11 +1262,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -1290,7 +1290,7 @@ spec:
                                             protocol:
                                               type: string
                                           required:
-                                          - containerPort
+                                            - containerPort
                                           type: object
                                         type: array
                                       readinessProbe:
@@ -1317,21 +1317,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -1348,11 +1348,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -1363,16 +1363,16 @@ spec:
                                           limits:
                                             additionalProperties:
                                               anyOf:
-                                              - type: integer
-                                              - type: string
+                                                - type: integer
+                                                - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             type: object
                                           requests:
                                             additionalProperties:
                                               anyOf:
-                                              - type: integer
-                                              - type: string
+                                                - type: integer
+                                                - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             type: object
@@ -1451,21 +1451,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -1482,11 +1482,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -1512,8 +1512,8 @@ spec:
                                             name:
                                               type: string
                                           required:
-                                          - devicePath
-                                          - name
+                                            - devicePath
+                                            - name
                                           type: object
                                         type: array
                                       volumeMounts:
@@ -1532,14 +1532,14 @@ spec:
                                             subPathExpr:
                                               type: string
                                           required:
-                                          - mountPath
-                                          - name
+                                            - mountPath
+                                            - name
                                           type: object
                                         type: array
                                       workingDir:
                                         type: string
                                     required:
-                                    - name
+                                      - name
                                     type: object
                                   type: array
                                 hostAliases:
@@ -1597,7 +1597,7 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   required:
-                                                  - key
+                                                    - key
                                                   type: object
                                                 fieldRef:
                                                   properties:
@@ -1606,7 +1606,7 @@ spec:
                                                     fieldPath:
                                                       type: string
                                                   required:
-                                                  - fieldPath
+                                                    - fieldPath
                                                   type: object
                                                 resourceFieldRef:
                                                   properties:
@@ -1614,14 +1614,14 @@ spec:
                                                       type: string
                                                     divisor:
                                                       anyOf:
-                                                      - type: integer
-                                                      - type: string
+                                                        - type: integer
+                                                        - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
                                                       type: string
                                                   required:
-                                                  - resource
+                                                    - resource
                                                   type: object
                                                 secretKeyRef:
                                                   properties:
@@ -1632,11 +1632,11 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   required:
-                                                  - key
+                                                    - key
                                                   type: object
                                               type: object
                                           required:
-                                          - name
+                                            - name
                                           type: object
                                         type: array
                                       envFrom:
@@ -1687,21 +1687,21 @@ spec:
                                                         value:
                                                           type: string
                                                       required:
-                                                      - name
-                                                      - value
+                                                        - name
+                                                        - value
                                                       type: object
                                                     type: array
                                                   path:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                   scheme:
                                                     type: string
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                               tcpSocket:
                                                 properties:
@@ -1709,11 +1709,11 @@ spec:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                             type: object
                                           preStop:
@@ -1737,21 +1737,21 @@ spec:
                                                         value:
                                                           type: string
                                                       required:
-                                                      - name
-                                                      - value
+                                                        - name
+                                                        - value
                                                       type: object
                                                     type: array
                                                   path:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                   scheme:
                                                     type: string
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                               tcpSocket:
                                                 properties:
@@ -1759,11 +1759,11 @@ spec:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                             type: object
                                         type: object
@@ -1791,21 +1791,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -1822,11 +1822,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -1850,12 +1850,13 @@ spec:
                                             protocol:
                                               type: string
                                           required:
-                                          - containerPort
+                                            - containerPort
+                                            - protocol
                                           type: object
                                         type: array
                                         x-kubernetes-list-map-keys:
-                                        - containerPort
-                                        - protocol
+                                          - containerPort
+                                          - protocol
                                         x-kubernetes-list-type: map
                                       readinessProbe:
                                         properties:
@@ -1881,21 +1882,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -1912,11 +1913,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -1927,16 +1928,16 @@ spec:
                                           limits:
                                             additionalProperties:
                                               anyOf:
-                                              - type: integer
-                                              - type: string
+                                                - type: integer
+                                                - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             type: object
                                           requests:
                                             additionalProperties:
                                               anyOf:
-                                              - type: integer
-                                              - type: string
+                                                - type: integer
+                                                - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             type: object
@@ -2015,21 +2016,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -2046,11 +2047,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -2074,8 +2075,8 @@ spec:
                                             name:
                                               type: string
                                           required:
-                                          - devicePath
-                                          - name
+                                            - devicePath
+                                            - name
                                           type: object
                                         type: array
                                       volumeMounts:
@@ -2094,14 +2095,14 @@ spec:
                                             subPathExpr:
                                               type: string
                                           required:
-                                          - mountPath
-                                          - name
+                                            - mountPath
+                                            - name
                                           type: object
                                         type: array
                                       workingDir:
                                         type: string
                                     required:
-                                    - name
+                                      - name
                                     type: object
                                   type: array
                                 nodeName:
@@ -2113,8 +2114,8 @@ spec:
                                 overhead:
                                   additionalProperties:
                                     anyOf:
-                                    - type: integer
-                                    - type: string
+                                      - type: integer
+                                      - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type: object
@@ -2131,7 +2132,7 @@ spec:
                                       conditionType:
                                         type: string
                                     required:
-                                    - conditionType
+                                      - conditionType
                                     type: object
                                   type: array
                                 restartPolicy:
@@ -2179,8 +2180,8 @@ spec:
                                           value:
                                             type: string
                                         required:
-                                        - name
-                                        - value
+                                          - name
+                                          - value
                                         type: object
                                       type: array
                                     windowsOptions:
@@ -2237,8 +2238,8 @@ spec:
                                                     type: string
                                                   type: array
                                               required:
-                                              - key
-                                              - operator
+                                                - key
+                                                - operator
                                               type: object
                                             type: array
                                           matchLabels:
@@ -2254,14 +2255,14 @@ spec:
                                       whenUnsatisfiable:
                                         type: string
                                     required:
-                                    - maxSkew
-                                    - topologyKey
-                                    - whenUnsatisfiable
+                                      - maxSkew
+                                      - topologyKey
+                                      - whenUnsatisfiable
                                     type: object
                                   type: array
                                   x-kubernetes-list-map-keys:
-                                  - topologyKey
-                                  - whenUnsatisfiable
+                                    - topologyKey
+                                    - whenUnsatisfiable
                                   x-kubernetes-list-type: map
                                 volumes:
                                   items:
@@ -2278,7 +2279,7 @@ spec:
                                           volumeID:
                                             type: string
                                         required:
-                                        - volumeID
+                                          - volumeID
                                         type: object
                                       azureDisk:
                                         properties:
@@ -2295,8 +2296,8 @@ spec:
                                           readOnly:
                                             type: boolean
                                         required:
-                                        - diskName
-                                        - diskURI
+                                          - diskName
+                                          - diskURI
                                         type: object
                                       azureFile:
                                         properties:
@@ -2307,8 +2308,8 @@ spec:
                                           shareName:
                                             type: string
                                         required:
-                                        - secretName
-                                        - shareName
+                                          - secretName
+                                          - shareName
                                         type: object
                                       cephfs:
                                         properties:
@@ -2330,7 +2331,7 @@ spec:
                                           user:
                                             type: string
                                         required:
-                                        - monitors
+                                          - monitors
                                         type: object
                                       cinder:
                                         properties:
@@ -2346,7 +2347,7 @@ spec:
                                           volumeID:
                                             type: string
                                         required:
-                                        - volumeID
+                                          - volumeID
                                         type: object
                                       configMap:
                                         properties:
@@ -2364,8 +2365,8 @@ spec:
                                                 path:
                                                   type: string
                                               required:
-                                              - key
-                                              - path
+                                                - key
+                                                - path
                                               type: object
                                             type: array
                                           name:
@@ -2391,7 +2392,7 @@ spec:
                                               type: string
                                             type: object
                                         required:
-                                        - driver
+                                          - driver
                                         type: object
                                       downwardAPI:
                                         properties:
@@ -2408,7 +2409,7 @@ spec:
                                                     fieldPath:
                                                       type: string
                                                   required:
-                                                  - fieldPath
+                                                    - fieldPath
                                                   type: object
                                                 mode:
                                                   format: int32
@@ -2421,17 +2422,17 @@ spec:
                                                       type: string
                                                     divisor:
                                                       anyOf:
-                                                      - type: integer
-                                                      - type: string
+                                                        - type: integer
+                                                        - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
                                                       type: string
                                                   required:
-                                                  - resource
+                                                    - resource
                                                   type: object
                                               required:
-                                              - path
+                                                - path
                                               type: object
                                             type: array
                                         type: object
@@ -2441,8 +2442,8 @@ spec:
                                             type: string
                                           sizeLimit:
                                             anyOf:
-                                            - type: integer
-                                            - type: string
+                                              - type: integer
+                                              - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                         type: object
@@ -2482,7 +2483,7 @@ spec:
                                                 type: string
                                             type: object
                                         required:
-                                        - driver
+                                          - driver
                                         type: object
                                       flocker:
                                         properties:
@@ -2503,7 +2504,7 @@ spec:
                                           readOnly:
                                             type: boolean
                                         required:
-                                        - pdName
+                                          - pdName
                                         type: object
                                       gitRepo:
                                         properties:
@@ -2514,7 +2515,7 @@ spec:
                                           revision:
                                             type: string
                                         required:
-                                        - repository
+                                          - repository
                                         type: object
                                       glusterfs:
                                         properties:
@@ -2525,8 +2526,8 @@ spec:
                                           readOnly:
                                             type: boolean
                                         required:
-                                        - endpoints
-                                        - path
+                                          - endpoints
+                                          - path
                                         type: object
                                       hostPath:
                                         properties:
@@ -2535,7 +2536,7 @@ spec:
                                           type:
                                             type: string
                                         required:
-                                        - path
+                                          - path
                                         type: object
                                       iscsi:
                                         properties:
@@ -2568,9 +2569,9 @@ spec:
                                           targetPortal:
                                             type: string
                                         required:
-                                        - iqn
-                                        - lun
-                                        - targetPortal
+                                          - iqn
+                                          - lun
+                                          - targetPortal
                                         type: object
                                       name:
                                         type: string
@@ -2583,8 +2584,8 @@ spec:
                                           server:
                                             type: string
                                         required:
-                                        - path
-                                        - server
+                                          - path
+                                          - server
                                         type: object
                                       persistentVolumeClaim:
                                         properties:
@@ -2593,7 +2594,7 @@ spec:
                                           readOnly:
                                             type: boolean
                                         required:
-                                        - claimName
+                                          - claimName
                                         type: object
                                       photonPersistentDisk:
                                         properties:
@@ -2602,7 +2603,7 @@ spec:
                                           pdID:
                                             type: string
                                         required:
-                                        - pdID
+                                          - pdID
                                         type: object
                                       portworxVolume:
                                         properties:
@@ -2613,7 +2614,7 @@ spec:
                                           volumeID:
                                             type: string
                                         required:
-                                        - volumeID
+                                          - volumeID
                                         type: object
                                       projected:
                                         properties:
@@ -2636,8 +2637,8 @@ spec:
                                                           path:
                                                             type: string
                                                         required:
-                                                        - key
-                                                        - path
+                                                          - key
+                                                          - path
                                                         type: object
                                                       type: array
                                                     name:
@@ -2657,7 +2658,7 @@ spec:
                                                               fieldPath:
                                                                 type: string
                                                             required:
-                                                            - fieldPath
+                                                              - fieldPath
                                                             type: object
                                                           mode:
                                                             format: int32
@@ -2670,17 +2671,17 @@ spec:
                                                                 type: string
                                                               divisor:
                                                                 anyOf:
-                                                                - type: integer
-                                                                - type: string
+                                                                  - type: integer
+                                                                  - type: string
                                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                                 x-kubernetes-int-or-string: true
                                                               resource:
                                                                 type: string
                                                             required:
-                                                            - resource
+                                                              - resource
                                                             type: object
                                                         required:
-                                                        - path
+                                                          - path
                                                         type: object
                                                       type: array
                                                   type: object
@@ -2697,8 +2698,8 @@ spec:
                                                           path:
                                                             type: string
                                                         required:
-                                                        - key
-                                                        - path
+                                                          - key
+                                                          - path
                                                         type: object
                                                       type: array
                                                     name:
@@ -2716,12 +2717,12 @@ spec:
                                                     path:
                                                       type: string
                                                   required:
-                                                  - path
+                                                    - path
                                                   type: object
                                               type: object
                                             type: array
                                         required:
-                                        - sources
+                                          - sources
                                         type: object
                                       quobyte:
                                         properties:
@@ -2738,8 +2739,8 @@ spec:
                                           volume:
                                             type: string
                                         required:
-                                        - registry
-                                        - volume
+                                          - registry
+                                          - volume
                                         type: object
                                       rbd:
                                         properties:
@@ -2765,8 +2766,8 @@ spec:
                                           user:
                                             type: string
                                         required:
-                                        - image
-                                        - monitors
+                                          - image
+                                          - monitors
                                         type: object
                                       scaleIO:
                                         properties:
@@ -2794,9 +2795,9 @@ spec:
                                           volumeName:
                                             type: string
                                         required:
-                                        - gateway
-                                        - secretRef
-                                        - system
+                                          - gateway
+                                          - secretRef
+                                          - system
                                         type: object
                                       secret:
                                         properties:
@@ -2814,8 +2815,8 @@ spec:
                                                 path:
                                                   type: string
                                               required:
-                                              - key
-                                              - path
+                                                - key
+                                                - path
                                               type: object
                                             type: array
                                           optional:
@@ -2850,14 +2851,14 @@ spec:
                                           volumePath:
                                             type: string
                                         required:
-                                        - volumePath
+                                          - volumePath
                                         type: object
                                     required:
-                                    - name
+                                      - name
                                     type: object
                                   type: array
                               required:
-                              - containers
+                                - containers
                               type: object
                           type: object
                         updateStrategy:
@@ -2895,24 +2896,24 @@ spec:
                                       name:
                                         type: string
                                     required:
-                                    - kind
-                                    - name
+                                      - kind
+                                      - name
                                     type: object
                                   resources:
                                     properties:
                                       limits:
                                         additionalProperties:
                                           anyOf:
-                                          - type: integer
-                                          - type: string
+                                            - type: integer
+                                            - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         type: object
                                       requests:
                                         additionalProperties:
                                           anyOf:
-                                          - type: integer
-                                          - type: string
+                                            - type: integer
+                                            - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         type: object
@@ -2931,8 +2932,8 @@ spec:
                                                 type: string
                                               type: array
                                           required:
-                                          - key
-                                          - operator
+                                            - key
+                                            - operator
                                           type: object
                                         type: array
                                       matchLabels:
@@ -2956,8 +2957,8 @@ spec:
                                   capacity:
                                     additionalProperties:
                                       anyOf:
-                                      - type: integer
-                                      - type: string
+                                        - type: integer
+                                        - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     type: object
@@ -2979,8 +2980,8 @@ spec:
                                         type:
                                           type: string
                                       required:
-                                      - status
-                                      - type
+                                        - status
+                                        - type
                                       type: object
                                     type: array
                                   phase:
@@ -2989,9 +2990,9 @@ spec:
                             type: object
                           type: array
                       required:
-                      - selector
-                      - serviceName
-                      - template
+                        - selector
+                        - serviceName
+                        - template
                       type: object
                     status:
                       properties:
@@ -3013,8 +3014,8 @@ spec:
                               type:
                                 type: string
                             required:
-                            - status
-                            - type
+                              - status
+                              - type
                             type: object
                           type: array
                         currentReplicas:
@@ -3037,7 +3038,7 @@ spec:
                           format: int32
                           type: integer
                       required:
-                      - replicas
+                        - replicas
                       type: object
                   type: object
                   x-kubernetes-embedded-resource: true
@@ -3094,16 +3095,17 @@ spec:
                                 type: string
                               targetPort:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 x-kubernetes-int-or-string: true
                             required:
-                            - port
+                              - port
+                              - protocol
                             type: object
                           type: array
                           x-kubernetes-list-map-keys:
-                          - port
-                          - protocol
+                            - port
+                            - protocol
                           x-kubernetes-list-type: map
                         publishNotReadyAddresses:
                           type: boolean
@@ -3178,8 +3180,8 @@ spec:
                                       type: string
                                     type: array
                                 required:
-                                - key
-                                - operator
+                                  - key
+                                  - operator
                                 type: object
                               type: array
                             matchLabels:
@@ -3219,8 +3221,8 @@ spec:
                                                             type: string
                                                           type: array
                                                       required:
-                                                      - key
-                                                      - operator
+                                                        - key
+                                                        - operator
                                                       type: object
                                                     type: array
                                                   matchFields:
@@ -3235,8 +3237,8 @@ spec:
                                                             type: string
                                                           type: array
                                                       required:
-                                                      - key
-                                                      - operator
+                                                        - key
+                                                        - operator
                                                       type: object
                                                     type: array
                                                 type: object
@@ -3244,8 +3246,8 @@ spec:
                                                 format: int32
                                                 type: integer
                                             required:
-                                            - preference
-                                            - weight
+                                              - preference
+                                              - weight
                                             type: object
                                           type: array
                                         requiredDuringSchedulingIgnoredDuringExecution:
@@ -3265,8 +3267,8 @@ spec:
                                                             type: string
                                                           type: array
                                                       required:
-                                                      - key
-                                                      - operator
+                                                        - key
+                                                        - operator
                                                       type: object
                                                     type: array
                                                   matchFields:
@@ -3281,14 +3283,14 @@ spec:
                                                             type: string
                                                           type: array
                                                       required:
-                                                      - key
-                                                      - operator
+                                                        - key
+                                                        - operator
                                                       type: object
                                                     type: array
                                                 type: object
                                               type: array
                                           required:
-                                          - nodeSelectorTerms
+                                            - nodeSelectorTerms
                                           type: object
                                       type: object
                                     podAffinity:
@@ -3312,8 +3314,8 @@ spec:
                                                                 type: string
                                                               type: array
                                                           required:
-                                                          - key
-                                                          - operator
+                                                            - key
+                                                            - operator
                                                           type: object
                                                         type: array
                                                       matchLabels:
@@ -3328,14 +3330,14 @@ spec:
                                                   topologyKey:
                                                     type: string
                                                 required:
-                                                - topologyKey
+                                                  - topologyKey
                                                 type: object
                                               weight:
                                                 format: int32
                                                 type: integer
                                             required:
-                                            - podAffinityTerm
-                                            - weight
+                                              - podAffinityTerm
+                                              - weight
                                             type: object
                                           type: array
                                         requiredDuringSchedulingIgnoredDuringExecution:
@@ -3355,8 +3357,8 @@ spec:
                                                             type: string
                                                           type: array
                                                       required:
-                                                      - key
-                                                      - operator
+                                                        - key
+                                                        - operator
                                                       type: object
                                                     type: array
                                                   matchLabels:
@@ -3371,7 +3373,7 @@ spec:
                                               topologyKey:
                                                 type: string
                                             required:
-                                            - topologyKey
+                                              - topologyKey
                                             type: object
                                           type: array
                                       type: object
@@ -3396,8 +3398,8 @@ spec:
                                                                 type: string
                                                               type: array
                                                           required:
-                                                          - key
-                                                          - operator
+                                                            - key
+                                                            - operator
                                                           type: object
                                                         type: array
                                                       matchLabels:
@@ -3412,14 +3414,14 @@ spec:
                                                   topologyKey:
                                                     type: string
                                                 required:
-                                                - topologyKey
+                                                  - topologyKey
                                                 type: object
                                               weight:
                                                 format: int32
                                                 type: integer
                                             required:
-                                            - podAffinityTerm
-                                            - weight
+                                              - podAffinityTerm
+                                              - weight
                                             type: object
                                           type: array
                                         requiredDuringSchedulingIgnoredDuringExecution:
@@ -3439,8 +3441,8 @@ spec:
                                                             type: string
                                                           type: array
                                                       required:
-                                                      - key
-                                                      - operator
+                                                        - key
+                                                        - operator
                                                       type: object
                                                     type: array
                                                   matchLabels:
@@ -3455,7 +3457,7 @@ spec:
                                               topologyKey:
                                                 type: string
                                             required:
-                                            - topologyKey
+                                              - topologyKey
                                             type: object
                                           type: array
                                       type: object
@@ -3491,7 +3493,7 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   required:
-                                                  - key
+                                                    - key
                                                   type: object
                                                 fieldRef:
                                                   properties:
@@ -3500,7 +3502,7 @@ spec:
                                                     fieldPath:
                                                       type: string
                                                   required:
-                                                  - fieldPath
+                                                    - fieldPath
                                                   type: object
                                                 resourceFieldRef:
                                                   properties:
@@ -3508,14 +3510,14 @@ spec:
                                                       type: string
                                                     divisor:
                                                       anyOf:
-                                                      - type: integer
-                                                      - type: string
+                                                        - type: integer
+                                                        - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
                                                       type: string
                                                   required:
-                                                  - resource
+                                                    - resource
                                                   type: object
                                                 secretKeyRef:
                                                   properties:
@@ -3526,11 +3528,11 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   required:
-                                                  - key
+                                                    - key
                                                   type: object
                                               type: object
                                           required:
-                                          - name
+                                            - name
                                           type: object
                                         type: array
                                       envFrom:
@@ -3581,21 +3583,21 @@ spec:
                                                         value:
                                                           type: string
                                                       required:
-                                                      - name
-                                                      - value
+                                                        - name
+                                                        - value
                                                       type: object
                                                     type: array
                                                   path:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                   scheme:
                                                     type: string
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                               tcpSocket:
                                                 properties:
@@ -3603,11 +3605,11 @@ spec:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                             type: object
                                           preStop:
@@ -3631,21 +3633,21 @@ spec:
                                                         value:
                                                           type: string
                                                       required:
-                                                      - name
-                                                      - value
+                                                        - name
+                                                        - value
                                                       type: object
                                                     type: array
                                                   path:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                   scheme:
                                                     type: string
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                               tcpSocket:
                                                 properties:
@@ -3653,11 +3655,11 @@ spec:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                             type: object
                                         type: object
@@ -3685,21 +3687,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -3716,11 +3718,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -3744,12 +3746,13 @@ spec:
                                             protocol:
                                               type: string
                                           required:
-                                          - containerPort
+                                            - containerPort
+                                            - protocol
                                           type: object
                                         type: array
                                         x-kubernetes-list-map-keys:
-                                        - containerPort
-                                        - protocol
+                                          - containerPort
+                                          - protocol
                                         x-kubernetes-list-type: map
                                       readinessProbe:
                                         properties:
@@ -3775,21 +3778,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -3806,11 +3809,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -3821,16 +3824,16 @@ spec:
                                           limits:
                                             additionalProperties:
                                               anyOf:
-                                              - type: integer
-                                              - type: string
+                                                - type: integer
+                                                - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             type: object
                                           requests:
                                             additionalProperties:
                                               anyOf:
-                                              - type: integer
-                                              - type: string
+                                                - type: integer
+                                                - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             type: object
@@ -3909,21 +3912,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -3940,11 +3943,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -3968,8 +3971,8 @@ spec:
                                             name:
                                               type: string
                                           required:
-                                          - devicePath
-                                          - name
+                                            - devicePath
+                                            - name
                                           type: object
                                         type: array
                                       volumeMounts:
@@ -3988,14 +3991,14 @@ spec:
                                             subPathExpr:
                                               type: string
                                           required:
-                                          - mountPath
-                                          - name
+                                            - mountPath
+                                            - name
                                           type: object
                                         type: array
                                       workingDir:
                                         type: string
                                     required:
-                                    - name
+                                      - name
                                     type: object
                                   type: array
                                 dnsConfig:
@@ -4051,7 +4054,7 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   required:
-                                                  - key
+                                                    - key
                                                   type: object
                                                 fieldRef:
                                                   properties:
@@ -4060,7 +4063,7 @@ spec:
                                                     fieldPath:
                                                       type: string
                                                   required:
-                                                  - fieldPath
+                                                    - fieldPath
                                                   type: object
                                                 resourceFieldRef:
                                                   properties:
@@ -4068,14 +4071,14 @@ spec:
                                                       type: string
                                                     divisor:
                                                       anyOf:
-                                                      - type: integer
-                                                      - type: string
+                                                        - type: integer
+                                                        - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
                                                       type: string
                                                   required:
-                                                  - resource
+                                                    - resource
                                                   type: object
                                                 secretKeyRef:
                                                   properties:
@@ -4086,11 +4089,11 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   required:
-                                                  - key
+                                                    - key
                                                   type: object
                                               type: object
                                           required:
-                                          - name
+                                            - name
                                           type: object
                                         type: array
                                       envFrom:
@@ -4141,21 +4144,21 @@ spec:
                                                         value:
                                                           type: string
                                                       required:
-                                                      - name
-                                                      - value
+                                                        - name
+                                                        - value
                                                       type: object
                                                     type: array
                                                   path:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                   scheme:
                                                     type: string
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                               tcpSocket:
                                                 properties:
@@ -4163,11 +4166,11 @@ spec:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                             type: object
                                           preStop:
@@ -4191,21 +4194,21 @@ spec:
                                                         value:
                                                           type: string
                                                       required:
-                                                      - name
-                                                      - value
+                                                        - name
+                                                        - value
                                                       type: object
                                                     type: array
                                                   path:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                   scheme:
                                                     type: string
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                               tcpSocket:
                                                 properties:
@@ -4213,11 +4216,11 @@ spec:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                             type: object
                                         type: object
@@ -4245,21 +4248,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -4276,11 +4279,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -4304,7 +4307,7 @@ spec:
                                             protocol:
                                               type: string
                                           required:
-                                          - containerPort
+                                            - containerPort
                                           type: object
                                         type: array
                                       readinessProbe:
@@ -4331,21 +4334,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -4362,11 +4365,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -4377,16 +4380,16 @@ spec:
                                           limits:
                                             additionalProperties:
                                               anyOf:
-                                              - type: integer
-                                              - type: string
+                                                - type: integer
+                                                - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             type: object
                                           requests:
                                             additionalProperties:
                                               anyOf:
-                                              - type: integer
-                                              - type: string
+                                                - type: integer
+                                                - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             type: object
@@ -4465,21 +4468,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -4496,11 +4499,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -4526,8 +4529,8 @@ spec:
                                             name:
                                               type: string
                                           required:
-                                          - devicePath
-                                          - name
+                                            - devicePath
+                                            - name
                                           type: object
                                         type: array
                                       volumeMounts:
@@ -4546,14 +4549,14 @@ spec:
                                             subPathExpr:
                                               type: string
                                           required:
-                                          - mountPath
-                                          - name
+                                            - mountPath
+                                            - name
                                           type: object
                                         type: array
                                       workingDir:
                                         type: string
                                     required:
-                                    - name
+                                      - name
                                     type: object
                                   type: array
                                 hostAliases:
@@ -4611,7 +4614,7 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   required:
-                                                  - key
+                                                    - key
                                                   type: object
                                                 fieldRef:
                                                   properties:
@@ -4620,7 +4623,7 @@ spec:
                                                     fieldPath:
                                                       type: string
                                                   required:
-                                                  - fieldPath
+                                                    - fieldPath
                                                   type: object
                                                 resourceFieldRef:
                                                   properties:
@@ -4628,14 +4631,14 @@ spec:
                                                       type: string
                                                     divisor:
                                                       anyOf:
-                                                      - type: integer
-                                                      - type: string
+                                                        - type: integer
+                                                        - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
                                                       type: string
                                                   required:
-                                                  - resource
+                                                    - resource
                                                   type: object
                                                 secretKeyRef:
                                                   properties:
@@ -4646,11 +4649,11 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   required:
-                                                  - key
+                                                    - key
                                                   type: object
                                               type: object
                                           required:
-                                          - name
+                                            - name
                                           type: object
                                         type: array
                                       envFrom:
@@ -4701,21 +4704,21 @@ spec:
                                                         value:
                                                           type: string
                                                       required:
-                                                      - name
-                                                      - value
+                                                        - name
+                                                        - value
                                                       type: object
                                                     type: array
                                                   path:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                   scheme:
                                                     type: string
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                               tcpSocket:
                                                 properties:
@@ -4723,11 +4726,11 @@ spec:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                             type: object
                                           preStop:
@@ -4751,21 +4754,21 @@ spec:
                                                         value:
                                                           type: string
                                                       required:
-                                                      - name
-                                                      - value
+                                                        - name
+                                                        - value
                                                       type: object
                                                     type: array
                                                   path:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                   scheme:
                                                     type: string
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                               tcpSocket:
                                                 properties:
@@ -4773,11 +4776,11 @@ spec:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                             type: object
                                         type: object
@@ -4805,21 +4808,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -4836,11 +4839,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -4864,12 +4867,13 @@ spec:
                                             protocol:
                                               type: string
                                           required:
-                                          - containerPort
+                                            - containerPort
+                                            - protocol
                                           type: object
                                         type: array
                                         x-kubernetes-list-map-keys:
-                                        - containerPort
-                                        - protocol
+                                          - containerPort
+                                          - protocol
                                         x-kubernetes-list-type: map
                                       readinessProbe:
                                         properties:
@@ -4895,21 +4899,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -4926,11 +4930,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -4941,16 +4945,16 @@ spec:
                                           limits:
                                             additionalProperties:
                                               anyOf:
-                                              - type: integer
-                                              - type: string
+                                                - type: integer
+                                                - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             type: object
                                           requests:
                                             additionalProperties:
                                               anyOf:
-                                              - type: integer
-                                              - type: string
+                                                - type: integer
+                                                - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             type: object
@@ -5029,21 +5033,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -5060,11 +5064,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -5088,8 +5092,8 @@ spec:
                                             name:
                                               type: string
                                           required:
-                                          - devicePath
-                                          - name
+                                            - devicePath
+                                            - name
                                           type: object
                                         type: array
                                       volumeMounts:
@@ -5108,14 +5112,14 @@ spec:
                                             subPathExpr:
                                               type: string
                                           required:
-                                          - mountPath
-                                          - name
+                                            - mountPath
+                                            - name
                                           type: object
                                         type: array
                                       workingDir:
                                         type: string
                                     required:
-                                    - name
+                                      - name
                                     type: object
                                   type: array
                                 nodeName:
@@ -5127,8 +5131,8 @@ spec:
                                 overhead:
                                   additionalProperties:
                                     anyOf:
-                                    - type: integer
-                                    - type: string
+                                      - type: integer
+                                      - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type: object
@@ -5145,7 +5149,7 @@ spec:
                                       conditionType:
                                         type: string
                                     required:
-                                    - conditionType
+                                      - conditionType
                                     type: object
                                   type: array
                                 restartPolicy:
@@ -5193,8 +5197,8 @@ spec:
                                           value:
                                             type: string
                                         required:
-                                        - name
-                                        - value
+                                          - name
+                                          - value
                                         type: object
                                       type: array
                                     windowsOptions:
@@ -5251,8 +5255,8 @@ spec:
                                                     type: string
                                                   type: array
                                               required:
-                                              - key
-                                              - operator
+                                                - key
+                                                - operator
                                               type: object
                                             type: array
                                           matchLabels:
@@ -5268,14 +5272,14 @@ spec:
                                       whenUnsatisfiable:
                                         type: string
                                     required:
-                                    - maxSkew
-                                    - topologyKey
-                                    - whenUnsatisfiable
+                                      - maxSkew
+                                      - topologyKey
+                                      - whenUnsatisfiable
                                     type: object
                                   type: array
                                   x-kubernetes-list-map-keys:
-                                  - topologyKey
-                                  - whenUnsatisfiable
+                                    - topologyKey
+                                    - whenUnsatisfiable
                                   x-kubernetes-list-type: map
                                 volumes:
                                   items:
@@ -5292,7 +5296,7 @@ spec:
                                           volumeID:
                                             type: string
                                         required:
-                                        - volumeID
+                                          - volumeID
                                         type: object
                                       azureDisk:
                                         properties:
@@ -5309,8 +5313,8 @@ spec:
                                           readOnly:
                                             type: boolean
                                         required:
-                                        - diskName
-                                        - diskURI
+                                          - diskName
+                                          - diskURI
                                         type: object
                                       azureFile:
                                         properties:
@@ -5321,8 +5325,8 @@ spec:
                                           shareName:
                                             type: string
                                         required:
-                                        - secretName
-                                        - shareName
+                                          - secretName
+                                          - shareName
                                         type: object
                                       cephfs:
                                         properties:
@@ -5344,7 +5348,7 @@ spec:
                                           user:
                                             type: string
                                         required:
-                                        - monitors
+                                          - monitors
                                         type: object
                                       cinder:
                                         properties:
@@ -5360,7 +5364,7 @@ spec:
                                           volumeID:
                                             type: string
                                         required:
-                                        - volumeID
+                                          - volumeID
                                         type: object
                                       configMap:
                                         properties:
@@ -5378,8 +5382,8 @@ spec:
                                                 path:
                                                   type: string
                                               required:
-                                              - key
-                                              - path
+                                                - key
+                                                - path
                                               type: object
                                             type: array
                                           name:
@@ -5405,7 +5409,7 @@ spec:
                                               type: string
                                             type: object
                                         required:
-                                        - driver
+                                          - driver
                                         type: object
                                       downwardAPI:
                                         properties:
@@ -5422,7 +5426,7 @@ spec:
                                                     fieldPath:
                                                       type: string
                                                   required:
-                                                  - fieldPath
+                                                    - fieldPath
                                                   type: object
                                                 mode:
                                                   format: int32
@@ -5435,17 +5439,17 @@ spec:
                                                       type: string
                                                     divisor:
                                                       anyOf:
-                                                      - type: integer
-                                                      - type: string
+                                                        - type: integer
+                                                        - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
                                                       type: string
                                                   required:
-                                                  - resource
+                                                    - resource
                                                   type: object
                                               required:
-                                              - path
+                                                - path
                                               type: object
                                             type: array
                                         type: object
@@ -5455,8 +5459,8 @@ spec:
                                             type: string
                                           sizeLimit:
                                             anyOf:
-                                            - type: integer
-                                            - type: string
+                                              - type: integer
+                                              - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                         type: object
@@ -5496,7 +5500,7 @@ spec:
                                                 type: string
                                             type: object
                                         required:
-                                        - driver
+                                          - driver
                                         type: object
                                       flocker:
                                         properties:
@@ -5517,7 +5521,7 @@ spec:
                                           readOnly:
                                             type: boolean
                                         required:
-                                        - pdName
+                                          - pdName
                                         type: object
                                       gitRepo:
                                         properties:
@@ -5528,7 +5532,7 @@ spec:
                                           revision:
                                             type: string
                                         required:
-                                        - repository
+                                          - repository
                                         type: object
                                       glusterfs:
                                         properties:
@@ -5539,8 +5543,8 @@ spec:
                                           readOnly:
                                             type: boolean
                                         required:
-                                        - endpoints
-                                        - path
+                                          - endpoints
+                                          - path
                                         type: object
                                       hostPath:
                                         properties:
@@ -5549,7 +5553,7 @@ spec:
                                           type:
                                             type: string
                                         required:
-                                        - path
+                                          - path
                                         type: object
                                       iscsi:
                                         properties:
@@ -5582,9 +5586,9 @@ spec:
                                           targetPortal:
                                             type: string
                                         required:
-                                        - iqn
-                                        - lun
-                                        - targetPortal
+                                          - iqn
+                                          - lun
+                                          - targetPortal
                                         type: object
                                       name:
                                         type: string
@@ -5597,8 +5601,8 @@ spec:
                                           server:
                                             type: string
                                         required:
-                                        - path
-                                        - server
+                                          - path
+                                          - server
                                         type: object
                                       persistentVolumeClaim:
                                         properties:
@@ -5607,7 +5611,7 @@ spec:
                                           readOnly:
                                             type: boolean
                                         required:
-                                        - claimName
+                                          - claimName
                                         type: object
                                       photonPersistentDisk:
                                         properties:
@@ -5616,7 +5620,7 @@ spec:
                                           pdID:
                                             type: string
                                         required:
-                                        - pdID
+                                          - pdID
                                         type: object
                                       portworxVolume:
                                         properties:
@@ -5627,7 +5631,7 @@ spec:
                                           volumeID:
                                             type: string
                                         required:
-                                        - volumeID
+                                          - volumeID
                                         type: object
                                       projected:
                                         properties:
@@ -5650,8 +5654,8 @@ spec:
                                                           path:
                                                             type: string
                                                         required:
-                                                        - key
-                                                        - path
+                                                          - key
+                                                          - path
                                                         type: object
                                                       type: array
                                                     name:
@@ -5671,7 +5675,7 @@ spec:
                                                               fieldPath:
                                                                 type: string
                                                             required:
-                                                            - fieldPath
+                                                              - fieldPath
                                                             type: object
                                                           mode:
                                                             format: int32
@@ -5684,17 +5688,17 @@ spec:
                                                                 type: string
                                                               divisor:
                                                                 anyOf:
-                                                                - type: integer
-                                                                - type: string
+                                                                  - type: integer
+                                                                  - type: string
                                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                                 x-kubernetes-int-or-string: true
                                                               resource:
                                                                 type: string
                                                             required:
-                                                            - resource
+                                                              - resource
                                                             type: object
                                                         required:
-                                                        - path
+                                                          - path
                                                         type: object
                                                       type: array
                                                   type: object
@@ -5711,8 +5715,8 @@ spec:
                                                           path:
                                                             type: string
                                                         required:
-                                                        - key
-                                                        - path
+                                                          - key
+                                                          - path
                                                         type: object
                                                       type: array
                                                     name:
@@ -5730,12 +5734,12 @@ spec:
                                                     path:
                                                       type: string
                                                   required:
-                                                  - path
+                                                    - path
                                                   type: object
                                               type: object
                                             type: array
                                         required:
-                                        - sources
+                                          - sources
                                         type: object
                                       quobyte:
                                         properties:
@@ -5752,8 +5756,8 @@ spec:
                                           volume:
                                             type: string
                                         required:
-                                        - registry
-                                        - volume
+                                          - registry
+                                          - volume
                                         type: object
                                       rbd:
                                         properties:
@@ -5779,8 +5783,8 @@ spec:
                                           user:
                                             type: string
                                         required:
-                                        - image
-                                        - monitors
+                                          - image
+                                          - monitors
                                         type: object
                                       scaleIO:
                                         properties:
@@ -5808,9 +5812,9 @@ spec:
                                           volumeName:
                                             type: string
                                         required:
-                                        - gateway
-                                        - secretRef
-                                        - system
+                                          - gateway
+                                          - secretRef
+                                          - system
                                         type: object
                                       secret:
                                         properties:
@@ -5828,8 +5832,8 @@ spec:
                                                 path:
                                                   type: string
                                               required:
-                                              - key
-                                              - path
+                                                - key
+                                                - path
                                               type: object
                                             type: array
                                           optional:
@@ -5864,14 +5868,14 @@ spec:
                                           volumePath:
                                             type: string
                                         required:
-                                        - volumePath
+                                          - volumePath
                                         type: object
                                     required:
-                                    - name
+                                      - name
                                     type: object
                                   type: array
                               required:
-                              - containers
+                                - containers
                               type: object
                           type: object
                         updateStrategy:
@@ -5909,24 +5913,24 @@ spec:
                                       name:
                                         type: string
                                     required:
-                                    - kind
-                                    - name
+                                      - kind
+                                      - name
                                     type: object
                                   resources:
                                     properties:
                                       limits:
                                         additionalProperties:
                                           anyOf:
-                                          - type: integer
-                                          - type: string
+                                            - type: integer
+                                            - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         type: object
                                       requests:
                                         additionalProperties:
                                           anyOf:
-                                          - type: integer
-                                          - type: string
+                                            - type: integer
+                                            - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         type: object
@@ -5945,8 +5949,8 @@ spec:
                                                 type: string
                                               type: array
                                           required:
-                                          - key
-                                          - operator
+                                            - key
+                                            - operator
                                           type: object
                                         type: array
                                       matchLabels:
@@ -5970,8 +5974,8 @@ spec:
                                   capacity:
                                     additionalProperties:
                                       anyOf:
-                                      - type: integer
-                                      - type: string
+                                        - type: integer
+                                        - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     type: object
@@ -5993,8 +5997,8 @@ spec:
                                         type:
                                           type: string
                                       required:
-                                      - status
-                                      - type
+                                        - status
+                                        - type
                                       type: object
                                     type: array
                                   phase:
@@ -6003,9 +6007,9 @@ spec:
                             type: object
                           type: array
                       required:
-                      - selector
-                      - serviceName
-                      - template
+                        - selector
+                        - serviceName
+                        - template
                       type: object
                     status:
                       properties:
@@ -6027,8 +6031,8 @@ spec:
                               type:
                                 type: string
                             required:
-                            - status
-                            - type
+                              - status
+                              - type
                             type: object
                           type: array
                         currentReplicas:
@@ -6051,7 +6055,7 @@ spec:
                           format: int32
                           type: integer
                       required:
-                      - replicas
+                        - replicas
                       type: object
                   type: object
                   x-kubernetes-embedded-resource: true
@@ -6108,16 +6112,17 @@ spec:
                                 type: string
                               targetPort:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 x-kubernetes-int-or-string: true
                             required:
-                            - port
+                              - port
+                              - protocol
                             type: object
                           type: array
                           x-kubernetes-list-map-keys:
-                          - port
-                          - protocol
+                            - port
+                            - protocol
                           x-kubernetes-list-type: map
                         publishNotReadyAddresses:
                           type: boolean
@@ -6192,8 +6197,8 @@ spec:
                                       type: string
                                     type: array
                                 required:
-                                - key
-                                - operator
+                                  - key
+                                  - operator
                                 type: object
                               type: array
                             matchLabels:
@@ -6233,8 +6238,8 @@ spec:
                                                             type: string
                                                           type: array
                                                       required:
-                                                      - key
-                                                      - operator
+                                                        - key
+                                                        - operator
                                                       type: object
                                                     type: array
                                                   matchFields:
@@ -6249,8 +6254,8 @@ spec:
                                                             type: string
                                                           type: array
                                                       required:
-                                                      - key
-                                                      - operator
+                                                        - key
+                                                        - operator
                                                       type: object
                                                     type: array
                                                 type: object
@@ -6258,8 +6263,8 @@ spec:
                                                 format: int32
                                                 type: integer
                                             required:
-                                            - preference
-                                            - weight
+                                              - preference
+                                              - weight
                                             type: object
                                           type: array
                                         requiredDuringSchedulingIgnoredDuringExecution:
@@ -6279,8 +6284,8 @@ spec:
                                                             type: string
                                                           type: array
                                                       required:
-                                                      - key
-                                                      - operator
+                                                        - key
+                                                        - operator
                                                       type: object
                                                     type: array
                                                   matchFields:
@@ -6295,14 +6300,14 @@ spec:
                                                             type: string
                                                           type: array
                                                       required:
-                                                      - key
-                                                      - operator
+                                                        - key
+                                                        - operator
                                                       type: object
                                                     type: array
                                                 type: object
                                               type: array
                                           required:
-                                          - nodeSelectorTerms
+                                            - nodeSelectorTerms
                                           type: object
                                       type: object
                                     podAffinity:
@@ -6326,8 +6331,8 @@ spec:
                                                                 type: string
                                                               type: array
                                                           required:
-                                                          - key
-                                                          - operator
+                                                            - key
+                                                            - operator
                                                           type: object
                                                         type: array
                                                       matchLabels:
@@ -6342,14 +6347,14 @@ spec:
                                                   topologyKey:
                                                     type: string
                                                 required:
-                                                - topologyKey
+                                                  - topologyKey
                                                 type: object
                                               weight:
                                                 format: int32
                                                 type: integer
                                             required:
-                                            - podAffinityTerm
-                                            - weight
+                                              - podAffinityTerm
+                                              - weight
                                             type: object
                                           type: array
                                         requiredDuringSchedulingIgnoredDuringExecution:
@@ -6369,8 +6374,8 @@ spec:
                                                             type: string
                                                           type: array
                                                       required:
-                                                      - key
-                                                      - operator
+                                                        - key
+                                                        - operator
                                                       type: object
                                                     type: array
                                                   matchLabels:
@@ -6385,7 +6390,7 @@ spec:
                                               topologyKey:
                                                 type: string
                                             required:
-                                            - topologyKey
+                                              - topologyKey
                                             type: object
                                           type: array
                                       type: object
@@ -6410,8 +6415,8 @@ spec:
                                                                 type: string
                                                               type: array
                                                           required:
-                                                          - key
-                                                          - operator
+                                                            - key
+                                                            - operator
                                                           type: object
                                                         type: array
                                                       matchLabels:
@@ -6426,14 +6431,14 @@ spec:
                                                   topologyKey:
                                                     type: string
                                                 required:
-                                                - topologyKey
+                                                  - topologyKey
                                                 type: object
                                               weight:
                                                 format: int32
                                                 type: integer
                                             required:
-                                            - podAffinityTerm
-                                            - weight
+                                              - podAffinityTerm
+                                              - weight
                                             type: object
                                           type: array
                                         requiredDuringSchedulingIgnoredDuringExecution:
@@ -6453,8 +6458,8 @@ spec:
                                                             type: string
                                                           type: array
                                                       required:
-                                                      - key
-                                                      - operator
+                                                        - key
+                                                        - operator
                                                       type: object
                                                     type: array
                                                   matchLabels:
@@ -6469,7 +6474,7 @@ spec:
                                               topologyKey:
                                                 type: string
                                             required:
-                                            - topologyKey
+                                              - topologyKey
                                             type: object
                                           type: array
                                       type: object
@@ -6505,7 +6510,7 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   required:
-                                                  - key
+                                                    - key
                                                   type: object
                                                 fieldRef:
                                                   properties:
@@ -6514,7 +6519,7 @@ spec:
                                                     fieldPath:
                                                       type: string
                                                   required:
-                                                  - fieldPath
+                                                    - fieldPath
                                                   type: object
                                                 resourceFieldRef:
                                                   properties:
@@ -6522,14 +6527,14 @@ spec:
                                                       type: string
                                                     divisor:
                                                       anyOf:
-                                                      - type: integer
-                                                      - type: string
+                                                        - type: integer
+                                                        - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
                                                       type: string
                                                   required:
-                                                  - resource
+                                                    - resource
                                                   type: object
                                                 secretKeyRef:
                                                   properties:
@@ -6540,11 +6545,11 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   required:
-                                                  - key
+                                                    - key
                                                   type: object
                                               type: object
                                           required:
-                                          - name
+                                            - name
                                           type: object
                                         type: array
                                       envFrom:
@@ -6595,21 +6600,21 @@ spec:
                                                         value:
                                                           type: string
                                                       required:
-                                                      - name
-                                                      - value
+                                                        - name
+                                                        - value
                                                       type: object
                                                     type: array
                                                   path:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                   scheme:
                                                     type: string
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                               tcpSocket:
                                                 properties:
@@ -6617,11 +6622,11 @@ spec:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                             type: object
                                           preStop:
@@ -6645,21 +6650,21 @@ spec:
                                                         value:
                                                           type: string
                                                       required:
-                                                      - name
-                                                      - value
+                                                        - name
+                                                        - value
                                                       type: object
                                                     type: array
                                                   path:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                   scheme:
                                                     type: string
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                               tcpSocket:
                                                 properties:
@@ -6667,11 +6672,11 @@ spec:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                             type: object
                                         type: object
@@ -6699,21 +6704,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -6730,11 +6735,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -6758,12 +6763,13 @@ spec:
                                             protocol:
                                               type: string
                                           required:
-                                          - containerPort
+                                            - containerPort
+                                            - protocol
                                           type: object
                                         type: array
                                         x-kubernetes-list-map-keys:
-                                        - containerPort
-                                        - protocol
+                                          - containerPort
+                                          - protocol
                                         x-kubernetes-list-type: map
                                       readinessProbe:
                                         properties:
@@ -6789,21 +6795,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -6820,11 +6826,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -6835,16 +6841,16 @@ spec:
                                           limits:
                                             additionalProperties:
                                               anyOf:
-                                              - type: integer
-                                              - type: string
+                                                - type: integer
+                                                - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             type: object
                                           requests:
                                             additionalProperties:
                                               anyOf:
-                                              - type: integer
-                                              - type: string
+                                                - type: integer
+                                                - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             type: object
@@ -6923,21 +6929,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -6954,11 +6960,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -6982,8 +6988,8 @@ spec:
                                             name:
                                               type: string
                                           required:
-                                          - devicePath
-                                          - name
+                                            - devicePath
+                                            - name
                                           type: object
                                         type: array
                                       volumeMounts:
@@ -7002,14 +7008,14 @@ spec:
                                             subPathExpr:
                                               type: string
                                           required:
-                                          - mountPath
-                                          - name
+                                            - mountPath
+                                            - name
                                           type: object
                                         type: array
                                       workingDir:
                                         type: string
                                     required:
-                                    - name
+                                      - name
                                     type: object
                                   type: array
                                 dnsConfig:
@@ -7065,7 +7071,7 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   required:
-                                                  - key
+                                                    - key
                                                   type: object
                                                 fieldRef:
                                                   properties:
@@ -7074,7 +7080,7 @@ spec:
                                                     fieldPath:
                                                       type: string
                                                   required:
-                                                  - fieldPath
+                                                    - fieldPath
                                                   type: object
                                                 resourceFieldRef:
                                                   properties:
@@ -7082,14 +7088,14 @@ spec:
                                                       type: string
                                                     divisor:
                                                       anyOf:
-                                                      - type: integer
-                                                      - type: string
+                                                        - type: integer
+                                                        - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
                                                       type: string
                                                   required:
-                                                  - resource
+                                                    - resource
                                                   type: object
                                                 secretKeyRef:
                                                   properties:
@@ -7100,11 +7106,11 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   required:
-                                                  - key
+                                                    - key
                                                   type: object
                                               type: object
                                           required:
-                                          - name
+                                            - name
                                           type: object
                                         type: array
                                       envFrom:
@@ -7155,21 +7161,21 @@ spec:
                                                         value:
                                                           type: string
                                                       required:
-                                                      - name
-                                                      - value
+                                                        - name
+                                                        - value
                                                       type: object
                                                     type: array
                                                   path:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                   scheme:
                                                     type: string
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                               tcpSocket:
                                                 properties:
@@ -7177,11 +7183,11 @@ spec:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                             type: object
                                           preStop:
@@ -7205,21 +7211,21 @@ spec:
                                                         value:
                                                           type: string
                                                       required:
-                                                      - name
-                                                      - value
+                                                        - name
+                                                        - value
                                                       type: object
                                                     type: array
                                                   path:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                   scheme:
                                                     type: string
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                               tcpSocket:
                                                 properties:
@@ -7227,11 +7233,11 @@ spec:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                             type: object
                                         type: object
@@ -7259,21 +7265,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -7290,11 +7296,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -7318,7 +7324,7 @@ spec:
                                             protocol:
                                               type: string
                                           required:
-                                          - containerPort
+                                            - containerPort
                                           type: object
                                         type: array
                                       readinessProbe:
@@ -7345,21 +7351,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -7376,11 +7382,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -7391,16 +7397,16 @@ spec:
                                           limits:
                                             additionalProperties:
                                               anyOf:
-                                              - type: integer
-                                              - type: string
+                                                - type: integer
+                                                - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             type: object
                                           requests:
                                             additionalProperties:
                                               anyOf:
-                                              - type: integer
-                                              - type: string
+                                                - type: integer
+                                                - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             type: object
@@ -7479,21 +7485,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -7510,11 +7516,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -7540,8 +7546,8 @@ spec:
                                             name:
                                               type: string
                                           required:
-                                          - devicePath
-                                          - name
+                                            - devicePath
+                                            - name
                                           type: object
                                         type: array
                                       volumeMounts:
@@ -7560,14 +7566,14 @@ spec:
                                             subPathExpr:
                                               type: string
                                           required:
-                                          - mountPath
-                                          - name
+                                            - mountPath
+                                            - name
                                           type: object
                                         type: array
                                       workingDir:
                                         type: string
                                     required:
-                                    - name
+                                      - name
                                     type: object
                                   type: array
                                 hostAliases:
@@ -7625,7 +7631,7 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   required:
-                                                  - key
+                                                    - key
                                                   type: object
                                                 fieldRef:
                                                   properties:
@@ -7634,7 +7640,7 @@ spec:
                                                     fieldPath:
                                                       type: string
                                                   required:
-                                                  - fieldPath
+                                                    - fieldPath
                                                   type: object
                                                 resourceFieldRef:
                                                   properties:
@@ -7642,14 +7648,14 @@ spec:
                                                       type: string
                                                     divisor:
                                                       anyOf:
-                                                      - type: integer
-                                                      - type: string
+                                                        - type: integer
+                                                        - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
                                                       type: string
                                                   required:
-                                                  - resource
+                                                    - resource
                                                   type: object
                                                 secretKeyRef:
                                                   properties:
@@ -7660,11 +7666,11 @@ spec:
                                                     optional:
                                                       type: boolean
                                                   required:
-                                                  - key
+                                                    - key
                                                   type: object
                                               type: object
                                           required:
-                                          - name
+                                            - name
                                           type: object
                                         type: array
                                       envFrom:
@@ -7715,21 +7721,21 @@ spec:
                                                         value:
                                                           type: string
                                                       required:
-                                                      - name
-                                                      - value
+                                                        - name
+                                                        - value
                                                       type: object
                                                     type: array
                                                   path:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                   scheme:
                                                     type: string
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                               tcpSocket:
                                                 properties:
@@ -7737,11 +7743,11 @@ spec:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                             type: object
                                           preStop:
@@ -7765,21 +7771,21 @@ spec:
                                                         value:
                                                           type: string
                                                       required:
-                                                      - name
-                                                      - value
+                                                        - name
+                                                        - value
                                                       type: object
                                                     type: array
                                                   path:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                   scheme:
                                                     type: string
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                               tcpSocket:
                                                 properties:
@@ -7787,11 +7793,11 @@ spec:
                                                     type: string
                                                   port:
                                                     anyOf:
-                                                    - type: integer
-                                                    - type: string
+                                                      - type: integer
+                                                      - type: string
                                                     x-kubernetes-int-or-string: true
                                                 required:
-                                                - port
+                                                  - port
                                                 type: object
                                             type: object
                                         type: object
@@ -7819,21 +7825,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -7850,11 +7856,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -7878,12 +7884,13 @@ spec:
                                             protocol:
                                               type: string
                                           required:
-                                          - containerPort
+                                            - containerPort
+                                            - protocol
                                           type: object
                                         type: array
                                         x-kubernetes-list-map-keys:
-                                        - containerPort
-                                        - protocol
+                                          - containerPort
+                                          - protocol
                                         x-kubernetes-list-type: map
                                       readinessProbe:
                                         properties:
@@ -7909,21 +7916,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -7940,11 +7947,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -7955,16 +7962,16 @@ spec:
                                           limits:
                                             additionalProperties:
                                               anyOf:
-                                              - type: integer
-                                              - type: string
+                                                - type: integer
+                                                - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             type: object
                                           requests:
                                             additionalProperties:
                                               anyOf:
-                                              - type: integer
-                                              - type: string
+                                                - type: integer
+                                                - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             type: object
@@ -8043,21 +8050,21 @@ spec:
                                                     value:
                                                       type: string
                                                   required:
-                                                  - name
-                                                  - value
+                                                    - name
+                                                    - value
                                                   type: object
                                                 type: array
                                               path:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                               scheme:
                                                 type: string
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           initialDelaySeconds:
                                             format: int32
@@ -8074,11 +8081,11 @@ spec:
                                                 type: string
                                               port:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 x-kubernetes-int-or-string: true
                                             required:
-                                            - port
+                                              - port
                                             type: object
                                           timeoutSeconds:
                                             format: int32
@@ -8102,8 +8109,8 @@ spec:
                                             name:
                                               type: string
                                           required:
-                                          - devicePath
-                                          - name
+                                            - devicePath
+                                            - name
                                           type: object
                                         type: array
                                       volumeMounts:
@@ -8122,14 +8129,14 @@ spec:
                                             subPathExpr:
                                               type: string
                                           required:
-                                          - mountPath
-                                          - name
+                                            - mountPath
+                                            - name
                                           type: object
                                         type: array
                                       workingDir:
                                         type: string
                                     required:
-                                    - name
+                                      - name
                                     type: object
                                   type: array
                                 nodeName:
@@ -8141,8 +8148,8 @@ spec:
                                 overhead:
                                   additionalProperties:
                                     anyOf:
-                                    - type: integer
-                                    - type: string
+                                      - type: integer
+                                      - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type: object
@@ -8159,7 +8166,7 @@ spec:
                                       conditionType:
                                         type: string
                                     required:
-                                    - conditionType
+                                      - conditionType
                                     type: object
                                   type: array
                                 restartPolicy:
@@ -8207,8 +8214,8 @@ spec:
                                           value:
                                             type: string
                                         required:
-                                        - name
-                                        - value
+                                          - name
+                                          - value
                                         type: object
                                       type: array
                                     windowsOptions:
@@ -8265,8 +8272,8 @@ spec:
                                                     type: string
                                                   type: array
                                               required:
-                                              - key
-                                              - operator
+                                                - key
+                                                - operator
                                               type: object
                                             type: array
                                           matchLabels:
@@ -8282,14 +8289,14 @@ spec:
                                       whenUnsatisfiable:
                                         type: string
                                     required:
-                                    - maxSkew
-                                    - topologyKey
-                                    - whenUnsatisfiable
+                                      - maxSkew
+                                      - topologyKey
+                                      - whenUnsatisfiable
                                     type: object
                                   type: array
                                   x-kubernetes-list-map-keys:
-                                  - topologyKey
-                                  - whenUnsatisfiable
+                                    - topologyKey
+                                    - whenUnsatisfiable
                                   x-kubernetes-list-type: map
                                 volumes:
                                   items:
@@ -8306,7 +8313,7 @@ spec:
                                           volumeID:
                                             type: string
                                         required:
-                                        - volumeID
+                                          - volumeID
                                         type: object
                                       azureDisk:
                                         properties:
@@ -8323,8 +8330,8 @@ spec:
                                           readOnly:
                                             type: boolean
                                         required:
-                                        - diskName
-                                        - diskURI
+                                          - diskName
+                                          - diskURI
                                         type: object
                                       azureFile:
                                         properties:
@@ -8335,8 +8342,8 @@ spec:
                                           shareName:
                                             type: string
                                         required:
-                                        - secretName
-                                        - shareName
+                                          - secretName
+                                          - shareName
                                         type: object
                                       cephfs:
                                         properties:
@@ -8358,7 +8365,7 @@ spec:
                                           user:
                                             type: string
                                         required:
-                                        - monitors
+                                          - monitors
                                         type: object
                                       cinder:
                                         properties:
@@ -8374,7 +8381,7 @@ spec:
                                           volumeID:
                                             type: string
                                         required:
-                                        - volumeID
+                                          - volumeID
                                         type: object
                                       configMap:
                                         properties:
@@ -8392,8 +8399,8 @@ spec:
                                                 path:
                                                   type: string
                                               required:
-                                              - key
-                                              - path
+                                                - key
+                                                - path
                                               type: object
                                             type: array
                                           name:
@@ -8419,7 +8426,7 @@ spec:
                                               type: string
                                             type: object
                                         required:
-                                        - driver
+                                          - driver
                                         type: object
                                       downwardAPI:
                                         properties:
@@ -8436,7 +8443,7 @@ spec:
                                                     fieldPath:
                                                       type: string
                                                   required:
-                                                  - fieldPath
+                                                    - fieldPath
                                                   type: object
                                                 mode:
                                                   format: int32
@@ -8449,17 +8456,17 @@ spec:
                                                       type: string
                                                     divisor:
                                                       anyOf:
-                                                      - type: integer
-                                                      - type: string
+                                                        - type: integer
+                                                        - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
                                                       type: string
                                                   required:
-                                                  - resource
+                                                    - resource
                                                   type: object
                                               required:
-                                              - path
+                                                - path
                                               type: object
                                             type: array
                                         type: object
@@ -8469,8 +8476,8 @@ spec:
                                             type: string
                                           sizeLimit:
                                             anyOf:
-                                            - type: integer
-                                            - type: string
+                                              - type: integer
+                                              - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                         type: object
@@ -8510,7 +8517,7 @@ spec:
                                                 type: string
                                             type: object
                                         required:
-                                        - driver
+                                          - driver
                                         type: object
                                       flocker:
                                         properties:
@@ -8531,7 +8538,7 @@ spec:
                                           readOnly:
                                             type: boolean
                                         required:
-                                        - pdName
+                                          - pdName
                                         type: object
                                       gitRepo:
                                         properties:
@@ -8542,7 +8549,7 @@ spec:
                                           revision:
                                             type: string
                                         required:
-                                        - repository
+                                          - repository
                                         type: object
                                       glusterfs:
                                         properties:
@@ -8553,8 +8560,8 @@ spec:
                                           readOnly:
                                             type: boolean
                                         required:
-                                        - endpoints
-                                        - path
+                                          - endpoints
+                                          - path
                                         type: object
                                       hostPath:
                                         properties:
@@ -8563,7 +8570,7 @@ spec:
                                           type:
                                             type: string
                                         required:
-                                        - path
+                                          - path
                                         type: object
                                       iscsi:
                                         properties:
@@ -8596,9 +8603,9 @@ spec:
                                           targetPortal:
                                             type: string
                                         required:
-                                        - iqn
-                                        - lun
-                                        - targetPortal
+                                          - iqn
+                                          - lun
+                                          - targetPortal
                                         type: object
                                       name:
                                         type: string
@@ -8611,8 +8618,8 @@ spec:
                                           server:
                                             type: string
                                         required:
-                                        - path
-                                        - server
+                                          - path
+                                          - server
                                         type: object
                                       persistentVolumeClaim:
                                         properties:
@@ -8621,7 +8628,7 @@ spec:
                                           readOnly:
                                             type: boolean
                                         required:
-                                        - claimName
+                                          - claimName
                                         type: object
                                       photonPersistentDisk:
                                         properties:
@@ -8630,7 +8637,7 @@ spec:
                                           pdID:
                                             type: string
                                         required:
-                                        - pdID
+                                          - pdID
                                         type: object
                                       portworxVolume:
                                         properties:
@@ -8641,7 +8648,7 @@ spec:
                                           volumeID:
                                             type: string
                                         required:
-                                        - volumeID
+                                          - volumeID
                                         type: object
                                       projected:
                                         properties:
@@ -8664,8 +8671,8 @@ spec:
                                                           path:
                                                             type: string
                                                         required:
-                                                        - key
-                                                        - path
+                                                          - key
+                                                          - path
                                                         type: object
                                                       type: array
                                                     name:
@@ -8685,7 +8692,7 @@ spec:
                                                               fieldPath:
                                                                 type: string
                                                             required:
-                                                            - fieldPath
+                                                              - fieldPath
                                                             type: object
                                                           mode:
                                                             format: int32
@@ -8698,17 +8705,17 @@ spec:
                                                                 type: string
                                                               divisor:
                                                                 anyOf:
-                                                                - type: integer
-                                                                - type: string
+                                                                  - type: integer
+                                                                  - type: string
                                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                                 x-kubernetes-int-or-string: true
                                                               resource:
                                                                 type: string
                                                             required:
-                                                            - resource
+                                                              - resource
                                                             type: object
                                                         required:
-                                                        - path
+                                                          - path
                                                         type: object
                                                       type: array
                                                   type: object
@@ -8725,8 +8732,8 @@ spec:
                                                           path:
                                                             type: string
                                                         required:
-                                                        - key
-                                                        - path
+                                                          - key
+                                                          - path
                                                         type: object
                                                       type: array
                                                     name:
@@ -8744,12 +8751,12 @@ spec:
                                                     path:
                                                       type: string
                                                   required:
-                                                  - path
+                                                    - path
                                                   type: object
                                               type: object
                                             type: array
                                         required:
-                                        - sources
+                                          - sources
                                         type: object
                                       quobyte:
                                         properties:
@@ -8766,8 +8773,8 @@ spec:
                                           volume:
                                             type: string
                                         required:
-                                        - registry
-                                        - volume
+                                          - registry
+                                          - volume
                                         type: object
                                       rbd:
                                         properties:
@@ -8793,8 +8800,8 @@ spec:
                                           user:
                                             type: string
                                         required:
-                                        - image
-                                        - monitors
+                                          - image
+                                          - monitors
                                         type: object
                                       scaleIO:
                                         properties:
@@ -8822,9 +8829,9 @@ spec:
                                           volumeName:
                                             type: string
                                         required:
-                                        - gateway
-                                        - secretRef
-                                        - system
+                                          - gateway
+                                          - secretRef
+                                          - system
                                         type: object
                                       secret:
                                         properties:
@@ -8842,8 +8849,8 @@ spec:
                                                 path:
                                                   type: string
                                               required:
-                                              - key
-                                              - path
+                                                - key
+                                                - path
                                               type: object
                                             type: array
                                           optional:
@@ -8878,14 +8885,14 @@ spec:
                                           volumePath:
                                             type: string
                                         required:
-                                        - volumePath
+                                          - volumePath
                                         type: object
                                     required:
-                                    - name
+                                      - name
                                     type: object
                                   type: array
                               required:
-                              - containers
+                                - containers
                               type: object
                           type: object
                         updateStrategy:
@@ -8923,24 +8930,24 @@ spec:
                                       name:
                                         type: string
                                     required:
-                                    - kind
-                                    - name
+                                      - kind
+                                      - name
                                     type: object
                                   resources:
                                     properties:
                                       limits:
                                         additionalProperties:
                                           anyOf:
-                                          - type: integer
-                                          - type: string
+                                            - type: integer
+                                            - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         type: object
                                       requests:
                                         additionalProperties:
                                           anyOf:
-                                          - type: integer
-                                          - type: string
+                                            - type: integer
+                                            - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         type: object
@@ -8959,8 +8966,8 @@ spec:
                                                 type: string
                                               type: array
                                           required:
-                                          - key
-                                          - operator
+                                            - key
+                                            - operator
                                           type: object
                                         type: array
                                       matchLabels:
@@ -8984,8 +8991,8 @@ spec:
                                   capacity:
                                     additionalProperties:
                                       anyOf:
-                                      - type: integer
-                                      - type: string
+                                        - type: integer
+                                        - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     type: object
@@ -9007,8 +9014,8 @@ spec:
                                         type:
                                           type: string
                                       required:
-                                      - status
-                                      - type
+                                        - status
+                                        - type
                                       type: object
                                     type: array
                                   phase:
@@ -9017,9 +9024,9 @@ spec:
                             type: object
                           type: array
                       required:
-                      - selector
-                      - serviceName
-                      - template
+                        - selector
+                        - serviceName
+                        - template
                       type: object
                     status:
                       properties:
@@ -9041,8 +9048,8 @@ spec:
                               type:
                                 type: string
                             required:
-                            - status
-                            - type
+                              - status
+                              - type
                             type: object
                           type: array
                         currentReplicas:
@@ -9065,7 +9072,7 @@ spec:
                           format: int32
                           type: integer
                       required:
-                      - replicas
+                        - replicas
                       type: object
                   type: object
                   x-kubernetes-embedded-resource: true
@@ -9076,9 +9083,9 @@ spec:
       type: object
   version: v1alpha1
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      served: true
+      storage: true
 status:
   acceptedNames:
     kind: ""

--- a/incubator/virtualcluster/config/sampleswithspec/clusterversion_v1_loadbalancer.yaml
+++ b/incubator/virtualcluster/config/sampleswithspec/clusterversion_v1_loadbalancer.yaml
@@ -162,6 +162,7 @@ spec:
               - --v=2
               ports:
               - containerPort: 6443
+                protocol: TCP
                 name: api
               livenessProbe:
                 # since we set anonymous-auth to false, we use tcp instead of https

--- a/incubator/virtualcluster/config/sampleswithspec/clusterversion_v1_nodeport.yaml
+++ b/incubator/virtualcluster/config/sampleswithspec/clusterversion_v1_nodeport.yaml
@@ -168,6 +168,7 @@ spec:
               - --v=2
               ports:
               - containerPort: 6443
+                protocol: TCP
                 name: api
               livenessProbe:
                 # since we set anonymous-auth to false, we use tcp instead of https

--- a/incubator/virtualcluster/doc/demo.md
+++ b/incubator/virtualcluster/doc/demo.md
@@ -52,11 +52,7 @@ And then you can manage VirtualCluster by `kubectl vc` command tool.
 To install VirtualCluster CRDs:
 
 ```bash
-# There is known controller runtime code gen problem so the generated CRD for clusterversions doesn't work for now
-# So temporarily we use a simplified one.
-# Slack conversation: https://kubernetes.slack.com/archives/C8E6YA9S7/p1604903060089400
-#kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/crds/tenancy.x-k8s.io_clusterversions.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/sampleswithspec/tenancy.x-k8s.io_clusterversions.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/crds/tenancy.x-k8s.io_clusterversions.yaml
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/crds/tenancy.x-k8s.io_virtualclusters.yaml
 ```
 
@@ -192,21 +188,21 @@ Please note that if you're working on `kind` cluster which, by default, exposes 
 $ VC_NAMESPACE="$(kubectl get VirtualCluster vc-sample-1 -o json | jq -r '.status.clusterNamespace')"
 
 # The svc node port exposed
-$ VS_SVC_PORT="$(kubectl get -n ${VC_NAMESPACE} svc/apiserver-svc -o json | jq '.spec.ports[0].nodePort')"
+$ VC_SVC_PORT="$(kubectl get -n ${VC_NAMESPACE} svc/apiserver-svc -o json | jq '.spec.ports[0].nodePort')"
 
 # Remove the container if there is any
-#$ docker rm -f ${CLUSTER_NAME}-kind-proxy-${VS_SVC_PORT} || true
+#$ docker rm -f ${CLUSTER_NAME}-kind-proxy-${VC_SVC_PORT} || true
 # Create this sidecar container
 $ docker run -d --restart always \
-    --name ${CLUSTER_NAME}-kind-proxy-${VS_SVC_PORT} \
-    --publish 127.0.0.1:${VS_SVC_PORT}:${VS_SVC_PORT} \
+    --name ${CLUSTER_NAME}-kind-proxy-${VC_SVC_PORT} \
+    --publish 127.0.0.1:${VC_SVC_PORT}:${VC_SVC_PORT} \
     --link ${CLUSTER_NAME}-control-plane:target \
     --network kind \
     alpine/socat -dd \
-    tcp-listen:${VS_SVC_PORT},fork,reuseaddr tcp-connect:target:${VS_SVC_PORT}
+    tcp-listen:${VC_SVC_PORT},fork,reuseaddr tcp-connect:target:${VC_SVC_PORT}
   
 # And update the vc-1.kubeconfig
-$ sed -i".bak" "s|.*server:.*|    server: https://127.0.0.1:${VS_SVC_PORT}|" vc-1.kubeconfig
+$ sed -i".bak" "s|.*server:.*|    server: https://127.0.0.1:${VC_SVC_PORT}|" vc-1.kubeconfig
 ```
 
 Now let's take a look how Virtual Cluster looks like:
@@ -333,19 +329,19 @@ By deleting the VirtualCluster CR, all the tenant resources created in the super
 
 ```bash
 # The VirtualCluster
-$ kubectl delete VirtualCluster vc-sample-1
+kubectl delete VirtualCluster vc-sample-1
 ```
 
 Of course, you can delete all others VirtualCluster objects too to clean up everything:
 
 ```bash
 # The ClusterVersion
-$ kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/sampleswithspec/clusterversion_v1_nodeport.yaml
+kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/sampleswithspec/clusterversion_v1_nodeport.yaml
 
 # The Virtual Cluster components
-$ kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/setup/all_in_one.yaml
+kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/setup/all_in_one.yaml
 
 # The CRDs
-$ kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/crds/tenancy.x-k8s.io_virtualclusters.yaml
-$ kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/sampleswithspec/tenancy.x-k8s.io_clusterversions.yaml
+kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/crds/tenancy.x-k8s.io_virtualclusters.yaml
+kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/incubator/virtualcluster/config/sampleswithspec/tenancy.x-k8s.io_clusterversions.yaml
 ```


### PR DESCRIPTION
Two major fixes:
1. Patch in `Makefile` to correct the CRDs generated by the `controller-gen` tool.
2. Use the generated CRDs, instead of temporary ones, in the demo doc.