### PR TITLE
[VC] Add framework code for an experimental vc scheduler

### DIFF
--- a/incubator/virtualcluster/experiment/.gitignore
+++ b/incubator/virtualcluster/experiment/.gitignore
@@ -1,0 +1,25 @@
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+_output
+coverage
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Kubernetes Generated files - skip generated files, except for vendored files
+
+vendor/
+
+# editor and IDE paraphernalia
+.idea
+*.swp
+*.swo
+*~

--- a/incubator/virtualcluster/experiment/Makefile
+++ b/incubator/virtualcluster/experiment/Makefile
@@ -1,0 +1,45 @@
+# Explicitly opt into go modules, even though we're inside a GOPATH directory
+export GO111MODULE=on
+
+# Image URL to use all building/pushing image targets
+DOCKER_REG ?= ${or ${VC_DOCKER_REGISTRY},"virtualcluster"}
+IMG ?= ${DOCKER_REG}/scheduler-amd64
+
+# TEST_FLAGS used as flags of go test.
+TEST_FLAGS ?= -v --race
+
+
+# CRD_OPTIONS ?= "crd:trivialVersions=true"
+CRD_OPTIONS ?= "crd:trivialVersions=true,maxDescLen=0"
+
+.PHONY: all
+all: build
+
+build: 
+	hack/make-rules/build.sh $(WHAT)
+
+.PHONY: clean
+clean: ## clean to remove bin/* and files created by module
+	@go mod tidy
+	@rm -rf _output/*
+	@rm -rf coverage/*
+
+# Run go fmt against code
+fmt:
+	go fmt ./pkg/... ./cmd/...
+
+# Run go vet against code
+vet:
+	go vet ./pkg/... ./cmd/...
+
+
+# Build docker image.
+#
+# 1. build all binaries.
+# 2. copy binaries to the corresponding docker image.
+build-images:
+	hack/make-rules/release-images.sh $(WHAT)
+
+# Push the docker image
+docker-push:
+	$(foreach i,$(IMG),docker push $i;)

--- a/incubator/virtualcluster/experiment/OWNERS
+++ b/incubator/virtualcluster/experiment/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- Fei-Guo
+- zhuangqh
+
+reviewers:
+- zhuangqh
+- Fei-Guo
+- christopherhein

--- a/incubator/virtualcluster/experiment/cmd/scheduler/app/config/config.go
+++ b/incubator/virtualcluster/experiment/cmd/scheduler/app/config/config.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/record"
+
+	schedulerconfig "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/scheduler/apis/config"
+)
+
+// Config has all the context to run a Syncer.
+type Config struct {
+	// the scheduler's configuration object
+	ComponentConfig schedulerconfig.SchedulerConfiguration
+
+	// the client only used for leader election
+	LeaderElectionClient clientset.Interface
+
+	// the rest config for the master
+	Kubeconfig *restclient.Config
+
+	// the event sink
+	Recorder    record.EventRecorder
+	Broadcaster record.EventBroadcaster
+
+	// LeaderElection is optional.
+	LeaderElection *leaderelection.LeaderElectionConfig
+}
+
+type completedConfig struct {
+	*Config
+}
+
+// CompletedConfig same as Config, just to swap private object.
+type CompletedConfig struct {
+	// Embed a private pointer that cannot be instantiated outside of this package.
+	*completedConfig
+}
+
+// Complete fills in any fields not set that are required to have valid data. It's mutating the receiver.
+func (c *Config) Complete() *CompletedConfig {
+	cc := completedConfig{c}
+	return &CompletedConfig{&cc}
+}

--- a/incubator/virtualcluster/experiment/cmd/scheduler/app/options/options.go
+++ b/incubator/virtualcluster/experiment/cmd/scheduler/app/options/options.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	clientset "k8s.io/client-go/kubernetes"
+	clientgokubescheme "k8s.io/client-go/kubernetes/scheme"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/tools/record"
+	cliflag "k8s.io/component-base/cli/flag"
+	componentbaseconfig "k8s.io/component-base/config"
+	"k8s.io/klog"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/apis"
+
+	schedulerappconfig "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/cmd/scheduler/app/config"
+	schedulerconfig "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/scheduler/apis/config"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/scheduler/constants"
+)
+
+type SchedulerOptions struct {
+	// The syncer configuration.
+	ComponentConfig schedulerconfig.SchedulerConfiguration
+
+	MetaCluster           string
+	MetaClusterKubeconfig string
+}
+
+// NewSchedulerOptions creates new scheduler options with a default config.
+func NewSchedulerOptions() (*SchedulerOptions, error) {
+	return &SchedulerOptions{
+		ComponentConfig: schedulerconfig.SchedulerConfiguration{
+			LeaderElection: schedulerconfig.SchedulerLeaderElectionConfiguration{
+				LeaderElectionConfiguration: componentbaseconfig.LeaderElectionConfiguration{
+					LeaderElect:   true,
+					LeaseDuration: v1.Duration{Duration: 15 * time.Second},
+					RenewDeadline: v1.Duration{Duration: 10 * time.Second},
+					RetryPeriod:   v1.Duration{Duration: 2 * time.Second},
+					ResourceLock:  resourcelock.ConfigMapsResourceLock,
+				},
+				LockObjectName: "vc-scheduler-leaderelection-lock",
+			},
+			ClientConnection: componentbaseconfig.ClientConnectionConfiguration{},
+		},
+	}, nil
+}
+
+func (o *SchedulerOptions) Flags() cliflag.NamedFlagSets {
+	fss := cliflag.NamedFlagSets{}
+
+	fs := fss.FlagSet("server")
+	fs.StringVar(&o.MetaCluster, "meta-cluster", o.MetaCluster, "The address of the meta cluster Kubernetes APIServer (overrides any value in meta-cluster-kubeconfig).")
+	fs.StringVar(&o.ComponentConfig.ClientConnection.Kubeconfig, "meta-master-kubeconfig", o.ComponentConfig.ClientConnection.Kubeconfig, "Path to kubeconfig file with authorization and meta cluster location information.")
+
+	BindFlags(&o.ComponentConfig.LeaderElection, fss.FlagSet("leader election"))
+
+	return fss
+}
+
+// BindFlags binds the LeaderElectionConfiguration struct fields to a flagset
+func BindFlags(l *schedulerconfig.SchedulerLeaderElectionConfiguration, fs *pflag.FlagSet) {
+	fs.BoolVar(&l.LeaderElect, "leader-elect", l.LeaderElect, ""+
+		"Start a leader election client and gain leadership before "+
+		"executing the main loop. Enable this when running replicated "+
+		"components for high availability.")
+	fs.DurationVar(&l.LeaseDuration.Duration, "leader-elect-lease-duration", l.LeaseDuration.Duration, ""+
+		"The duration that non-leader candidates will wait after observing a leadership "+
+		"renewal until attempting to acquire leadership of a led but unrenewed leader "+
+		"slot. This is effectively the maximum duration that a leader can be stopped "+
+		"before it is replaced by another candidate. This is only applicable if leader "+
+		"election is enabled.")
+	fs.DurationVar(&l.RenewDeadline.Duration, "leader-elect-renew-deadline", l.RenewDeadline.Duration, ""+
+		"The interval between attempts by the acting master to renew a leadership slot "+
+		"before it stops leading. This must be less than or equal to the lease duration. "+
+		"This is only applicable if leader election is enabled.")
+	fs.DurationVar(&l.RetryPeriod.Duration, "leader-elect-retry-period", l.RetryPeriod.Duration, ""+
+		"The duration the clients should wait between attempting acquisition and renewal "+
+		"of a leadership. This is only applicable if leader election is enabled.")
+	fs.StringVar(&l.ResourceLock, "leader-elect-resource-lock", l.ResourceLock, ""+
+		"The type of resource object that is used for locking during "+
+		"leader election. Supported options are `endpoints` and `configmaps` (default).")
+	fs.StringVar(&l.LockObjectNamespace, "lock-object-namespace", l.LockObjectNamespace, "DEPRECATED: define the namespace of the lock object.")
+	fs.StringVar(&l.LockObjectName, "lock-object-name", l.LockObjectName, "DEPRECATED: define the name of the lock object.")
+}
+
+// Config return a syncer config object
+func (o *SchedulerOptions) Config() (*schedulerappconfig.Config, error) {
+	c := &schedulerappconfig.Config{}
+	c.ComponentConfig = o.ComponentConfig
+
+	// Prepare kube clients
+	leaderElectionClient, restConfig, err := createClients(c.ComponentConfig.ClientConnection, o.MetaCluster, c.ComponentConfig.LeaderElection.RenewDeadline.Duration)
+	if err != nil {
+		return nil, err
+	}
+
+	// Prepare event clients.
+	eventBroadcaster := record.NewBroadcaster()
+	recorder := eventBroadcaster.NewRecorder(clientgokubescheme.Scheme, corev1.EventSource{Component: constants.SchedulerUserAgent})
+	leaderElectionBroadcaster := record.NewBroadcaster()
+	leaderElectionRecorder := leaderElectionBroadcaster.NewRecorder(clientgokubescheme.Scheme, corev1.EventSource{Component: constants.SchedulerUserAgent})
+
+	// Set up leader election if enabled.
+	var leaderElectionConfig *leaderelection.LeaderElectionConfig
+	if c.ComponentConfig.LeaderElection.LeaderElect {
+		leaderElectionConfig, err = makeLeaderElectionConfig(c.ComponentConfig.LeaderElection, leaderElectionClient, leaderElectionRecorder)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Setup Scheme for all resources
+	if err := apis.AddToScheme(clientgokubescheme.Scheme); err != nil {
+		return nil, err
+	}
+
+	c.ComponentConfig.RestConfig = restConfig
+	c.Broadcaster = eventBroadcaster
+	c.Recorder = recorder
+	c.LeaderElectionClient = leaderElectionClient
+	c.LeaderElection = leaderElectionConfig
+
+	return c, nil
+}
+
+// makeLeaderElectionConfig builds a leader election configuration. It will
+// create a new resource lock associated with the configuration.
+func makeLeaderElectionConfig(config schedulerconfig.SchedulerLeaderElectionConfiguration, client clientset.Interface, recorder record.EventRecorder) (*leaderelection.LeaderElectionConfig, error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get hostname: %v", err)
+	}
+	// add a uniquifier so that two processes on the same host don't accidentally both become active
+	id := hostname + "_" + string(uuid.NewUUID())
+
+	if config.LockObjectNamespace == "" {
+		var err error
+		config.LockObjectNamespace, err = getInClusterNamespace()
+		if err != nil {
+			return nil, fmt.Errorf("unable to find leader election namespace: %v", err)
+		}
+	}
+
+	rl, err := resourcelock.New(config.ResourceLock,
+		config.LockObjectNamespace,
+		config.LockObjectName,
+		client.CoreV1(),
+		client.CoordinationV1(),
+		resourcelock.ResourceLockConfig{
+			Identity:      id,
+			EventRecorder: recorder,
+		})
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create resource lock: %v", err)
+	}
+
+	return &leaderelection.LeaderElectionConfig{
+		Lock:          rl,
+		LeaseDuration: config.LeaseDuration.Duration,
+		RenewDeadline: config.RenewDeadline.Duration,
+		RetryPeriod:   config.RetryPeriod.Duration,
+		WatchDog:      leaderelection.NewLeaderHealthzAdaptor(time.Second * 20),
+		Name:          constants.SchedulerUserAgent,
+	}, nil
+}
+
+func getInClusterNamespace() (string, error) {
+	// Check whether the namespace file exists.
+	// If not, we are not running in cluster so can't guess the namespace.
+	_, err := os.Stat("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if os.IsNotExist(err) {
+		return "", fmt.Errorf("not running in-cluster, please specify LeaderElectionNamespace")
+	} else if err != nil {
+		return "", fmt.Errorf("error checking namespace file: %v", err)
+	}
+
+	// Load the namespace file and return its content
+	namespace, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		return "", fmt.Errorf("error reading namespace file: %v", err)
+	}
+	return string(namespace), nil
+}
+
+func createClients(config componentbaseconfig.ClientConnectionConfiguration, masterOverride string, timeout time.Duration) (clientset.Interface,
+	*restclient.Config, error) {
+	// This creates a client, first loading any specified kubeconfig
+	// file, and then overriding the Master flag, if non-empty.
+	var (
+		restConfig *restclient.Config
+		err        error
+	)
+	if len(config.Kubeconfig) == 0 && len(masterOverride) == 0 {
+		klog.Info("Neither kubeconfig file nor master URL was specified. Falling back to in-cluster config.")
+		restConfig, err = restclient.InClusterConfig()
+	} else {
+		// This creates a client, first loading any specified kubeconfig
+		// file, and then overriding the Master flag, if non-empty.
+		restConfig, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			&clientcmd.ClientConfigLoadingRules{ExplicitPath: config.Kubeconfig},
+			&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: masterOverride}}).ClientConfig()
+	}
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if restConfig.Timeout == 0 {
+		restConfig.Timeout = constants.DefaultRequestTimeout
+	}
+
+	restConfig.ContentConfig.ContentType = config.AcceptContentTypes
+	restConfig.QPS = config.QPS
+	if restConfig.QPS == 0 {
+		restConfig.QPS = constants.DefaultSchedulerClientQPS
+	}
+	restConfig.Burst = int(config.Burst)
+	if restConfig.Burst == 0 {
+		restConfig.Burst = constants.DefaultSchedulerClientBurst
+	}
+
+	leaderElectionRestConfig := *restConfig
+	restConfig.Timeout = timeout
+	leaderElectionClient, err := clientset.NewForConfig(restclient.AddUserAgent(&leaderElectionRestConfig, "leader-election"))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return leaderElectionClient, restConfig, nil
+}

--- a/incubator/virtualcluster/experiment/cmd/scheduler/app/server.go
+++ b/incubator/virtualcluster/experiment/cmd/scheduler/app/server.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apiserver/pkg/util/term"
+	"k8s.io/client-go/tools/leaderelection"
+	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/component-base/cli/globalflag"
+	"k8s.io/klog"
+
+	schedulerappconfig "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/cmd/scheduler/app/config"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/cmd/scheduler/app/options"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/version/verflag"
+)
+
+func NewSchedulerCommand(stopChan <-chan struct{}) *cobra.Command {
+	s, err := options.NewSchedulerOptions()
+	if err != nil {
+		klog.Fatalf("unable to initialize command options: %v", err)
+	}
+
+	cmd := &cobra.Command{
+		Use:  "scheduler",
+		Long: `The scheduler handles tenant namespace scheduling over super clusters.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			verflag.PrintAndExitIfRequested()
+			c, err := s.Config()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%v\n", err)
+				os.Exit(1)
+			}
+
+			if err := Run(c.Complete(), stopChan); err != nil {
+				fmt.Fprintf(os.Stderr, "%v\n", err)
+				os.Exit(1)
+			}
+		},
+	}
+
+	fs := cmd.Flags()
+	namedFlagSets := s.Flags()
+	verflag.AddFlags(namedFlagSets.FlagSet("global"))
+	globalflag.AddGlobalFlags(namedFlagSets.FlagSet("global"), cmd.Name())
+
+	for _, f := range namedFlagSets.FlagSets {
+		fs.AddFlagSet(f)
+	}
+	usageFmt := "Usage:\n  %s\n"
+	cols, _, _ := term.TerminalSize(cmd.OutOrStdout())
+	cmd.SetUsageFunc(func(cmd *cobra.Command) error {
+		fmt.Fprintf(cmd.OutOrStderr(), usageFmt, cmd.UseLine())
+		cliflag.PrintSections(cmd.OutOrStderr(), namedFlagSets, cols)
+		return nil
+	})
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\n\n"+usageFmt, cmd.Long, cmd.UseLine())
+		cliflag.PrintSections(cmd.OutOrStdout(), namedFlagSets, cols)
+	})
+
+	return cmd
+}
+
+// Run start the scheduler.
+func Run(cc *schedulerappconfig.CompletedConfig, stopCh <-chan struct{}) error {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	go func() {
+		select {
+		case <-stopCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	// Prepare a reusable runCommand function.
+	run := startScheduler(ctx, stopCh)
+
+	if cc.LeaderElection != nil {
+		cc.LeaderElection.Callbacks = leaderelection.LeaderCallbacks{
+			OnStartedLeading: run,
+			OnStoppedLeading: func() {
+				klog.Fatalf("leaderelection lost")
+			},
+		}
+		leaderElector, err := leaderelection.NewLeaderElector(*cc.LeaderElection)
+		if err != nil {
+			return fmt.Errorf("couldn't create leader elector: %v", err)
+		}
+
+		leaderElector.Run(ctx)
+		return fmt.Errorf("lost lease")
+	}
+
+	run(ctx)
+	return fmt.Errorf("finished without leader elect")
+}
+
+func startScheduler(ctx context.Context, stopCh <-chan struct{}) func(context.Context) {
+	return func(ctx context.Context) {
+		//TODO start scheduler
+		<-ctx.Done()
+	}
+}

--- a/incubator/virtualcluster/experiment/cmd/scheduler/main.go
+++ b/incubator/virtualcluster/experiment/cmd/scheduler/main.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/component-base/logs"
+
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/cmd/scheduler/app"
+)
+
+func main() {
+	logs.InitLogs()
+	defer logs.FlushLogs()
+
+	stopChan := genericapiserver.SetupSignalHandler()
+
+	if err := app.NewSchedulerCommand(stopChan).Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/incubator/virtualcluster/experiment/hack/lib/build.sh
+++ b/incubator/virtualcluster/experiment/hack/lib/build.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+readonly VC_EXPERIMENT_GO_PACKAGE=sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment
+
+readonly VC_EXPERIMENT_ALL_TARGETS=(
+  cmd/scheduler
+)
+readonly VC_EXPERIMENT_ALL_BINARIES=("${VC_EXPERIMENT_ALL_TARGETS[@]##*/}")
+
+# binaries_from_targets take a list of build targets and return the
+# full go package to be built
+binaries_from_targets() {
+  local target
+  for target; do
+    # If the target starts with what looks like a domain name, assume it has a
+    # fully-qualified package name rather than one that needs the Kubernetes
+    # package prepended.
+    if [[ "${target}" =~ ^([[:alnum:]]+".")+[[:alnum:]]+"/" ]]; then
+      echo "${target}"
+    else
+      echo "${VC_EXPERIMENT_GO_PACKAGE}/${target}"
+    fi
+  done
+}
+
+version() {
+  # GIT_COMMIT is used for daemon GitCommit in go build.
+  GIT_COMMIT=$(git rev-parse HEAD)
+
+  # BUILD_DATE is used for daemon BuildTime in go build.
+  BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+  GIT_VERSION="v1.0.0"
+
+  VERSION_PKG=sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/version
+  echo "-X ${VERSION_PKG}.gitVersion=${GIT_VERSION}"
+  echo "-X ${VERSION_PKG}.gitCommit=${GIT_COMMIT}"
+  echo "-X ${VERSION_PKG}.buildDate=${BUILD_DATE}"
+}
+
+# Build binaries targets specified
+#
+# Input:
+#   $@ - targets and go flags.  If no targets are set then all binaries targets
+#     are built.
+build_binaries() {
+  local goflags goldflags gcflags
+  goldflags="${GOLDFLAGS:-} -s -w $(version)"
+  gcflags="${GOGCFLAGS:-}"
+  goflags=${GOFLAGS:-}
+
+  local -a targets=()
+  local arg
+
+  for arg; do
+    if [[ "${arg}" == -* ]]; then
+      # Assume arguments starting with a dash are flags to pass to go.
+      goflags+=("${arg}")
+    else
+      targets+=("${arg}")
+    fi
+  done
+
+  if [[ ${#targets[@]} -eq 0 ]]; then
+    targets=("${VC_EXPERIMENT_ALL_TARGETS[@]}")
+  fi
+
+  local -a binaries
+  while IFS="" read -r binary; do binaries+=("$binary"); done < <(binaries_from_targets "${targets[@]}")
+
+  mkdir -p ${VC_EXPERIMENT_BIN_DIR}
+  cd ${VC_EXPERIMENT_BIN_DIR}
+  for binary in "${binaries[@]}"; do
+    echo "Building ${binary}"
+    GOOS=${GOOS:-linux} go build -ldflags "${goldflags:-}" -gcflags "${gcflags:-}" ${goflags} ${binary}
+  done
+}

--- a/incubator/virtualcluster/experiment/hack/lib/docker-image.sh
+++ b/incubator/virtualcluster/experiment/hack/lib/docker-image.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Get the set of binaries that run in Docker (on Linux)
+# Entry format is "<name-of-binary>,<base-image>".
+# Binaries are placed in /usr/local/bin inside the image.
+#
+# $1 - server architecture
+get_docker_wrapped_binaries() {
+  local arch=$1
+  local debian_base_version=v1.0.0
+  local debian_iptables_version=v11.0.2
+  local targets=()
+  for target in ${@:2}; do
+      targets+=($target,${VC_BASE_IMAGE_REGISTRY}/debian-base-${arch}:${debian_base_version})
+  done
+
+  if [ ${#targets[@]} -eq 0 ]; then
+    ### If you change any of these lists, please also update VC_ALL_TARGETS
+    targets=(
+      scheduler,"${VC_BASE_IMAGE_REGISTRY}/debian-base-${arch}:${debian_base_version}"
+    )
+  fi
+
+  echo "${targets[@]}"
+}
+
+
+# This builds all the release docker images (One docker image per binary)
+# Args:
+#  $1 - binary_dir, the directory to save the tared images to.
+#  $2 - arch, architecture for which we are building docker images.
+create_docker_image() {
+  local binary_dir="$1"
+  local arch="$2"
+  local binary_name
+  local binaries=($(get_docker_wrapped_binaries "${arch}" "${@:3}"))
+
+  for wrappable in "${binaries[@]}"; do
+
+    local oldifs=$IFS
+    IFS=","
+    set $wrappable
+    IFS=$oldifs
+
+    local binary_name="$1"
+    local base_image=$2
+    local image_user=""
+    BASE_IMAGE=${BASE_IMAGE:-debian}
+    if [ "$BASE_IMAGE" == "distroless" ]; then
+      base_image="gcr.io/distroless/static:nonroot"
+      image_user="USER nonroot:nonroot"
+    fi
+    local docker_build_path="${binary_dir}/${binary_name}.dockerbuild"
+    local docker_file_path="${docker_build_path}/Dockerfile"
+    local binary_file_path="${binary_dir}/${binary_name}"
+    local docker_image_tag="${VC_DOCKER_REGISTRY}/${binary_name}-${arch}:latest"
+
+    echo "Starting docker build for image: ${binary_name}-${arch}"
+    (
+      rm -rf "${docker_build_path}"
+      mkdir -p "${docker_build_path}"
+      ln "${binary_dir}/${binary_name}" "${docker_build_path}/${binary_name}"
+      cat <<EOF > "${docker_file_path}"
+FROM ${base_image}
+COPY ${binary_name} /usr/local/bin/${binary_name}
+${image_user}
+EOF
+      "${DOCKER[@]}" build -q -t "${docker_image_tag}" "${docker_build_path}" >/dev/null
+    ) &
+  done
+
+  wait-for-jobs || { echo "previous Docker build failed"; return 1; }
+  echo "Docker builds done"
+}
+
+# Package up all of the binaries in docker images
+build_images() {
+  # Clean out any old images
+  rm -rf "${VC_EXPERIMENT_RELEASE_DIR}"
+  mkdir -p "${VC_EXPERIMENT_RELEASE_DIR}"
+  cd ${VC_EXPERIMENT_BIN_DIR}
+  local targets=()
+
+  for arg; do
+    targets+=(${arg##*/})
+  done
+  echo "${targets[@]-}"
+  
+  if [ ${#targets[@]} -eq 0 ]; then
+    cp "${VC_EXPERIMENT_ALL_BINARIES[@]/#/}" ${VC_EXPERIMENT_RELEASE_DIR}
+  else
+    cp ${targets[@]} ${VC_EXPERIMENT_RELEASE_DIR}
+  fi
+
+  create_docker_image "${VC_EXPERIMENT_RELEASE_DIR}" "amd64" "${targets[@]-}"
+}

--- a/incubator/virtualcluster/experiment/hack/lib/init.sh
+++ b/incubator/virtualcluster/experiment/hack/lib/init.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export GO111MODULE=on
+
+VC_EXPERIMENT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+VC_EXPERIMENT_OUTPUT_DIR=${VC_EXPERIMENT_ROOT}/_output/
+VC_EXPERIMENT_BIN_DIR=${VC_EXPERIMENT_OUTPUT_DIR}/bin/
+VC_EXPERIMENT_RELEASE_DIR=${VC_EXPERIMENT_OUTPUT_DIR}/release/
+
+readonly VC_DOCKER_REGISTRY="${VC_DOCKER_REGISTRY:-virtualcluster}"
+readonly VC_BASE_IMAGE_REGISTRY="${VC_BASE_IMAGE_REGISTRY:-k8s.gcr.io}"
+
+DOCKER="docker"
+
+source "${VC_EXPERIMENT_ROOT}/hack/lib/build.sh"
+source "${VC_EXPERIMENT_ROOT}/hack/lib/docker-image.sh"
+source "${VC_EXPERIMENT_ROOT}/hack/lib/util.sh"

--- a/incubator/virtualcluster/experiment/hack/lib/util.sh
+++ b/incubator/virtualcluster/experiment/hack/lib/util.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Wait for background jobs to finish. Return with
+# an error status if any of the jobs failed.
+wait-for-jobs() {
+  local fail=0
+  local job
+  for job in $(jobs -p); do
+    wait "${job}" || fail=$((fail + 1))
+  done
+  return ${fail}
+}

--- a/incubator/virtualcluster/experiment/hack/make-rules/build.sh
+++ b/incubator/virtualcluster/experiment/hack/make-rules/build.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+VC_EXPERIMENT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+source "${VC_EXPERIMENT_ROOT}/hack/lib/init.sh"
+
+build_binaries "$@"

--- a/incubator/virtualcluster/experiment/hack/make-rules/release-images.sh
+++ b/incubator/virtualcluster/experiment/hack/make-rules/release-images.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+VC_EXPERIMENT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+source "${VC_EXPERIMENT_ROOT}/hack/lib/init.sh"
+
+build_binaries "$@"
+build_images "$@"

--- a/incubator/virtualcluster/experiment/pkg/scheduler/apis/config/types.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/apis/config/types.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	componentbaseconfig "k8s.io/component-base/config"
+)
+
+// SchedulerConfiguration configures a vc namespace scheduler. It is read only during scheduler life cycle.
+type SchedulerConfiguration struct {
+	metav1.TypeMeta
+
+	// LeaderElection defines the configuration of leader election client.
+	LeaderElection SchedulerLeaderElectionConfiguration
+
+	// ClientConnection specifies the kubeconfig file and client connection
+	// settings for the proxy server to use when communicating with the apiserver.
+	ClientConnection componentbaseconfig.ClientConnectionConfiguration
+
+	// Super master rest config
+	RestConfig *rest.Config
+}
+
+// SchedulerLeaderElectionConfiguration expands LeaderElectionConfiguration
+// to include syncer specific configuration.
+type SchedulerLeaderElectionConfiguration struct {
+	componentbaseconfig.LeaderElectionConfiguration
+	// LockObjectNamespace defines the namespace of the lock object
+	LockObjectNamespace string
+	// LockObjectName defines the lock object name
+	LockObjectName string
+}

--- a/incubator/virtualcluster/experiment/pkg/scheduler/constants/constants.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/constants/constants.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+import (
+	"time"
+
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/version"
+)
+
+const (
+
+	// Override the client-go default 5 qps and 10 burst
+	DefaultSchedulerClientQPS   = 100
+	DefaultSchedulerClientBurst = 500
+
+	// DefaultRequestTimeout is set for all client-go request. This is the absolute
+	// timeout of the HTTP request, including reading the response body.
+	DefaultRequestTimeout = 30 * time.Second
+)
+
+var SchedulerUserAgent = "scheduler" + version.BriefVersion()


### PR DESCRIPTION
This change creates an experiment fold in VC repo. It contains the implementation of a VC scheduler which supports the experimental feature  - superclusterpooling.

When there are multiple super clusters, this scheduler will decide which super cluster should sync the tenant objects (namespace, pod, etc) that are created in the tenant master.

This change adds necessary build scripts so that the scheduler development can be decoupled with main vc repo.