### PR TITLE
[VC] Add supercluster reconciling loop

### DIFF
--- a/incubator/virtualcluster/experiment/pkg/scheduler/constants/constants.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/constants/constants.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ const (
 	DefaultRequestTimeout = 30 * time.Second
 
 	VirtualClusterWorker = 3
+	SuperClusterWorker   = 3
 )
 
 var SchedulerUserAgent = "scheduler" + version.BriefVersion()

--- a/incubator/virtualcluster/experiment/pkg/scheduler/resource/supercluster/register.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/resource/supercluster/register.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watchers
+
+import (
+	schedulerconfig "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/scheduler/apis/config"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/scheduler/manager"
+)
+
+var AddToManagerFuncs []manager.ResourceWatcherNew
+
+func init() {
+	AddToManagerFuncs = []manager.ResourceWatcherNew{}
+}
+
+func Register(config *schedulerconfig.SchedulerConfiguration, watchManager *manager.WatchManager) error {
+	for _, f := range AddToManagerFuncs {
+		if c, err := f(config); err != nil {
+			return err
+		} else {
+			watchManager.AddResourceWatcher(c)
+		}
+	}
+	return nil
+}

--- a/incubator/virtualcluster/experiment/pkg/scheduler/scheduler.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/scheduler.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -34,9 +34,11 @@ import (
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/scheduler/constants"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/scheduler/manager"
 	//	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/scheduler/reconciler"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/apis/cluster/v1alpha4"
 	superclient "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/client/clientset/versioned"
 	superinformers "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/client/informers/externalversions/cluster/v1alpha4"
 	superLister "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/client/listers/cluster/v1alpha4"
+	superClusterWatchers "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/scheduler/resource/supercluster"
 	virtualClusterWatchers "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/scheduler/resource/virtualcluster"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
 	vcclient "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/client/clientset/versioned"
@@ -46,22 +48,25 @@ import (
 )
 
 type Scheduler struct {
-	config                *schedulerconfig.SchedulerConfiguration
-	metaClusterClient     clientset.Interface
-	recorder              record.EventRecorder
+	config            *schedulerconfig.SchedulerConfiguration
+	metaClusterClient clientset.Interface
+	recorder          record.EventRecorder
+
+	superClusterWatcher *manager.WatchManager
+	superClusterLister  superLister.ClusterLister
+	superClusterSynced  cache.InformerSynced
+	superClusterQueue   workqueue.RateLimitingInterface
+	superClusterWorkers int
+	superClusterLock    sync.Mutex
+	superClusterSet     map[string]mc.ClusterInterface
+
 	virtualClusterWatcher *manager.WatchManager
-
-	superClusterLister superLister.ClusterLister
-	superClusterSynced cache.InformerSynced
-
-	virtualClusterLister virtualClusterLister.VirtualClusterLister
-	virtualClusterSynced cache.InformerSynced
-
+	virtualClusterLister  virtualClusterLister.VirtualClusterLister
+	virtualClusterSynced  cache.InformerSynced
 	virtualClusterQueue   workqueue.RateLimitingInterface
 	virtualClusterWorkers int
-	// virtualClusterSet holds the virtualcluster collection
-	virtualClusterLock sync.Mutex
-	virtualClusterSet  map[string]mc.ClusterInterface
+	virtualClusterLock    sync.Mutex
+	virtualClusterSet     map[string]mc.ClusterInterface
 }
 
 func New(
@@ -81,6 +86,9 @@ func New(
 		virtualClusterQueue:   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virtualcluster"),
 		virtualClusterWorkers: constants.VirtualClusterWorker,
 		virtualClusterSet:     make(map[string]mc.ClusterInterface),
+		superClusterQueue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "supercluster"),
+		superClusterWorkers:   constants.SuperClusterWorker,
+		superClusterSet:       make(map[string]mc.ClusterInterface),
 	}
 
 	// Handle VirtualCluster add&delete
@@ -98,6 +106,24 @@ func New(
 			DeleteFunc: scheduler.enqueueVirtualCluster,
 		},
 	)
+
+	// Handle SuperCluster add&delete
+
+	superInformer.Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: scheduler.enqueueSuperCluster,
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				newSuper := newObj.(*v1alpha4.Cluster)
+				oldSuper := oldObj.(*v1alpha4.Cluster)
+				if newSuper.ResourceVersion == oldSuper.ResourceVersion {
+					return
+				}
+				scheduler.enqueueSuperCluster(newObj)
+			},
+			DeleteFunc: scheduler.enqueueSuperCluster,
+		},
+	)
+
 	scheduler.virtualClusterLister = vcInformer.Lister()
 	scheduler.virtualClusterSynced = vcInformer.Informer().HasSynced
 	scheduler.superClusterLister = superInformer.Lister()
@@ -105,12 +131,15 @@ func New(
 
 	vcWatcher := manager.New()
 	scheduler.virtualClusterWatcher = vcWatcher
-
 	virtualClusterWatchers.Register(config, vcWatcher)
+
+	superWatcher := manager.New()
+	scheduler.superClusterWatcher = superWatcher
+	superClusterWatchers.Register(config, superWatcher)
+
 	return scheduler
 }
 
-// enqueue deleted and running object.
 func (s *Scheduler) enqueueVirtualCluster(obj interface{}) {
 	_, ok := obj.(*v1alpha1.VirtualCluster)
 
@@ -135,6 +164,30 @@ func (s *Scheduler) enqueueVirtualCluster(obj interface{}) {
 	s.virtualClusterQueue.Add(key)
 }
 
+func (s *Scheduler) enqueueSuperCluster(obj interface{}) {
+	_, ok := obj.(*v1alpha4.Cluster)
+
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %+v", obj))
+			return
+		}
+		_, ok = tombstone.Obj.(*v1alpha4.Cluster)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a v1alpha4.cluster %+v", obj))
+			return
+		}
+	}
+
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	s.superClusterQueue.Add(key)
+}
+
 func (s *Scheduler) Run(stopChan <-chan struct{}) {
 	go func() {
 		if err := s.virtualClusterWatcher.Start(stopChan); err != nil {
@@ -146,21 +199,42 @@ func (s *Scheduler) Run(stopChan <-chan struct{}) {
 		defer utilruntime.HandleCrash()
 		defer s.virtualClusterQueue.ShutDown()
 
-		klog.Infof("starting Scheduler")
-		defer klog.Infof("shutting down scheduler")
+		klog.Infof("starting scheduler virtualcluster workerqueue")
+		defer klog.Infof("shutting down scheduler virtualcluster workerqueue")
 
 		if !cache.WaitForCacheSync(stopChan, s.virtualClusterSynced) {
 			return
 		}
 
-		if !cache.WaitForCacheSync(stopChan, s.superClusterSynced) {
-			return
-		}
-
-		klog.V(5).Infof("starting scheduler workers")
+		klog.Infof("starting scheduler virtualcluster workers")
 		for i := 0; i < s.virtualClusterWorkers; i++ {
 			go wait.Until(s.virtualClusterWorkerRun, 1*time.Second, stopChan)
 		}
 		<-stopChan
+	}()
+
+	go func() {
+		if err := s.superClusterWatcher.Start(stopChan); err != nil {
+			klog.Infof("supercluster watch manager exits: %v", err)
+		}
+	}()
+
+	go func() {
+		defer utilruntime.HandleCrash()
+		defer s.superClusterQueue.ShutDown()
+
+		klog.Infof("starting scheduler supercluster workerqueue")
+		defer klog.Infof("shutting down scheduler supercluster workerqueue")
+
+		if !cache.WaitForCacheSync(stopChan, s.superClusterSynced) {
+			return
+		}
+
+		klog.Infof("starting scheduler supercluster workers")
+		for i := 0; i < s.superClusterWorkers; i++ {
+			go wait.Until(s.superClusterWorkerRun, 1*time.Second, stopChan)
+		}
+		<-stopChan
+
 	}()
 }


### PR DESCRIPTION
This change adds supercluster reconciling loop. The implementation is very similar to that of virtualcluster reconciling loop.

We probably can avoid some duplicated code by introducing interfaces but the gain is moderate since we only have two types of cluster for now. 

In next change, I will refactor the cluster interface so that it can support both VirtualCluster and Cluster CRDs.