### PR TITLE
[VC] Identify supercluster via configmap

### DIFF
--- a/incubator/virtualcluster/cmd/syncer/app/config/config.go
+++ b/incubator/virtualcluster/cmd/syncer/app/config/config.go
@@ -34,8 +34,8 @@ type Config struct {
 	// config is the syncer's configuration object.
 	ComponentConfig syncerconfig.SyncerConfiguration
 
-	// the general kube client
-	SecretClient corev1.SecretsGetter
+	// the super cluster client
+	SuperClient corev1.CoreV1Interface
 	// virtual cluster CR client
 	VirtualClusterClient   vcclient.Interface
 	VirtualClusterInformer vcinformers.VirtualClusterInformer

--- a/incubator/virtualcluster/cmd/syncer/app/options/options.go
+++ b/incubator/virtualcluster/cmd/syncer/app/options/options.go
@@ -83,7 +83,7 @@ func NewResourceSyncerOptions() (*ResourceSyncerOptions, error) {
 			DefaultOpaqueMetaDomains:   []string{"kubernetes.io", "k8s.io"},
 			ExtraSyncingResources:      []string{},
 			VNAgentPort:                int32(10550),
-			FeatureGates:               map[string]bool{feature.SuperClusterPool: false},
+			FeatureGates:               map[string]bool{feature.SuperClusterPooling: false},
 		},
 		Address:  "",
 		Port:     "80",
@@ -172,7 +172,7 @@ func (o *ResourceSyncerOptions) Config() (*syncerappconfig.Config, error) {
 		return nil, err
 	}
 	c.ComponentConfig.RestConfig = restConfig
-	c.SecretClient = superMasterClient.CoreV1()
+	c.SuperClient = superMasterClient.CoreV1()
 	c.VirtualClusterClient = virtualClusterClient
 	c.VirtualClusterInformer = vcinformers.NewSharedInformerFactory(virtualClusterClient, 0).Tenancy().V1alpha1().VirtualClusters()
 	c.SuperMasterClient = superMasterClient

--- a/incubator/virtualcluster/cmd/syncer/app/server.go
+++ b/incubator/virtualcluster/cmd/syncer/app/server.go
@@ -100,7 +100,7 @@ resource isolation policy specified in Tenant CRD.`,
 
 func Run(cc *syncerconfig.CompletedConfig, stopCh <-chan struct{}) error {
 	ss := syncer.New(&cc.ComponentConfig,
-		cc.SecretClient,
+		cc.SuperClient,
 		cc.VirtualClusterClient,
 		cc.VirtualClusterInformer,
 		cc.SuperMasterClient,

--- a/incubator/virtualcluster/pkg/syncer/conversion/helper.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/helper.go
@@ -90,7 +90,7 @@ func GetVirtualOwner(obj runtime.Object) (cluster, namespace string) {
 	return cluster, namespace
 }
 
-func GetKubeConfigOfVC(c v1core.SecretsGetter, vc *v1alpha1.VirtualCluster) ([]byte, error) {
+func GetKubeConfigOfVC(c v1core.CoreV1Interface, vc *v1alpha1.VirtualCluster) ([]byte, error) {
 	if adminKubeConfig, exists := vc.GetAnnotations()[constants.LabelAdminKubeConfig]; exists {
 		decoded, err := base64.StdEncoding.DecodeString(adminKubeConfig)
 		if err != nil {

--- a/incubator/virtualcluster/pkg/syncer/syncer.go
+++ b/incubator/virtualcluster/pkg/syncer/syncer.go
@@ -17,8 +17,10 @@ limitations under the License.
 package syncer
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -26,6 +28,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -50,15 +53,23 @@ import (
 	mc "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/metrics"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/resources"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/util"
 )
 
 var (
 	numHealthCluster   uint64
 	numUnHealthCluster uint64
+	SuperClusterID     string
+)
+
+const (
+	SuperClusterInfoCfgMap = "supercluster-info"
+	SuperClusterIDKey      = "id"
 )
 
 type Syncer struct {
-	secretClient      v1core.SecretsGetter
+	config            *config.SyncerConfiguration
+	superClient       v1core.CoreV1Interface
 	recorder          record.EventRecorder
 	controllerManager *manager.ControllerManager
 	// lister that can list virtual clusters from a shared cache
@@ -81,7 +92,7 @@ type Bootstrap interface {
 
 func New(
 	config *config.SyncerConfiguration,
-	secretClient v1core.SecretsGetter,
+	superClient v1core.CoreV1Interface,
 	virtualClusterClient vcclient.Interface,
 	virtualClusterInformer vcinformers.VirtualClusterInformer,
 	superMasterClient clientset.Interface,
@@ -89,11 +100,12 @@ func New(
 	recorder record.EventRecorder,
 ) *Syncer {
 	syncer := &Syncer{
-		secretClient: secretClient,
-		recorder:     recorder,
-		queue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virtual_cluster"),
-		workers:      constants.UwsControllerWorkerLow,
-		clusterSet:   make(map[string]mc.ClusterInterface),
+		config:      config,
+		superClient: superClient,
+		recorder:    recorder,
+		queue:       workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virtual_cluster"),
+		workers:     constants.UwsControllerWorkerLow,
+		clusterSet:  make(map[string]mc.ClusterInterface),
 	}
 
 	// Handle VirtualCluster add&delete
@@ -150,6 +162,19 @@ func (s *Syncer) enqueueVirtualCluster(obj interface{}) {
 
 // Run begins watching and downward&upward syncing.
 func (s *Syncer) Run(stopChan <-chan struct{}) {
+	if feature.Enabled(s.config.FeatureGates, feature.SuperClusterPooling) {
+		klog.Infof("SuperClusterPooling feature is enabled!")
+		cfg, err := s.superClient.ConfigMaps("kube-system").Get(context.TODO(), SuperClusterInfoCfgMap, metav1.GetOptions{})
+		if err != nil {
+			klog.Infof("Fail to get configmap kube-system/%v from super cluster which is required for SuperClusterPooling feature. Quit!", SuperClusterInfoCfgMap)
+			os.Exit(1)
+		}
+		var ok bool
+		if SuperClusterID, ok = cfg.Data[SuperClusterIDKey]; ok == false {
+			klog.Infof("Fail to get ID value from configmap kube-system/%v. Quit!", SuperClusterInfoCfgMap)
+			os.Exit(1)
+		}
+	}
 	go func() {
 		if err := s.controllerManager.Start(stopChan); err != nil {
 			klog.V(1).Infof("controller manager exit: %v", err)
@@ -277,7 +302,7 @@ func (s *Syncer) addCluster(key string, vc *v1alpha1.VirtualCluster) error {
 
 	clusterName := conversion.ToClusterKey(vc)
 
-	adminKubeConfigBytes, err := conversion.GetKubeConfigOfVC(s.secretClient, vc)
+	adminKubeConfigBytes, err := conversion.GetKubeConfigOfVC(s.superClient, vc)
 	if err != nil {
 		return err
 	}

--- a/incubator/virtualcluster/pkg/syncer/util/feature.go
+++ b/incubator/virtualcluster/pkg/syncer/util/feature.go
@@ -23,12 +23,12 @@ import (
 )
 
 const (
-	// SuperClusterPool is an experimental feature
-	SuperClusterPool = "SuperClusterPool"
+	// SuperClusterPooling is an experimental feature
+	SuperClusterPooling = "SuperClusterPooling"
 )
 
 var InitFeatureGates = FeatureList{
-	SuperClusterPool: {Default: false},
+	SuperClusterPooling: {Default: false},
 }
 
 // Feature represents a feature being gated


### PR DESCRIPTION
When supporting multiple super masters, the syncer needs to identify the super cluster it is serving for to decide if an object marked with super cluster owner in the tenant master should be synced or not. 

Since K8s does not provide a reliable UUID for a cluster, we leverage a configmap created by the super cluster administrator to identify the super cluster. The configmap is stored in kube-system namespace and uses the predefined name (we can make it configurable later if needed). The syncer will not verify the ID and relies on the administrator to guarantee its uniqueness. 

This change also renames the feature name for better readability. 

