### PR TITLE
[VC] Add scheduler resource watcher framework

### DIFF
--- a/incubator/virtualcluster/experiment/cmd/scheduler/app/config/config.go
+++ b/incubator/virtualcluster/experiment/cmd/scheduler/app/config/config.go
@@ -17,18 +17,29 @@ limitations under the License.
 package config
 
 import (
+	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/record"
 
 	schedulerconfig "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/scheduler/apis/config"
+	vcclient "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/client/clientset/versioned"
+	vcinformers "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/client/informers/externalversions/tenancy/v1alpha1"
 )
 
 // Config has all the context to run a Syncer.
 type Config struct {
 	// the scheduler's configuration object
 	ComponentConfig schedulerconfig.SchedulerConfiguration
+
+	// virtual cluster CR client
+	VirtualClusterClient   vcclient.Interface
+	VirtualClusterInformer vcinformers.VirtualClusterInformer
+
+	// the meta cluster client
+	MetaClusterClient          clientset.Interface
+	MetaClusterInformerFactory informers.SharedInformerFactory
 
 	// the client only used for leader election
 	LeaderElectionClient clientset.Interface

--- a/incubator/virtualcluster/experiment/pkg/scheduler/constants/constants.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/constants/constants.go
@@ -31,6 +31,8 @@ const (
 	// DefaultRequestTimeout is set for all client-go request. This is the absolute
 	// timeout of the HTTP request, including reading the response body.
 	DefaultRequestTimeout = 30 * time.Second
+
+	VirtualClusterWorker = 3
 )
 
 var SchedulerUserAgent = "scheduler" + version.BriefVersion()

--- a/incubator/virtualcluster/experiment/pkg/scheduler/manager/manager.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/manager/manager.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"sync"
+
+	schedulerconfig "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/scheduler/apis/config"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/listener"
+)
+
+// WatchManager manages number of resource watchers.
+type WatchManager struct {
+	resourceWatchers map[ResourceWatcher]struct{}
+}
+
+func New() *WatchManager {
+	return &WatchManager{resourceWatchers: make(map[ResourceWatcher]struct{})}
+}
+
+// ResourceWatcher is the interface used by WatchManager to manage multiple resource watchers.
+type ResourceWatcher interface {
+	listener.ClusterChangeListener
+	Start(stopCh <-chan struct{}) error
+}
+
+type ResourceWatcherNew func(*schedulerconfig.SchedulerConfiguration) (ResourceWatcher, error)
+
+// AddResourceWatcher adds a resource watcher to the WatchManager.
+func (m *WatchManager) AddResourceWatcher(s ResourceWatcher) {
+	m.resourceWatchers[s] = struct{}{}
+	listener.AddListener(s)
+}
+
+func (m *WatchManager) Start(stop <-chan struct{}) error {
+	errCh := make(chan error)
+
+	wg := &sync.WaitGroup{}
+	wg.Add(len(m.resourceWatchers))
+
+	for s := range m.resourceWatchers {
+		go func(s ResourceWatcher) {
+			defer wg.Done()
+			if err := s.Start(stop); err != nil {
+				errCh <- err
+			}
+		}(s)
+	}
+
+	doneCh := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(doneCh)
+	}()
+
+	select {
+	case <-doneCh:
+		return nil
+	case <-stop:
+		return nil
+	case err := <-errCh:
+		return err
+	}
+}

--- a/incubator/virtualcluster/experiment/pkg/scheduler/scheduler.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/scheduler.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+
+	schedulerconfig "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/scheduler/apis/config"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/scheduler/constants"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/scheduler/manager"
+	virtualClusterWatchers "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/scheduler/watcher/virtualcluster"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
+	vcclient "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/client/clientset/versioned"
+	vcinformers "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/client/informers/externalversions/tenancy/v1alpha1"
+	virtualClusterListerers "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/client/listers/tenancy/v1alpha1"
+	mc "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/mccontroller"
+)
+
+type Scheduler struct {
+	config                *schedulerconfig.SchedulerConfiguration
+	metaClusterClient     clientset.Interface
+	recorder              record.EventRecorder
+	virtualClusterWatcher *manager.WatchManager
+
+	// lister that can list virtualclusters from an informer cache
+	virtualClusterListerer virtualClusterListerers.VirtualClusterLister
+	// returns true when the vc cache is ready
+	virtualClusterSyncer cache.InformerSynced
+
+	virtualClusterQueue workqueue.RateLimitingInterface
+	vcWorkers           int
+	// virtualClusterSet holds the virtualcluster collection
+	virtualClusterLock sync.Mutex
+	virtualClusterSet  map[string]mc.ClusterInterface
+}
+
+func New(
+	config *schedulerconfig.SchedulerConfiguration,
+	vcClient vcclient.Interface,
+	vcInformer vcinformers.VirtualClusterInformer,
+	metaClusterClient clientset.Interface,
+	metaInformers informers.SharedInformerFactory,
+	recorder record.EventRecorder,
+) *Scheduler {
+	scheduler := &Scheduler{
+		config:              config,
+		metaClusterClient:   metaClusterClient,
+		recorder:            recorder,
+		virtualClusterQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virtualcluster"),
+		vcWorkers:           constants.VirtualClusterWorker,
+		virtualClusterSet:   make(map[string]mc.ClusterInterface),
+	}
+
+	// Handle VirtualCluster add&delete
+	vcInformer.Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: scheduler.enqueueVirtualCluster,
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				newVC := newObj.(*v1alpha1.VirtualCluster)
+				oldVC := oldObj.(*v1alpha1.VirtualCluster)
+				if newVC.ResourceVersion == oldVC.ResourceVersion {
+					return
+				}
+				scheduler.enqueueVirtualCluster(newObj)
+			},
+			DeleteFunc: scheduler.enqueueVirtualCluster,
+		},
+	)
+	scheduler.virtualClusterListerer = vcInformer.Lister()
+	scheduler.virtualClusterSyncer = vcInformer.Informer().HasSynced
+
+	vcWatcher := manager.New()
+	scheduler.virtualClusterWatcher = vcWatcher
+
+	virtualClusterWatchers.Register(config, vcWatcher)
+	return scheduler
+}
+
+// enqueue deleted and running object.
+func (s *Scheduler) enqueueVirtualCluster(obj interface{}) {
+	_, ok := obj.(*v1alpha1.VirtualCluster)
+
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %+v", obj))
+			return
+		}
+		_, ok = tombstone.Obj.(*v1alpha1.VirtualCluster)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a vc %+v", obj))
+			return
+		}
+	}
+
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	s.virtualClusterQueue.Add(key)
+}
+
+func (s *Scheduler) Run(stopChan <-chan struct{}) {
+	go func() {
+		if err := s.virtualClusterWatcher.Start(stopChan); err != nil {
+			klog.Infof("virtualcluster watch manager exits: %v", err)
+		}
+	}()
+
+	go func() {
+		defer utilruntime.HandleCrash()
+		defer s.virtualClusterQueue.ShutDown()
+
+		klog.Infof("starting Scheduler")
+		defer klog.Infof("shutting down scheduler")
+
+		if !cache.WaitForCacheSync(stopChan, s.virtualClusterSyncer) {
+			return
+		}
+
+		klog.V(5).Infof("starting scheduler workers")
+		for i := 0; i < s.vcWorkers; i++ {
+			go wait.Until(s.vcWorkerRun, 1*time.Second, stopChan)
+		}
+		<-stopChan
+	}()
+}
+
+func (s *Scheduler) vcWorkerRun() {
+	for s.processNextWorkItem() {
+	}
+}
+
+func (s *Scheduler) processNextWorkItem() bool {
+	key, quit := s.virtualClusterQueue.Get()
+	if quit {
+		return false
+	}
+	defer s.virtualClusterQueue.Done(key)
+
+	err := s.syncVirtualCluster(key.(string))
+	if err == nil {
+		s.virtualClusterQueue.Forget(key)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("error processing virtual cluster %v (will retry): %v", key, err))
+	s.virtualClusterQueue.AddRateLimited(key)
+	return true
+}
+
+func (s *Scheduler) syncVirtualCluster(key string) error {
+	// TODO: add vc reconcile logic
+	return nil
+}

--- a/incubator/virtualcluster/experiment/pkg/scheduler/watcher/virtualcluster/register.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/watcher/virtualcluster/register.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watchers
+
+import (
+	schedulerconfig "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/scheduler/apis/config"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/scheduler/manager"
+)
+
+var AddToManagerFuncs []manager.ResourceWatcherNew
+
+func init() {
+	AddToManagerFuncs = []manager.ResourceWatcherNew{}
+}
+
+func Register(config *schedulerconfig.SchedulerConfiguration, watchManager *manager.WatchManager) error {
+	for _, f := range AddToManagerFuncs {
+		if c, err := f(config); err != nil {
+			return err
+		} else {
+			watchManager.AddResourceWatcher(c)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This change adds basic data structure for the vc scheduler. Like VC syncer, the scheduler also needs to 
manage multiple tenant clusters by watching the VC crd. Unlike VC syncer, the scheduler only needs to watch the tenant object states for scheduling, hence many interfaces are simpler. 

We leverage the multicluster controller framework in VC syncer to allow the scheduler to watch multiple tenant apiservers. This change adds the framework code.