### PR TITLE
Exclude kube-node-lease from HNC

### DIFF
--- a/incubator/hnc/internal/config/default_config.go
+++ b/incubator/hnc/internal/config/default_config.go
@@ -5,8 +5,9 @@ package config
 // exclude some default namespaces with constantly changing objects.
 // TODO make the exclusion configurable - https://github.com/kubernetes-sigs/multi-tenancy/issues/374
 var EX = map[string]bool{
-	"kube-system":  true,
-	"kube-public":  true,
-	"hnc-system":   true,
-	"cert-manager": true,
+	"kube-system":     true,
+	"kube-public":     true,
+	"hnc-system":      true,
+	"cert-manager":    true,
+	"kube-node-lease": true,
 }


### PR DESCRIPTION
We shouldn't allow subnamespaces or nontrivial hierarchies in
kube-node-lease, just like it's not allowed in kube-system and a few
others.

Tested: without this change, can create a subns in kube-node-lease; with
this change, I get the appropriate error message. Not adding an
automated test for this since it would just duplicate the contents of
the default_config.go file. All existing e2e tests pass.

Fixes #1229 