### PR TITLE
VC: introduce differ to optimize patroller algorithm

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/conversion/helper.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/helper.go
@@ -79,12 +79,7 @@ func GetVirtualNamespace(nsLister listersv1.NamespaceLister, pNamespace string) 
 	return
 }
 
-func GetVirtualOwner(obj runtime.Object) (cluster, namespace string) {
-	meta, err := meta.Accessor(obj)
-	if err != nil {
-		return "", ""
-	}
-
+func GetVirtualOwner(meta metav1.Object) (cluster, namespace string) {
 	cluster = meta.GetAnnotations()[constants.LabelCluster]
 	namespace = meta.GetAnnotations()[constants.LabelNamespace]
 	return cluster, namespace

--- a/incubator/virtualcluster/pkg/syncer/patrol/differ/differ.go
+++ b/incubator/virtualcluster/pkg/syncer/patrol/differ/differ.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package differ
+
+import (
+	"sync"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type ClusterObject struct {
+	metav1.Object
+	Key          string
+	OwnerCluster string
+}
+
+func (c ClusterObject) GetOwnerCluster() string {
+	return c.OwnerCluster
+}
+
+type Handler interface {
+	OnAdd(obj ClusterObject)
+	OnDelete(obj ClusterObject)
+	OnUpdate(obj1, obj2 ClusterObject)
+}
+
+type Differ interface {
+	Insert(object ...ClusterObject)
+	Has(object ClusterObject) bool
+	Get(key string) ClusterObject
+	Len() int
+	Delete(object ClusterObject)
+	Clear()
+	GetKeys() sets.String
+	// Difference compute the different keys between caller and callee.
+	// receive a handler and execute to keep consistent with caller.
+	Difference(Differ, Handler)
+}
+
+type container struct {
+	mu  sync.Mutex
+	set map[string]ClusterObject
+}
+
+func NewDiffSet(objects ...ClusterObject) Differ {
+	c := &container{
+		set: make(map[string]ClusterObject),
+	}
+	c.Insert(objects...)
+	return c
+}
+
+func (c *container) Get(key string) ClusterObject {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.set[key]
+}
+
+func (c *container) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.set)
+}
+
+func (c *container) Insert(objects ...ClusterObject) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, object := range objects {
+		c.set[object.Key] = object
+	}
+}
+
+func (c *container) Has(object ClusterObject) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, contained := c.set[object.Key]
+	return contained
+}
+
+func (c *container) GetKeys() sets.String {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	s := sets.NewString()
+	for k := range c.set {
+		s.Insert(k)
+	}
+	return s
+}
+
+func (c *container) Delete(object ClusterObject) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.set, object.Key)
+}
+
+func (c *container) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.set = make(map[string]ClusterObject)
+}
+
+func (c *container) Difference(set2 Differ, handler Handler) {
+	keySet1 := c.GetKeys()
+	keySet2 := set2.GetKeys()
+
+	groupedIntersectionSet := make(map[string]sets.String)
+	for k, v := range c.set {
+		if !keySet2.Has(k) {
+			continue
+		}
+		keySet1.Delete(k)
+		keySet2.Delete(k)
+		group := v.OwnerCluster
+		if group == "" {
+			group = set2.Get(k).OwnerCluster
+		}
+		_, exists := groupedIntersectionSet[group]
+		if !exists {
+			groupedIntersectionSet[group] = sets.NewString()
+		}
+		groupedIntersectionSet[group].Insert(k)
+	}
+
+	var wg sync.WaitGroup
+
+	for k := range keySet1 {
+		wg.Add(1)
+		go func(key string) {
+			defer wg.Done()
+			handler.OnAdd(c.Get(key))
+		}(k)
+	}
+
+	// the most possible case, concurrently processing them by cluster group
+	// to avoid tons of go routines.
+	for _, s := range groupedIntersectionSet {
+		wg.Add(1)
+		go func(iset sets.String) {
+			defer wg.Done()
+			for k := range iset {
+				handler.OnUpdate(c.Get(k), set2.Get(k))
+			}
+		}(s)
+	}
+
+	for k := range keySet2 {
+		wg.Add(1)
+		go func(key string) {
+			defer wg.Done()
+			handler.OnDelete(set2.Get(key))
+		}(k)
+	}
+
+	wg.Wait()
+}

--- a/incubator/virtualcluster/pkg/syncer/patrol/differ/differ_test.go
+++ b/incubator/virtualcluster/pkg/syncer/patrol/differ/differ_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package differ
+
+import (
+	"math/rand"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+)
+
+func makeObject(ns, name string) metav1.Object {
+	return &metav1.ObjectMeta{
+		Namespace: ns,
+		Name:      name,
+	}
+}
+
+func TestDifferSet(t *testing.T) {
+	s := NewDiffSet()
+	if s.Len() != 0 {
+		t.Errorf("Expected len=0: %d", s.Len())
+	}
+
+	a := ClusterObject{Key: "n1/a", Object: makeObject("n1", "a")}
+	b := ClusterObject{Key: "n1/b", Object: makeObject("n1", "b")}
+	c := ClusterObject{Key: "n1/c", Object: makeObject("n1", "c")}
+
+	s.Insert(a)
+	if s.Len() != 1 {
+		t.Errorf("Expected len=2: %d", s.Len())
+	}
+	s.Insert(b)
+	if s.Has(c) {
+		t.Errorf("Unexpected contents: %s", c)
+	}
+	if !s.Has(a) {
+		t.Errorf("Missing contents: %s", a)
+	}
+	s.Delete(a)
+	if s.Has(a) {
+		t.Errorf("Unexpected contents: %s", a)
+	}
+	if s.Len() != 1 {
+		t.Errorf("Expected len=1: %d", s.Len())
+	}
+	if !s.GetKeys().Has("n1/b") {
+		t.Errorf("Missing key: %s", "n1/b")
+	}
+	s.Clear()
+	if s.Len() > 0 {
+		t.Errorf("Expected len=0: %d", s.Len())
+	}
+}
+
+func TestDifferSetDifference(t *testing.T) {
+	ta := ClusterObject{Key: "t1-n1/a", OwnerCluster: "t1", Object: makeObject("n1", "a")}
+	a := ClusterObject{Key: "t1-n1/a", Object: makeObject(conversion.ToSuperMasterNamespace("t1", "n1"), "a")}
+	tb := ClusterObject{Key: "t1-n1/b", OwnerCluster: "t1", Object: makeObject("n1", "b")}
+	c := ClusterObject{Key: "t1-n1/c", Object: makeObject(conversion.ToSuperMasterNamespace("t1", "n1"), "c")}
+
+	vSet := NewDiffSet(ta, tb)
+	pSet := NewDiffSet(a, c)
+
+	addCounter := make(map[string]int)
+	updateCounter := make(map[string]int)
+	deleteCounter := make(map[string]int)
+
+	d := HandlerFuncs{
+		AddFunc: func(obj ClusterObject) {
+			addCounter[obj.Key] = addCounter[obj.Key] + 1
+		},
+		UpdateFunc: func(obj1, obj2 ClusterObject) {
+			updateCounter[obj1.Key] = updateCounter[obj1.Key] + 1
+			updateCounter[obj2.Key] = updateCounter[obj1.Key]
+		},
+		DeleteFunc: func(obj ClusterObject) {
+			deleteCounter[obj.Key] = deleteCounter[obj.Key] + 1
+		},
+	}
+
+	vSet.Difference(pSet, d)
+
+	expectedAddCounter := map[string]int{tb.Key: 1}
+	expectedUpdateCounter := map[string]int{ta.Key: 1}
+	expectedDeleteCounter := map[string]int{c.Key: 1}
+
+	if !equality.Semantic.DeepEqual(addCounter, expectedAddCounter) {
+		t.Errorf("Expected addCounter %+v, got %+v", expectedAddCounter, addCounter)
+	}
+	if !equality.Semantic.DeepEqual(updateCounter, expectedUpdateCounter) {
+		t.Errorf("Expected updateCounter %+v, got %+v", expectedUpdateCounter, updateCounter)
+	}
+	if !equality.Semantic.DeepEqual(deleteCounter, expectedDeleteCounter) {
+		t.Errorf("Expected deleteCounter %+v, got %+v", expectedDeleteCounter, deleteCounter)
+	}
+}
+
+func Benchmark_Difference_1000(b *testing.B) {
+	b.ReportAllocs()
+	rand.Seed(time.Now().UnixNano())
+
+	groupNum := 50
+	totalNum := 1000
+
+	pSet := NewDiffSet()
+	for i := 0; i < groupNum; i++ {
+		for j := 0; j < totalNum/groupNum; j++ {
+			cluster := strconv.Itoa(i)
+			obj := makeObject(conversion.ToSuperMasterNamespace(cluster, "n"), strconv.Itoa(j))
+			pSet.Insert(ClusterObject{
+				Object: obj,
+				Key:    DefaultClusterObjectKey(obj, ""),
+			})
+		}
+	}
+
+	vSet := NewDiffSet()
+	for i := 0; i < groupNum; i++ {
+		for j := 0; j < totalNum/groupNum; j++ {
+			obj := makeObject("n", strconv.Itoa(j))
+			cluster := strconv.Itoa(i)
+			vSet.Insert(ClusterObject{
+				Object:       obj,
+				OwnerCluster: cluster,
+				Key:          DefaultClusterObjectKey(obj, cluster),
+			})
+		}
+	}
+
+	counter := make(map[string]int)
+	var mu sync.Mutex
+
+	b.ResetTimer()
+	vSet.Difference(pSet, HandlerFuncs{
+		UpdateFunc: func(obj1, obj2 ClusterObject) {
+			// workload
+			time.Sleep(time.Millisecond)
+			mu.Lock()
+			counter[obj1.Key] += 1
+			mu.Unlock()
+		},
+	})
+	b.StopTimer()
+
+	if len(counter) != totalNum {
+		b.Errorf("expected num=%d, got %d", totalNum, len(counter))
+	}
+	for _, count := range counter {
+		if count != 1 {
+			b.Errorf("count more than 1: %d", count)
+		}
+	}
+}

--- a/incubator/virtualcluster/pkg/syncer/patrol/differ/handler.go
+++ b/incubator/virtualcluster/pkg/syncer/patrol/differ/handler.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package differ
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
+)
+
+// HandlerFuncs is an adaptor to let you easily specify as many or
+// as few of the handle functions as you want while still implementing
+// Handler.
+type HandlerFuncs struct {
+	AddFunc    func(obj ClusterObject)
+	DeleteFunc func(obj ClusterObject)
+	UpdateFunc func(obj1, obj2 ClusterObject)
+}
+
+// OnAdd calls AddFunc if it's not nil.
+func (h HandlerFuncs) OnAdd(obj ClusterObject) {
+	if h.AddFunc != nil {
+		h.AddFunc(obj)
+	}
+}
+
+// OnUpdate calls UpdateFunc if it's not nil.
+func (h HandlerFuncs) OnUpdate(obj1, obj2 ClusterObject) {
+	if h.UpdateFunc != nil {
+		h.UpdateFunc(obj1, obj2)
+	}
+}
+
+// OnDelete calls DeleteFunc if it's not nil.
+func (h HandlerFuncs) OnDelete(obj ClusterObject) {
+	if h.DeleteFunc != nil {
+		h.DeleteFunc(obj)
+	}
+}
+
+// FilteringHandler applies the provided filter to all events coming
+// in. If any object match the filter, will skip this func.
+type FilteringHandler struct {
+	FilterFunc func(obj ClusterObject) bool
+	Handler    Handler
+}
+
+// OnAdd calls the nested handler only if the filter succeeds
+func (h FilteringHandler) OnAdd(obj ClusterObject) {
+	if h.FilterFunc != nil && !h.FilterFunc(obj) {
+		return
+	}
+	h.Handler.OnAdd(obj)
+}
+
+// OnUpdate calls the nested handler only if both match the filter.
+func (h FilteringHandler) OnUpdate(obj1, obj2 ClusterObject) {
+	if h.FilterFunc != nil && (!h.FilterFunc(obj1) || !h.FilterFunc(obj2)) {
+		return
+	}
+	h.Handler.OnUpdate(obj1, obj2)
+}
+
+// OnDelete calls the nested handler only if the filter succeeds
+func (h FilteringHandler) OnDelete(obj ClusterObject) {
+	if h.FilterFunc != nil && !h.FilterFunc(obj) {
+		return
+	}
+	h.Handler.OnDelete(obj)
+}
+
+func DefaultDifferFilter(obj ClusterObject) bool {
+	if obj.OwnerCluster != "" {
+		return true
+	}
+	clusterName, vNamespace := conversion.GetVirtualOwner(obj)
+	if clusterName != "" && vNamespace != "" {
+		return true
+	}
+	return false
+}
+
+func DefaultClusterObjectKey(obj metav1.Object, ownerCluster string) string {
+	var ns = obj.GetNamespace()
+	if ownerCluster != "" {
+		ns = conversion.ToSuperMasterNamespace(ownerCluster, ns)
+	}
+	return fmt.Sprintf("%s%c%s", ns, '/', obj.GetName())
+}

--- a/incubator/virtualcluster/pkg/syncer/resources/configmap/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/configmap/checker.go
@@ -18,11 +18,9 @@ package configmap
 import (
 	"context"
 	"fmt"
-	"sync"
 	"sync/atomic"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -32,6 +30,7 @@ import (
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/metrics"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/patrol/differ"
 )
 
 var numMissMatchedConfigMaps uint64
@@ -55,97 +54,75 @@ func (c *controller) PatrollerDo() {
 		return
 	}
 
-	wg := sync.WaitGroup{}
-	numMissMatchedConfigMaps = 0
-
-	for _, clusterName := range clusterNames {
-		wg.Add(1)
-		go func(clusterName string) {
-			defer wg.Done()
-			c.checkConfigMapsOfTenantCluster(clusterName)
-		}(clusterName)
-	}
-	wg.Wait()
-
 	pConfigMaps, err := c.configMapLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("error listing configmaps from super master informer cache: %v", err)
 		return
 	}
+	pSet := differ.NewDiffSet()
+	for _, pCM := range pConfigMaps {
+		pSet.Insert(differ.ClusterObject{Object: pCM, Key: differ.DefaultClusterObjectKey(pCM, "")})
+	}
 
-	for _, pConfigMap := range pConfigMaps {
-		clusterName, vNamespace := conversion.GetVirtualOwner(pConfigMap)
-		if len(clusterName) == 0 || len(vNamespace) == 0 {
+	vSet := differ.NewDiffSet()
+	for _, cluster := range clusterNames {
+		listObj, err := c.multiClusterConfigMapController.List(cluster)
+		if err != nil {
+			klog.Errorf("error listing configmaps from cluster %s informer cache: %v", cluster, err)
 			continue
 		}
-		shouldDelete := false
-		vConfigMapObj, err := c.multiClusterConfigMapController.Get(clusterName, vNamespace, pConfigMap.Name)
-		if errors.IsNotFound(err) {
-			shouldDelete = true
-		}
-		if err == nil {
-			vConfigMap := vConfigMapObj.(*v1.ConfigMap)
-			if pConfigMap.Annotations[constants.LabelUID] != string(vConfigMap.UID) {
-				shouldDelete = true
-				klog.Warningf("Found pConfigMap %s/%s delegated UID is different from tenant object.", pConfigMap.Namespace, pConfigMap.Name)
-			}
-		}
-
-		if shouldDelete {
-			// vConfigMap not found and pConfigMap still exist, we need to delete pConfigMap manually
-			deleteOptions := &metav1.DeleteOptions{}
-			deleteOptions.Preconditions = metav1.NewUIDPreconditions(string(pConfigMap.UID))
-			if err = c.configMapClient.ConfigMaps(pConfigMap.Namespace).Delete(context.TODO(), pConfigMap.Name, *deleteOptions); err != nil {
-				klog.Errorf("error deleting pConfigMap %v/%v in super master: %v", pConfigMap.Namespace, pConfigMap.Name, err)
-			} else {
-				metrics.CheckerRemedyStats.WithLabelValues("DeletedOrphanSuperMasterConfigMaps").Inc()
-			}
+		cmList := listObj.(*v1.ConfigMapList)
+		for i := range cmList.Items {
+			vSet.Insert(differ.ClusterObject{
+				Object:       &cmList.Items[i],
+				OwnerCluster: cluster,
+				Key:          differ.DefaultClusterObjectKey(&cmList.Items[i], cluster),
+			})
 		}
 	}
 
-	metrics.CheckerMissMatchStats.WithLabelValues("MissMatchedConfigMaps").Set(float64(numMissMatchedConfigMaps))
-}
-
-// checkConfigMapsOfTenantCluster checks to see if configmaps in specific cluster keeps consistency.
-func (c *controller) checkConfigMapsOfTenantCluster(clusterName string) {
-	listObj, err := c.multiClusterConfigMapController.List(clusterName)
-	if err != nil {
-		klog.Errorf("error listing configmaps from cluster %s informer cache: %v", clusterName, err)
-		return
+	configMapDiffer := differ.HandlerFuncs{}
+	configMapDiffer.AddFunc = func(vObj differ.ClusterObject) {
+		if err := c.multiClusterConfigMapController.RequeueObject(vObj.OwnerCluster, vObj.Object); err != nil {
+			klog.Errorf("error requeue vConfigMap %v/%v in cluster %s: %v", vObj.GetNamespace(), vObj.GetName(), vObj.GetOwnerCluster(), err)
+		} else {
+			metrics.CheckerRemedyStats.WithLabelValues("RequeuedTenantConfigMaps").Inc()
+		}
 	}
-	klog.V(4).Infof("check configmaps consistency in cluster %s", clusterName)
-	configMapList := listObj.(*v1.ConfigMapList)
-	for i, vConfigMap := range configMapList.Items {
-		targetNamespace := conversion.ToSuperMasterNamespace(clusterName, vConfigMap.Namespace)
-		pConfigMap, err := c.configMapLister.ConfigMaps(targetNamespace).Get(vConfigMap.Name)
-		if errors.IsNotFound(err) {
-			// pConfigMap not found and vConfigMap still exists, we need to create pConfigMap again
-			if err := c.multiClusterConfigMapController.RequeueObject(clusterName, &configMapList.Items[i]); err != nil {
-				klog.Errorf("error requeue vConfigMap %v/%v in cluster %s: %v", vConfigMap.Namespace, vConfigMap.Name, clusterName, err)
-			} else {
-				metrics.CheckerRemedyStats.WithLabelValues("RequeuedTenantConfigMaps").Inc()
-			}
-			continue
-		}
+	configMapDiffer.UpdateFunc = func(vObj, pObj differ.ClusterObject) {
+		vCM := vObj.Object.(*v1.ConfigMap)
+		pCM := pObj.Object.(*v1.ConfigMap)
 
+		if pCM.Annotations[constants.LabelUID] != string(vCM.UID) {
+			klog.Errorf("Found pConfigMap %s delegated UID is different from tenant object.", pObj.Key)
+			configMapDiffer.OnDelete(pObj)
+			return
+		}
+		spec, err := c.multiClusterConfigMapController.GetSpec(vObj.GetOwnerCluster())
 		if err != nil {
-			klog.Errorf("error getting pConfigMap %s/%s from super master cache: %v", targetNamespace, vConfigMap.Name, err)
-			continue
+			klog.Errorf("fail to get cluster spec : %s", vObj.GetOwnerCluster())
+			return
 		}
-
-		if pConfigMap.Annotations[constants.LabelUID] != string(vConfigMap.UID) {
-			klog.Errorf("Found pConfigMap %s/%s delegated UID is different from tenant object.", targetNamespace, pConfigMap.Name)
-			continue
-		}
-		spec, err := c.multiClusterConfigMapController.GetSpec(clusterName)
-		if err != nil {
-			klog.Errorf("fail to get cluster spec : %s", clusterName)
-			continue
-		}
-		updated := conversion.Equality(c.config, spec).CheckConfigMapEquality(pConfigMap, &vConfigMap)
+		updated := conversion.Equality(c.config, spec).CheckConfigMapEquality(pCM, vCM)
 		if updated != nil {
 			atomic.AddUint64(&numMissMatchedConfigMaps, 1)
-			klog.Warningf("ConfigMap %v/%v diff in super&tenant master", vConfigMap.Namespace, vConfigMap.Name)
+			klog.Warningf("ConfigMap %s diff in super&tenant master", pObj.Key)
 		}
 	}
+	configMapDiffer.DeleteFunc = func(pObj differ.ClusterObject) {
+		deleteOptions := &metav1.DeleteOptions{}
+		deleteOptions.Preconditions = metav1.NewUIDPreconditions(string(pObj.GetUID()))
+		if err = c.configMapClient.ConfigMaps(pObj.GetNamespace()).Delete(context.TODO(), pObj.GetName(), *deleteOptions); err != nil {
+			klog.Errorf("error deleting pConfigMap %s in super master: %v", pObj.Key, err)
+		} else {
+			metrics.CheckerRemedyStats.WithLabelValues("DeletedOrphanSuperMasterConfigMaps").Inc()
+		}
+	}
+
+	vSet.Difference(pSet, differ.FilteringHandler{
+		Handler:    configMapDiffer,
+		FilterFunc: differ.DefaultDifferFilter,
+	})
+
+	metrics.CheckerMissMatchStats.WithLabelValues("MissMatchedConfigMaps").Set(float64(numMissMatchedConfigMaps))
 }


### PR DESCRIPTION
1. refactor: using differ in configmap checker
2. add differ for patroller in better performance
    - compare tenant and super object in O(N+M)
    - reduce temporary memory copy from lister

Signed-off-by: zhuangqh <zhuangqhc@gmail.com>