### PR TITLE
[VC] Add featuregates cmdline support in syncer

### DIFF
--- a/incubator/virtualcluster/cmd/syncer/app/options/options.go
+++ b/incubator/virtualcluster/cmd/syncer/app/options/options.go
@@ -47,6 +47,7 @@ import (
 	vcinformers "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/client/informers/externalversions"
 	syncerconfig "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/apis/config"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/util"
 )
 
 // ResourceSyncerOptions is the main context object for the resource syncer.
@@ -82,6 +83,7 @@ func NewResourceSyncerOptions() (*ResourceSyncerOptions, error) {
 			DefaultOpaqueMetaDomains:   []string{"kubernetes.io", "k8s.io"},
 			ExtraSyncingResources:      []string{},
 			VNAgentPort:                int32(10550),
+			FeatureGates:               map[string]bool{feature.SuperClusterPool: false},
 		},
 		Address:  "",
 		Port:     "80",
@@ -90,7 +92,7 @@ func NewResourceSyncerOptions() (*ResourceSyncerOptions, error) {
 	}, nil
 }
 
-func (o *ResourceSyncerOptions) Flags() cliflag.NamedFlagSets {
+func (o *ResourceSyncerOptions) Flags(featureGatesString *string) cliflag.NamedFlagSets {
 	fss := cliflag.NamedFlagSets{}
 
 	fs := fss.FlagSet("server")
@@ -100,6 +102,7 @@ func (o *ResourceSyncerOptions) Flags() cliflag.NamedFlagSets {
 	fs.StringSliceVar(&o.ComponentConfig.DefaultOpaqueMetaDomains, "default-opaque-meta-domains", o.ComponentConfig.DefaultOpaqueMetaDomains, "DefaultOpaqueMetaDomains is the default opaque meta configuration for each Virtual Cluster.")
 	fs.StringSliceVar(&o.ComponentConfig.ExtraSyncingResources, "extra-syncing-resources", o.ComponentConfig.ExtraSyncingResources, "ExtraSyncingResources defines additional resources that need to be synced for each Virtual Cluster. (priorityclass, ingress)")
 	fs.Int32Var(&o.ComponentConfig.VNAgentPort, "vn-agent-port", 10550, "Port the vn-agent listens on")
+	fs.StringVar(featureGatesString, "feature-gates", *featureGatesString, "A set of key=value pairs that describe feature gates for various features. ")
 
 	serverFlags := fss.FlagSet("metricsServer")
 	serverFlags.StringVar(&o.Address, "address", o.Address, "The server address.")

--- a/incubator/virtualcluster/cmd/syncer/app/server.go
+++ b/incubator/virtualcluster/cmd/syncer/app/server.go
@@ -36,6 +36,7 @@ import (
 	syncerconfig "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/cmd/syncer/app/config"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/cmd/syncer/app/options"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/util"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/version/verflag"
 )
 
@@ -45,6 +46,7 @@ func NewSyncerCommand(stopChan <-chan struct{}) *cobra.Command {
 		klog.Fatalf("unable to initialize command options: %v", err)
 	}
 
+	var featureGatesString string
 	cmd := &cobra.Command{
 		Use: "syncer",
 		Long: `The resource syncer is a daemon that watches tenant masters to
@@ -52,8 +54,15 @@ keep tenant requests are synchronized to super master by creating corresponding
 custom resources on behalf of the tenant users in super master, following the
 resource isolation policy specified in Tenant CRD.`,
 		Run: func(cmd *cobra.Command, args []string) {
+			var err error
+			var c *syncerconfig.Config
+			s.ComponentConfig.FeatureGates, err = feature.NewFeatureGate(&feature.InitFeatureGates, featureGatesString)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%v\n", err)
+				os.Exit(1)
+			}
 			verflag.PrintAndExitIfRequested()
-			c, err := s.Config()
+			c, err = s.Config()
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
 				os.Exit(1)
@@ -67,7 +76,7 @@ resource isolation policy specified in Tenant CRD.`,
 	}
 
 	fs := cmd.Flags()
-	namedFlagSets := s.Flags()
+	namedFlagSets := s.Flags(&featureGatesString)
 	verflag.AddFlags(namedFlagSets.FlagSet("global"))
 	globalflag.AddGlobalFlags(namedFlagSets.FlagSet("global"), cmd.Name())
 

--- a/incubator/virtualcluster/pkg/syncer/apis/config/types.go
+++ b/incubator/virtualcluster/pkg/syncer/apis/config/types.go
@@ -54,6 +54,9 @@ type SyncerConfiguration struct {
 	// VNAgentPort defines the port that the VN Agent is running on per host
 	VNAgentPort int32
 
+	// FeatureGates enabled by the user.
+	FeatureGates map[string]bool
+
 	// Super master rest config
 	RestConfig *rest.Config
 }

--- a/incubator/virtualcluster/pkg/syncer/util/feature.go
+++ b/incubator/virtualcluster/pkg/syncer/util/feature.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package feature
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	// SuperClusterPool is an experimental feature
+	SuperClusterPool = "SuperClusterPool"
+)
+
+var InitFeatureGates = FeatureList{
+	SuperClusterPool: {Default: false},
+}
+
+// Feature represents a feature being gated
+type Feature struct {
+	Default bool
+}
+
+// FeatureList represents a list of feature gates
+type FeatureList map[string]Feature
+
+// Supports indicates whether a feature name is supported on the given
+// feature set
+func Supports(featureList FeatureList, featureName string) bool {
+	for k := range featureList {
+		if featureName == string(k) {
+			return true
+		}
+	}
+	return false
+}
+
+// Enabled indicates whether a feature name has been enabled
+func Enabled(featureList map[string]bool, featureName string) bool {
+	return featureList[featureName]
+}
+
+// NewFeatureGate parses a string of the form "key1=value1,key2=value2,..." into a
+// map[string]bool of known keys or returns an error.
+func NewFeatureGate(f *FeatureList, value string) (map[string]bool, error) {
+	featureGate := map[string]bool{}
+	for _, s := range strings.Split(value, ",") {
+		if len(s) == 0 {
+			continue
+		}
+
+		arr := strings.SplitN(s, "=", 2)
+		if len(arr) != 2 {
+			return nil, fmt.Errorf("missing bool value for feature-gate key:%s", s)
+		}
+
+		k := strings.TrimSpace(arr[0])
+		v := strings.TrimSpace(arr[1])
+
+		if !Supports(*f, k) {
+			return nil, fmt.Errorf("unrecognized feature-gate key: %s", k)
+		}
+
+		boolValue, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value %v for feature-gate key: %s, use true|false instead", v, k)
+		}
+		featureGate[k] = boolValue
+	}
+	return featureGate, nil
+}


### PR DESCRIPTION
We will enhance syncer to support various new features such as enabling a super cluster pool to serve multiple tenants. 

This change adds feature-gate command line support to the syncer.