### PR TITLE
Increase memory limits and requests and update docs

### DIFF
--- a/incubator/hnc/config/manager/manager.yaml
+++ b/incubator/hnc/config/manager/manager.yaml
@@ -49,8 +49,8 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 100Mi
+            memory: 300Mi
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 150Mi
       terminationGracePeriodSeconds: 10

--- a/incubator/hnc/docs/user-guide/faq.md
+++ b/incubator/hnc/docs/user-guide/faq.md
@@ -57,6 +57,18 @@ limitations. You can adjust the `--apiserver-qps-throttle` parameter in the
 manifest to increase it from the default of 50qps if your cluster supports
 higher values.
 
+## How much memory does HNC need?
+
+As of Dec. 2020, the [HNC performance test](../../scripts/performance/README.md)
+shows that 700 namespaces with 10 propagatable objects in each namespace would
+use about 200M memory during HNC startup and about 150M afterwards. Thus, we set
+a default of 300M memory limits and 150M memory requests for HNC.
+
+To change HNC memory limits and requests, you can update the values in
+`config/manager/manager.yaml`, run `make manifests` and reapply the manifest. If
+you are using a GKE cluster, you can view the real-time memory usage in the
+`Workloads` tab and determine what's the best limits and requests for you.
+
 ## Does HNC support high-availability?
 
 HNC is currently deployed as a single in-memory pod and therefore does not


### PR DESCRIPTION
Increase memory limits to 300M and requests to 150M since we store more
info, e.g. source objects, in the forest now. About 700 namespaces with
10 propagatable objects in each namespace would use about 200M memory
from performance tests.

Add memory usage in user-guide faq docs.