### PR TITLE
Create client for checking CRD deletion

### DIFF
--- a/incubator/hnc/cmd/manager/main.go
+++ b/incubator/hnc/cmd/manager/main.go
@@ -192,7 +192,7 @@ func startControllers(mgr ctrl.Manager, certsCreated chan struct{}) {
 
 	// Create all reconciling controllers
 	setupLog.Info("Creating controllers", "maxReconciles", maxReconciles)
-	if err := reconcilers.Create(mgr, f, maxReconciles); err != nil {
+	if err := reconcilers.Create(mgr, f, maxReconciles, false); err != nil {
 		setupLog.Error(err, "cannot create controllers")
 		os.Exit(1)
 	}

--- a/incubator/hnc/internal/reconcilers/anchor.go
+++ b/incubator/hnc/internal/reconcilers/anchor.go
@@ -128,7 +128,7 @@ func (r *AnchorReconciler) onDeleting(ctx context.Context, log logr.Logger, inst
 	// We handle deletions differently depending on whether _one_ anchor is being deleted (i.e., the
 	// user wants to delete the namespace) or whether the Anchor CRD is being deleted, which usually
 	// means HNC is being uninstalled and we shouldn't delete _any_ namespaces.
-	deletingCRD, err := isDeletingCRD(ctx, r, api.Anchors)
+	deletingCRD, err := isDeletingCRD(ctx, api.Anchors)
 	if err != nil {
 		log.Error(err, "Couldn't determine if CRD is being deleted")
 		return false, err

--- a/incubator/hnc/internal/reconcilers/hierarchy_config.go
+++ b/incubator/hnc/internal/reconcilers/hierarchy_config.go
@@ -625,7 +625,7 @@ func (r *HierarchyConfigReconciler) getSingleton(ctx context.Context, nm string)
 	deletingCRD := false
 	if inst.CreationTimestamp.IsZero() || !inst.DeletionTimestamp.IsZero() {
 		var err error
-		deletingCRD, err = isDeletingCRD(ctx, r, api.HierarchyConfigurations)
+		deletingCRD, err = isDeletingCRD(ctx, api.HierarchyConfigurations)
 		if err != nil {
 			return nil, false, err
 		}

--- a/incubator/hnc/internal/reconcilers/hnc_config.go
+++ b/incubator/hnc/internal/reconcilers/hnc_config.go
@@ -235,7 +235,7 @@ func (r *ConfigReconciler) validateSingleton(inst *api.HNCConfiguration) {
 func (r *ConfigReconciler) writeSingleton(ctx context.Context, inst *api.HNCConfiguration) error {
 	if inst.CreationTimestamp.IsZero() {
 		// No point creating it if the CRD's being deleted
-		if isDeleted, err := isDeletingCRD(ctx, r, api.HNCConfigSingletons); isDeleted || err != nil {
+		if isDeleted, err := isDeletingCRD(ctx, api.HNCConfigSingletons); isDeleted || err != nil {
 			r.Log.Info("CRD is being deleted (or CRD deletion status couldn't be determined); skip update")
 			return err
 		}

--- a/incubator/hnc/internal/reconcilers/suite_test.go
+++ b/incubator/hnc/internal/reconcilers/suite_test.go
@@ -35,6 +35,7 @@ import (
 
 	// +kubebuilder:scaffold:imports
 
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
 	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/forest"
 	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/reconcilers"
@@ -99,7 +100,7 @@ var _ = BeforeSuite(func(done Done) {
 		Scheme: scheme.Scheme,
 	})
 	Expect(err).ToNot(HaveOccurred())
-	err = reconcilers.Create(k8sManager, forest.NewForest(), 100)
+	err = reconcilers.Create(k8sManager, forest.NewForest(), 100, true)
 	Expect(err).ToNot(HaveOccurred())
 
 	k8sClient = k8sManager.GetClient()


### PR DESCRIPTION
The default client uses cache, and therefore, it might fail to notice if
a CR is deleted. We instead use our own client who doesn't use the
cache.

Tested: make test-e2e

Fix #1285