### PR TITLE
[VC] Introduce basic structures (Pod, Namespace, Cluster) for scheduler cache

### DIFF
--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/cluster.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/cluster.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+type Cluster struct {
+	name     string
+	labels   map[string]string
+	capacity v1.ResourceList
+
+	alloc  v1.ResourceList
+	slices map[string][]*Slice            // ns key -> slice array
+	pods   map[string]map[string]struct{} // ns key -> Pod map
+}
+
+func NewCluster(name string, labels map[string]string, capacity v1.ResourceList) *Cluster {
+	alloc := capacity.DeepCopy()
+
+	for k, v := range alloc {
+		v.Set(0)
+		alloc[k] = v
+	}
+
+	return &Cluster{
+		name:     name,
+		labels:   labels,
+		capacity: capacity,
+		alloc:    alloc,
+		slices:   make(map[string][]*Slice),
+		pods:     make(map[string]map[string]struct{}),
+	}
+}
+
+func (c *Cluster) DeepCopy() *Cluster {
+	labelcopy := make(map[string]string)
+	for k, v := range c.labels {
+		labelcopy[k] = v
+	}
+
+	out := NewCluster(c.name, c.labels, c.capacity.DeepCopy())
+
+	slicesCopy := make(map[string][]*Slice)
+
+	for k, v := range c.slices {
+		s := make([]*Slice, 0, len(v))
+		for _, each := range v {
+			s = append(s, each.DeepCopy())
+		}
+		slicesCopy[k] = s
+	}
+
+	podsCopy := make(map[string]map[string]struct{})
+	for k, v := range c.pods {
+		podsCopy[k] = make(map[string]struct{})
+		for name, _ := range v {
+			podsCopy[k][name] = struct{}{}
+		}
+	}
+	out.slices = slicesCopy
+	out.pods = podsCopy
+	out.alloc = c.alloc.DeepCopy()
+	return out
+}
+
+func (c *Cluster) AddNamespace(key string, slices []*Slice) error {
+	if _, ok := c.slices[key]; ok {
+		return fmt.Errorf("namespace key %s is already in cluster %s, cannot add twice", key, c.name)
+	}
+	allocCopy := c.alloc.DeepCopy()
+	for _, s := range slices {
+		if s.cluster != c.name {
+			return fmt.Errorf("slice %s is placed in cluster %s, not %s", s.owner, s.cluster, c.name)
+		}
+		for k, v := range s.size {
+			each, ok := allocCopy[k]
+			if !ok {
+				return fmt.Errorf("slice %s has quota %s which is not in known cluster %s's allocable resources", s.owner, k, c.name)
+			}
+			each.Add(v)
+			var upper resource.Quantity
+			upper, ok = c.capacity[k]
+			if !ok {
+				return fmt.Errorf("slice %s has quota %s which is not in known cluster %s's capacity resources", s.owner, k, c.name)
+			}
+
+			if upper.Cmp(each) == -1 {
+				return fmt.Errorf("cluster %s's resource %s allocation is > capacity after adding %s's slices ", c.name, k, key)
+			}
+			allocCopy[k] = each
+		}
+	}
+	// apply changes only when no errors
+	c.alloc = allocCopy
+	c.slices[key] = slices
+	return nil
+}
+
+func (c *Cluster) RemoveNamespace(key string) error {
+	slices, ok := c.slices[key]
+	if !ok {
+		return fmt.Errorf("namespace key %s is not in cluster %s, cannot remove twice", key, c.name)
+	}
+	allocCopy := c.alloc.DeepCopy()
+	for _, s := range slices {
+		for k, v := range s.size {
+			each, _ := allocCopy[k]
+			if each.Cmp(v) == -1 {
+				// This usually means the cache is messed up
+				return fmt.Errorf("cluster %s's resource %s allocation is < 0 after removing %s's slices ", c.name, k, key)
+			}
+			each.Sub(v)
+			allocCopy[k] = each
+		}
+	}
+	c.alloc = allocCopy
+	delete(c.slices, key)
+	return nil
+}
+
+func (c *Cluster) AddPod(pod *Pod) error {
+	key := pod.GetNamespaceKey()
+	if pod.cluster != c.name {
+		return fmt.Errorf("%s's Pod %s should not be placed in cluster %v (scheduled to %v) ", pod.GetNamespaceKey(), pod.name, c.name, pod.cluster)
+	}
+	if _, ok := c.pods[key]; !ok {
+		c.pods[key] = make(map[string]struct{})
+	}
+	c.pods[key][pod.name] = struct{}{}
+	return nil
+}
+
+func (c *Cluster) RemovePod(pod *Pod) {
+	key := pod.GetNamespaceKey()
+	delete(c.pods[key], pod.name)
+	if len(c.pods[key]) == 0 {
+		delete(c.pods, key)
+	}
+}

--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/cluster_test.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/cluster_test.go
@@ -1,0 +1,283 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+const (
+	defaultNamespace = "testnamespace"
+	defaultCluster   = "testcluster"
+)
+
+func Equals(a v1.ResourceList, b v1.ResourceList) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for key, value1 := range a {
+		value2, found := b[key]
+		if !found {
+			return false
+		}
+		if value1.Cmp(value2) != 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
+func TestAddNamespace(t *testing.T) {
+	defaultCapacity := v1.ResourceList{
+		"cpu":    resource.MustParse("2000M"),
+		"memory": resource.MustParse("4Gi"),
+	}
+
+	defaultQuotaSlice := v1.ResourceList{
+		"cpu":    resource.MustParse("500M"),
+		"memory": resource.MustParse("1Gi"),
+	}
+
+	overMemQuotaSlice := v1.ResourceList{
+		"cpu":    resource.MustParse("400M"),
+		"memory": resource.MustParse("5Gi"),
+	}
+
+	overCpuQuotaSlice := v1.ResourceList{
+		"cpu":    resource.MustParse("4000M"),
+		"memory": resource.MustParse("3Gi"),
+	}
+
+	testcases := map[string]struct {
+		cluster    *Cluster
+		slices     []*Slice
+		allocAfter v1.ResourceList
+		succeed    bool
+	}{
+		"Succeed to add one slice": {
+			cluster: NewCluster(defaultCluster, nil, defaultCapacity),
+			slices: []*Slice{
+				NewSlice(defaultNamespace, defaultQuotaSlice, defaultCluster),
+			},
+			allocAfter: v1.ResourceList{
+				"cpu":    resource.MustParse("500M"),
+				"memory": resource.MustParse("1Gi"),
+			},
+			succeed: true,
+		},
+
+		"Succeed to add two slices": {
+			cluster: NewCluster(defaultCluster, nil, defaultCapacity),
+			slices: []*Slice{
+				NewSlice(defaultNamespace, defaultQuotaSlice, defaultCluster),
+				NewSlice(defaultNamespace, defaultQuotaSlice, defaultCluster),
+			},
+			allocAfter: v1.ResourceList{
+				"cpu":    resource.MustParse("1000M"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			succeed: true,
+		},
+
+		"Fail to due to exceeding cluster memory capacity": {
+			cluster: NewCluster(defaultCluster, nil, defaultCapacity),
+			slices: []*Slice{
+				NewSlice(defaultNamespace, overMemQuotaSlice, defaultCluster),
+			},
+			allocAfter: v1.ResourceList{
+				"cpu":    resource.MustParse("0M"),
+				"memory": resource.MustParse("0Gi"),
+			},
+			succeed: false,
+		},
+
+		"Fail due to exceeding cluster cpu capacity": {
+			cluster: NewCluster(defaultCluster, nil, defaultCapacity),
+			slices: []*Slice{
+				NewSlice(defaultNamespace, overCpuQuotaSlice, defaultCluster),
+			},
+			allocAfter: v1.ResourceList{
+				"cpu":    resource.MustParse("0M"),
+				"memory": resource.MustParse("0Gi"),
+			},
+			succeed: false,
+		},
+
+		"Fail to add due to exceeding capacity with multiple slices": {
+			cluster: NewCluster(defaultCluster, nil, defaultCapacity),
+			slices: []*Slice{
+				NewSlice(defaultNamespace, defaultQuotaSlice, defaultCluster),
+				NewSlice(defaultNamespace, defaultQuotaSlice, defaultCluster),
+				NewSlice(defaultNamespace, defaultQuotaSlice, defaultCluster),
+				NewSlice(defaultNamespace, defaultQuotaSlice, defaultCluster),
+				NewSlice(defaultNamespace, defaultQuotaSlice, defaultCluster),
+			},
+			allocAfter: v1.ResourceList{
+				"cpu":    resource.MustParse("0M"),
+				"memory": resource.MustParse("0Gi"),
+			},
+			succeed: false,
+		},
+	}
+
+	for k, tc := range testcases {
+		t.Run(k, func(t *testing.T) {
+			err := tc.cluster.AddNamespace(defaultNamespace, tc.slices)
+			if tc.succeed && err != nil {
+				t.Errorf("test %s should succeed but fails with err %v", k, err)
+			}
+
+			if !tc.succeed && err == nil {
+				t.Errorf("test %s should fail but succeeds", k)
+			}
+
+			if !Equals(tc.allocAfter, tc.cluster.alloc) {
+				t.Errorf("the alloc is not expected. Exp: %v, Got %v", tc.allocAfter, tc.cluster.alloc)
+			}
+		})
+
+	}
+
+}
+
+func TestRemoveNamespace(t *testing.T) {
+	defaultCapacity := v1.ResourceList{
+		"cpu":    resource.MustParse("2000M"),
+		"memory": resource.MustParse("4Gi"),
+	}
+
+	defaultQuotaSlice := v1.ResourceList{
+		"cpu":    resource.MustParse("500M"),
+		"memory": resource.MustParse("1Gi"),
+	}
+
+	defaultAlloc := v1.ResourceList{
+		"cpu":    resource.MustParse("1000M"),
+		"memory": resource.MustParse("2Gi"),
+	}
+
+	testcases := map[string]struct {
+		cluster    *Cluster
+		curSlices  []*Slice
+		curAlloc   v1.ResourceList
+		allocAfter v1.ResourceList
+		succeed    bool
+	}{
+		"Succeed to remove one slice": {
+			cluster: NewCluster(defaultCluster, nil, defaultCapacity),
+			curSlices: []*Slice{
+				NewSlice(defaultNamespace, defaultQuotaSlice, defaultCluster),
+			},
+			curAlloc: defaultAlloc,
+			allocAfter: v1.ResourceList{
+				"cpu":    resource.MustParse("500M"),
+				"memory": resource.MustParse("1Gi"),
+			},
+			succeed: true,
+		},
+
+		"Succeed to remove two slices": {
+			cluster: NewCluster(defaultCluster, nil, defaultCapacity),
+			curSlices: []*Slice{
+				NewSlice(defaultNamespace, defaultQuotaSlice, defaultCluster),
+				NewSlice(defaultNamespace, defaultQuotaSlice, defaultCluster),
+			},
+			curAlloc: defaultAlloc,
+			allocAfter: v1.ResourceList{
+				"cpu":    resource.MustParse("0M"),
+				"memory": resource.MustParse("0Gi"),
+			},
+			succeed: true,
+		},
+
+		"Fail due to cache mess up": {
+			cluster: NewCluster(defaultCluster, nil, defaultCapacity),
+			curSlices: []*Slice{
+				NewSlice(defaultNamespace, defaultQuotaSlice, defaultCluster),
+				NewSlice(defaultNamespace, defaultQuotaSlice, defaultCluster),
+				NewSlice(defaultNamespace, defaultQuotaSlice, defaultCluster),
+			},
+			curAlloc:   defaultAlloc,
+			allocAfter: defaultAlloc,
+			succeed:    false,
+		},
+	}
+
+	for k, tc := range testcases {
+		t.Run(k, func(t *testing.T) {
+			tc.cluster.alloc = tc.curAlloc
+			for _, each := range tc.curSlices {
+				tc.cluster.slices[defaultNamespace] = append(tc.cluster.slices[defaultNamespace], each)
+			}
+
+			err := tc.cluster.RemoveNamespace(defaultNamespace)
+			if tc.succeed && err != nil {
+				t.Errorf("test %s should succeed but fails with err %v", k, err)
+			}
+
+			if !tc.succeed && err == nil {
+				t.Errorf("test %s should fail but succeeds", k)
+			}
+
+			if !Equals(tc.allocAfter, tc.cluster.alloc) {
+				t.Errorf("the alloc is not expected. Exp: %v, Got %v", tc.allocAfter, tc.cluster.alloc)
+			}
+		})
+
+	}
+
+}
+
+func TestDeepCopy(t *testing.T) {
+	defaultCapacity := v1.ResourceList{
+		"cpu":    resource.MustParse("2000M"),
+		"memory": resource.MustParse("4Gi"),
+	}
+	defaultRequest := v1.ResourceList{
+		"cpu":    resource.MustParse("1000M"),
+		"memory": resource.MustParse("2Gi"),
+	}
+	defaultQuotaSlice := v1.ResourceList{
+		"cpu":    resource.MustParse("500M"),
+		"memory": resource.MustParse("1Gi"),
+	}
+
+	cluster := NewCluster(defaultCluster, nil, defaultCapacity)
+	pod := NewPod("tenant", defaultNamespace, "pod-1", "123456", defaultCluster, defaultRequest)
+
+	cluster.AddPod(pod)
+	slices := []*Slice{NewSlice(defaultNamespace, defaultQuotaSlice, defaultCluster)}
+	cluster.AddNamespace(defaultNamespace, slices)
+	clone := cluster.DeepCopy()
+
+	if clone.name != cluster.name ||
+		!equality.Semantic.DeepEqual(clone.capacity, cluster.capacity) ||
+		!equality.Semantic.DeepEqual(clone.alloc, cluster.alloc) ||
+		clone.slices[defaultNamespace][0].owner != cluster.slices[defaultNamespace][0].owner ||
+		!equality.Semantic.DeepEqual(clone.slices[defaultNamespace][0].size, cluster.slices[defaultNamespace][0].size) ||
+		clone.slices[defaultNamespace][0].cluster != cluster.slices[defaultNamespace][0].cluster ||
+		!equality.Semantic.DeepEqual(clone.pods[pod.GetNamespaceKey()], cluster.pods[pod.GetNamespaceKey()]) {
+		t.Errorf("deepcopy fails %v %v", clone.alloc, cluster.alloc)
+	}
+}

--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/namespace.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/namespace.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"fmt"
+	"math"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+type Placement struct {
+	cluster string
+	num     int
+}
+
+func NewPlacement(cluster string, num int) *Placement {
+	return &Placement{
+		cluster: cluster,
+		num:     num,
+	}
+}
+
+type Namespace struct {
+	owner  string //tenant cluster name
+	name   string
+	labels map[string]string
+
+	quota      v1.ResourceList
+	quotaSlice v1.ResourceList
+
+	schedule []*Placement
+}
+
+type Slice struct {
+	owner   string // namespace key
+	size    v1.ResourceList
+	cluster string
+}
+
+func NewSlice(owner string, size v1.ResourceList, cluster string) *Slice {
+	return &Slice{
+		owner:   owner,
+		size:    size,
+		cluster: cluster,
+	}
+}
+
+func (s Slice) DeepCopy() *Slice {
+	return NewSlice(s.owner, s.size.DeepCopy(), s.cluster)
+}
+
+func NewNamespace(owner, name string, labels map[string]string, quota, quotaSlice v1.ResourceList, schedule []*Placement) *Namespace {
+	return &Namespace{
+		owner:      owner,
+		name:       name,
+		labels:     labels,
+		quota:      quota,
+		quotaSlice: quotaSlice,
+		schedule:   schedule,
+	}
+}
+
+func (n *Namespace) DeepCopy() *Namespace {
+	schedCopy := make([]*Placement, 0, len(n.schedule))
+	for _, each := range n.schedule {
+		schedCopy = append(schedCopy, NewPlacement(each.cluster, each.num))
+	}
+	labelCopy := make(map[string]string)
+	for k, v := range n.labels {
+		labelCopy[k] = v
+	}
+	return NewNamespace(n.owner, n.name, labelCopy, n.quota.DeepCopy(), n.quotaSlice.DeepCopy(), schedCopy)
+
+}
+
+func (n *Namespace) GetKey() string {
+	return fmt.Sprintf("%s/%s", n.owner, n.name)
+}
+
+func GetNumSlices(quota, quotaSlice v1.ResourceList) (int, error) {
+	more := make(map[v1.ResourceName]struct{})
+	for k, _ := range quota {
+		more[k] = struct{}{}
+	}
+	num := 0
+	for k, v := range quotaSlice {
+		q, ok := quota[k]
+
+		if !ok {
+			return 0, fmt.Errorf("quota slice resouce %v is missing from quota", k)
+		}
+		if v.Value() == 0 {
+			return 0, fmt.Errorf("quota slice resource %v has value of 0", k)
+		}
+		delete(more, k)
+		if q.Cmp(v) == -1 {
+			return 0, fmt.Errorf("quota slice is larger than quota for resource %v", k)
+		}
+		n := math.Ceil(float64(q.Value()) / float64(v.Value()))
+		if n > float64(num) {
+			num = int(n)
+		}
+	}
+	if len(more) != 0 {
+		return 0, fmt.Errorf("quota slice has missing resouces %v", more)
+	}
+	return num, nil
+}

--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/namespace_test.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/namespace_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestGetNumSlices(t *testing.T) {
+
+	testcases := map[string]struct {
+		quota      v1.ResourceList
+		quotaSlice v1.ResourceList
+		expect     int
+		succeed    bool
+	}{
+		"Succeed with scale": {
+			quota: v1.ResourceList{
+				"cpu":    resource.MustParse("1000M"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			quotaSlice: v1.ResourceList{
+				"cpu":    resource.MustParse("500M"),
+				"memory": resource.MustParse("1Gi"),
+			},
+			expect:  2,
+			succeed: true,
+		},
+
+		"Succeed with memory fragmentation": {
+			quota: v1.ResourceList{
+				"cpu":    resource.MustParse("1000M"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			quotaSlice: v1.ResourceList{
+				"cpu":    resource.MustParse("10M"),
+				"memory": resource.MustParse("1Gi"),
+			},
+			expect:  100,
+			succeed: true,
+		},
+
+		"Succeed with cpu fragmentation": {
+			quota: v1.ResourceList{
+				"cpu":    resource.MustParse("1000M"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			quotaSlice: v1.ResourceList{
+				"cpu":    resource.MustParse("200M"),
+				"memory": resource.MustParse("50Mi"),
+			},
+			expect:  41,
+			succeed: true,
+		},
+
+		"Succeed with both fragmentations": {
+			quota: v1.ResourceList{
+				"cpu":    resource.MustParse("1000M"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			quotaSlice: v1.ResourceList{
+				"cpu":    resource.MustParse("800M"),
+				"memory": resource.MustParse("800Mi"),
+			},
+			expect:  3,
+			succeed: true,
+		},
+
+		"Fail with big slice": {
+			quota: v1.ResourceList{
+				"cpu":    resource.MustParse("1000M"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			quotaSlice: v1.ResourceList{
+				"cpu":    resource.MustParse("8000M"),
+				"memory": resource.MustParse("800Mi"),
+			},
+			expect:  0,
+			succeed: false,
+		},
+
+		"Fail with missing resource in slice": {
+			quota: v1.ResourceList{
+				"cpu":    resource.MustParse("1000M"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			quotaSlice: v1.ResourceList{
+				"cpu": resource.MustParse("8000M"),
+			},
+			expect:  0,
+			succeed: false,
+		},
+
+		"Fail with more resource in slice": {
+			quota: v1.ResourceList{
+				"cpu":    resource.MustParse("1000M"),
+				"memory": resource.MustParse("2Gi"),
+			},
+			quotaSlice: v1.ResourceList{
+				"cpu":     resource.MustParse("8000M"),
+				"memory":  resource.MustParse("800Mi"),
+				"storage": resource.MustParse("1Gi"),
+			},
+			expect:  0,
+			succeed: false,
+		},
+	}
+
+	for k, tc := range testcases {
+		t.Run(k, func(t *testing.T) {
+			num, err := GetNumSlices(tc.quota, tc.quotaSlice)
+			if tc.succeed && err != nil {
+				t.Errorf("test %s should succeed but fails with err %v", k, err)
+			}
+
+			if !tc.succeed && err == nil {
+				t.Errorf("test %s should fail but succeeds", k)
+			}
+
+			if num != tc.expect {
+				t.Errorf("The num is not expected. Exp: %v, Got %v", tc.expect, num)
+			}
+
+		})
+	}
+
+}

--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/pod.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/pod.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+type Pod struct {
+	owner     string //tenant cluster name
+	namespace string
+	name      string
+	uid       string
+
+	request v1.ResourceList
+
+	cluster string // the scheduled cluster
+}
+
+func NewPod(owner, namespace, name, uid, cluster string, request v1.ResourceList) *Pod {
+	return &Pod{
+		owner:     owner,
+		namespace: namespace,
+		name:      name,
+		uid:       uid,
+		request:   request,
+		cluster:   cluster,
+	}
+}
+
+func (p *Pod) DeepCopy() *Pod {
+	return NewPod(p.owner, p.namespace, p.name, p.uid, p.cluster, p.request.DeepCopy())
+}
+
+func (p *Pod) GetNamespaceKey() string {
+	return fmt.Sprintf("%s/%s", p.owner, p.namespace)
+}
+
+func (p *Pod) GetKey() string {
+	return fmt.Sprintf("%s/%s", p.GetNamespaceKey(), p.uid)
+}


### PR DESCRIPTION
This change introduces basic structures in scheduler cache. They are Pod, Namespace and Cluster.

The basic model is that a namespace quota is divided into multiple slices based on the quota slice size. The slices are assigned to different clusters. A Pod is assigned to a cluster based on the quota slices distribution of the corresponding namespace.  The cluster object will track the overall slice allocation.

All objects will be protected by a cache lock which will be introduced in future change hence we don't have per object lock.