### PR TITLE
Don't delete the managedBy annotation

### DIFF
--- a/incubator/hnc/internal/reconcilers/hierarchy_config.go
+++ b/incubator/hnc/internal/reconcilers/hierarchy_config.go
@@ -312,7 +312,7 @@ func (r *HierarchyConfigReconciler) upgradeV1A1SubnamespaceAnnotation(inst *core
 }
 
 // upgradeV1A1ManagedBy replaces the v1alpha1 `managedBy` annotation with the v1alpha2 `managed-by`
-// annotation. If there's a conflict, the old one is ignored and deleted.
+// annotation. If there's a conflict, the old one is ignored.
 func (r *HierarchyConfigReconciler) upgradeV1A1ManagedBy(inst *corev1.Namespace) {
 	// Get old annotation
 	a := inst.GetAnnotations()
@@ -320,9 +320,6 @@ func (r *HierarchyConfigReconciler) upgradeV1A1ManagedBy(inst *corev1.Namespace)
 	if !oldExists {
 		return
 	}
-
-	// Remove old annotation
-	delete(a, api.AnnotationManagedByV1A1)
 
 	// Add new annotation if it doesn't already exist
 	if _, newExists := a[api.AnnotationManagedBy]; !newExists {


### PR DESCRIPTION
Prior to this change, HNC removes the v1a1 managedBy annotation, but if
it's being set by an external manager (which, after all, is the only
reason it exists), this will create a war between the manager and HNC.
Ironically, that's exactly what this annotation is trying to prevent.

This change simply removes the code to "clean up" the old annotation.
It should be the responsibility of the external tool to stop setting it.

This change will *not* be cherrypicked into the master branch since
we're removing all the v1a1 conversion code anyway.

Tested: I had to make this change in order to include HNC v0.6.0 in the
latest version of Hierarchy Controller (the GKE product that includes
HNC); this change simply upstreams that fix. Without this change, I
verified that as part of HierarchyController, the resourceVersions of
the namespaces synced by ConfigSync increased rapidly, while with this
change, they remained stable.

Also updated the conversion tests to remove a bunch of flakiness. One
test (ensuring that an object whose source is deleted during conversion
isn't touched) was still flaky in my last full run; I added a sleep to
fix it but I'm not going to rerun the whole 45min test (the test usually
passed in isolation anyway).