### PR TITLE
Ensure consistent logging for all validators

### DIFF
--- a/incubator/hnc/internal/validators/anchor.go
+++ b/incubator/hnc/internal/validators/anchor.go
@@ -39,7 +39,7 @@ type anchorRequest struct {
 
 // Handle implements the validation webhook.
 func (v *Anchor) Handle(ctx context.Context, req admission.Request) admission.Response {
-	log := v.Log.WithValues("Namespace", req.Namespace, "Name", req.Name)
+	log := v.Log.WithValues("ns", req.Namespace, "nm", req.Name, "op", req.Operation, "user", req.UserInfo.Username)
 	// Early exit since the HNC SA can do whatever it wants.
 	if isHNCServiceAccount(&req.AdmissionRequest.UserInfo) {
 		log.V(1).Info("Allowed change by HNC SA")
@@ -48,7 +48,7 @@ func (v *Anchor) Handle(ctx context.Context, req admission.Request) admission.Re
 
 	decoded, err := v.decodeRequest(log, req)
 	if err != nil {
-		v.Log.Error(err, "Couldn't decode request")
+		log.Error(err, "Couldn't decode request")
 		return deny(metav1.StatusReasonBadRequest, err.Error())
 	}
 	if decoded == nil {

--- a/incubator/hnc/internal/validators/hierarchy.go
+++ b/incubator/hnc/internal/validators/hierarchy.go
@@ -83,7 +83,7 @@ type request struct {
 //
 // Authz false positives are prevented as described by the comments to `getServerChecks`.
 func (v *Hierarchy) Handle(ctx context.Context, req admission.Request) admission.Response {
-	log := v.Log.WithValues("ns", req.Namespace, "user", req.UserInfo.Username)
+	log := v.Log.WithValues("ns", req.Namespace, "op", req.Operation, "user", req.UserInfo.Username)
 	decoded, err := v.decodeRequest(req)
 	if err != nil {
 		log.Error(err, "Couldn't decode request")
@@ -115,7 +115,6 @@ func (v *Hierarchy) handle(ctx context.Context, log logr.Logger, req *request) a
 	// object wouldn't pass legality. We should probably only give the HNC SA the ability to modify
 	// the _status_, though. TODO: https://github.com/kubernetes-sigs/multi-tenancy/issues/80.
 	if isHNCServiceAccount(req.ui) {
-		log.V(1).Info("Allowed change by HNC SA")
 		return allow("HNC SA")
 	}
 

--- a/incubator/hnc/internal/validators/hncconfig.go
+++ b/incubator/hnc/internal/validators/hncconfig.go
@@ -47,7 +47,7 @@ type grTranslator interface {
 type gvkSet map[schema.GroupVersionKind]api.SynchronizationMode
 
 func (c *HNCConfig) Handle(ctx context.Context, req admission.Request) admission.Response {
-	log := c.Log.WithValues("NamespaceName", req.Name)
+	log := c.Log.WithValues("nm", req.Name, "op", req.Operation, "user", req.UserInfo.Username)
 	if isHNCServiceAccount(&req.AdmissionRequest.UserInfo) {
 		return allow("HNC SA")
 	}

--- a/incubator/hnc/internal/validators/namespace.go
+++ b/incubator/hnc/internal/validators/namespace.go
@@ -39,7 +39,7 @@ type nsRequest struct {
 
 // Handle implements the validation webhook.
 func (v *Namespace) Handle(ctx context.Context, req admission.Request) admission.Response {
-	log := v.Log.WithValues("NamespaceName", req.Name)
+	log := v.Log.WithValues("nm", req.Name, "op", req.Operation, "user", req.UserInfo.Username)
 	// Early exit since the HNC SA can do whatever it wants.
 	if isHNCServiceAccount(&req.AdmissionRequest.UserInfo) {
 		log.V(1).Info("Allowed change by HNC SA")

--- a/incubator/hnc/internal/validators/object.go
+++ b/incubator/hnc/internal/validators/object.go
@@ -41,7 +41,7 @@ type Object struct {
 }
 
 func (o *Object) Handle(ctx context.Context, req admission.Request) admission.Response {
-	log := o.Log.WithValues("nm", req.Name, "resource", req.Resource, "nnm", req.Namespace, "op", req.Operation)
+	log := o.Log.WithValues("resource", req.Resource, "ns", req.Namespace, "nm", req.Name, "op", req.Operation, "user", req.UserInfo.Username)
 
 	// Before even looking at the objects, early-exit for any changes we shouldn't be involved in.
 	// This reduces the chance we'll hose some aspect of the cluster we weren't supposed to touch.


### PR DESCRIPTION
Add the username and operation for all logs.

Tested: deployed with verbose logging and ensured the username and op
were visible for all operations.

Fixes #1138 