### PR TITLE
[VC] syncer: support readiness gate condition

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/resources/pod/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/dws.go
@@ -312,6 +312,15 @@ func (c *controller) reconcilePodUpdate(clusterName, targetNamespace, requestUID
 			return err
 		}
 	}
+	updatedPodStatus := conversion.CheckDWPodConditionEquality(pPod, vPod)
+	if updatedPodStatus != nil {
+		updatedPod = pPod.DeepCopy()
+		updatedPod.Status = *updatedPodStatus
+		pPod, err = c.client.Pods(targetNamespace).UpdateStatus(context.TODO(), updatedPod, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
In most cases, the source of truth is super pod status, because super master actually
own the physical resources, status is reported by **real** kubelet.
Besides, kubernetes allows user-defined conditions, such as pod readiness gate, it will
report readiness state to pod conditions. In other words, the source of truth for user-defined
pod conditions should be tenant side controller, only the condition reported by kubelet should
keep consistent with super.
 It is not recommended that webhook in super append other readiness gate to pod. we left them unchanged
in super, don't sync them upward to tenant side.

Signed-off-by: zhuangqh <zhuangqhc@gmail.com>