### PR TITLE
Generate event for exceptions

### DIFF
--- a/incubator/hnc/api/v1alpha2/hierarchy_types.go
+++ b/incubator/hnc/api/v1alpha2/hierarchy_types.go
@@ -85,8 +85,11 @@ const (
 	// EventCannotUpdate is for events when a namespace has an object that couldn't
 	// be propagated *into* this namespace - that is, it couldn't be created in
 	// the first place, or it couldn't be updated. The error message will point to
-	//the source namespace.
+	// the source namespace.
 	EventCannotUpdate string = "CannotUpdateObject"
+	// EventCannotGetSelector is for events when an object has annotations that cannot be
+	// parsed into a valid selector
+	EventCannotParseSelector string = "CannotParseSelector"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/incubator/hnc/internal/reconcilers/object.go
+++ b/incubator/hnc/internal/reconcilers/object.go
@@ -690,8 +690,8 @@ func (r *ObjectReconciler) syncPropagation(ctx context.Context, log logr.Logger,
 func (r *ObjectReconciler) shouldPropagateSource(log logr.Logger, inst *unstructured.Unstructured, dst string) bool {
 	nsLabels := r.Forest.Get(dst).GetLabels()
 	if ok, err := selectors.ShouldPropagate(inst, nsLabels); err != nil {
-		// TODO: generate events for the errors
 		log.Error(err, "Cannot propagate")
+		r.EventRecorder.Event(inst, "Warning", api.EventCannotParseSelector, err.Error())
 		return false
 	} else if !ok {
 		return false


### PR DESCRIPTION
If the reconciler cannot parse the selector annotation to a valid
selector, we record an event so that the user will get notified.

Tested:
```
$ k create ns a
$ k hns create a1 -n a
$ k delete validatingwebhookconfigurations.admissionregistration.k8s.io hnc-validating-webhook-configuration
$ k create role test -n a --verb=update --resource=deployments
$ k annotate role test -n a "propagate.hnc.x-k8s.io/none"="**foo"
$ k get event -n a
LAST SEEN   TYPE      REASON                OBJECT      MESSAGE
41s         Warning   CannotParseSelector   role/test   invalid propagate.hnc.x-k8s.io/none value: strconv.ParseBool: parsing "**foo": invalid syntax
```

Fix #1165