### PR TITLE
Fix MustNotRun() can pass without error bug

### DIFF
--- a/incubator/hnc/pkg/testutils/testutils.go
+++ b/incubator/hnc/pkg/testutils/testutils.go
@@ -87,9 +87,9 @@ func MustNotRun(cmdln ...string) {
 }
 
 func mustNotRun(offset int, cmdln ...string) {
-	EventuallyWithOffset(offset+1, func() error {
+	ExpectWithOffset(offset+1, func() error {
 		return TryRun(cmdln...)
-	}, eventuallyTimeout).ShouldNot(Succeed(), "Command: %s", cmdln)
+	}).ShouldNot(Equal(nil), "Command: %s", cmdln)
 }
 
 func TryRun(cmdln ...string) error {


### PR DESCRIPTION
Replace `Eventually()` with `Expect()` in `MustNotRun()` so that commands like
`kubectl create` won't pass for the first time and then eventually fail
without throwing any errors.

Tested by `make test-e2e` (22/32 passed, 10/32 skipped).