### PR TITLE
[VC] Introduce SchedulerCache

### DIFF
--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/cache.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/cache.go
@@ -1,0 +1,270 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"fmt"
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
+)
+
+var _ Cache = &schedulerCache{}
+
+type schedulerCache struct {
+	stop <-chan struct{}
+
+	mu sync.RWMutex
+
+	clusters   map[string]*Cluster
+	pods       map[string]*Pod
+	namespaces map[string]*Namespace
+}
+
+func NewSchedulerCache(stop <-chan struct{}) *schedulerCache {
+	return &schedulerCache{
+		stop:       stop,
+		clusters:   make(map[string]*Cluster),
+		pods:       make(map[string]*Pod),
+		namespaces: make(map[string]*Namespace),
+	}
+
+}
+
+func (c *schedulerCache) addPod(pod *Pod) error {
+	cluster, ok := c.clusters[pod.cluster]
+	if !ok {
+		return fmt.Errorf("fail to add pod %s because cluster %s is not in the cache", pod.GetKey(), pod.cluster)
+	}
+	return cluster.AddPod(pod)
+}
+
+func (c *schedulerCache) AddPod(pod *Pod) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	clone := pod.DeepCopy()
+	key := clone.GetKey()
+	curState, ok := c.pods[key]
+	switch {
+	case ok:
+		if curState.cluster != clone.cluster {
+			// Pod scheduling result is changed
+			klog.Warningf("pod %s was added to cluster %s, but is adding to %s now", key, curState.cluster, clone.cluster)
+
+			if err := c.removePod(curState); err != nil {
+				return fmt.Errorf("fail to remove Pod %s with error %v", key, err)
+			}
+			if err := c.addPod(clone); err != nil {
+				return fmt.Errorf("fail to add pod %s with error %v", key, err)
+			}
+		}
+		c.pods[key] = clone
+	case !ok:
+		if err := c.addPod(clone); err != nil {
+			return fmt.Errorf("fail to add pod %s with error %v", key, err)
+		}
+		c.pods[key] = clone
+	default:
+		return fmt.Errorf("pod %v was already added", key)
+	}
+	return nil
+}
+
+func (c *schedulerCache) removePod(pod *Pod) error {
+	cluster, ok := c.clusters[pod.cluster]
+	if !ok {
+		return fmt.Errorf("fail to remove pod %s because cluster %s is not in the cache", pod.GetKey(), pod.cluster)
+	}
+	cluster.RemovePod(pod)
+	return nil
+}
+
+func (c *schedulerCache) RemovePod(pod *Pod) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	key := pod.GetKey()
+
+	curState, ok := c.pods[key]
+	switch {
+	case ok:
+		if curState.cluster != pod.cluster {
+			klog.Warningf("pod %s was added to cluster %s, but is adding to %s now, the cache is inconsistent", key, curState.cluster, pod.cluster)
+		}
+		if err := c.removePod(pod); err != nil {
+			return fmt.Errorf("fail to remove pod %s with error %v", key, err)
+		}
+		delete(c.pods, key)
+	default:
+		return fmt.Errorf("pod %v was already deleted", key)
+
+	}
+	return nil
+
+}
+
+func (c *schedulerCache) addNamespaceToCluster(cluster, key string, num int, slice v1.ResourceList) error {
+	if num == 0 {
+		return nil
+	}
+	clusterState, ok := c.clusters[cluster]
+	if !ok {
+		return fmt.Errorf("namespace %s has a placement to a cluster %s that does not exist", key, cluster)
+	}
+	var slices []*Slice
+	for i := 0; i < num; i++ {
+		slices = append(slices, NewSlice(key, slice, cluster))
+	}
+	return clusterState.AddNamespace(key, slices)
+}
+
+func (c *schedulerCache) AddNamespace(namespace *Namespace) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.addNamespaceWithoutLock(namespace)
+}
+
+func (c *schedulerCache) addNamespaceWithoutLock(namespace *Namespace) error {
+	clone := namespace.DeepCopy()
+	key := clone.GetKey()
+	if _, ok := c.namespaces[key]; ok {
+		// Namespace update cannot be done in this method.
+		return fmt.Errorf("namespace %s was added to cache", key)
+	}
+	var err error
+	var expect int
+	expect, err = GetNumSlices(clone.quota, clone.quotaSlice)
+	if err != nil {
+		return fmt.Errorf("fail to get the number of slices for namespace %s", key)
+	}
+
+	sched := 0
+	for _, each := range clone.schedule {
+		sched = sched + each.num
+	}
+	if expect != sched {
+		return fmt.Errorf("namespace %s has %d slices, but only %d have been scheduled, it cannot be added to cache", key, expect, sched)
+	}
+	i := -1
+
+	for _, each := range clone.schedule {
+		err = c.addNamespaceToCluster(each.cluster, key, each.num, clone.quotaSlice)
+		if err != nil {
+			break
+		}
+		i++
+	}
+	// We need to rollback if any error happens.
+	if err != nil {
+		for ; i > -1; i-- {
+			// We don't expect any error here.
+			c.removeNamespaceFromCluster(clone.schedule[i].cluster, key)
+		}
+	} else {
+		c.namespaces[key] = clone
+	}
+	return err
+}
+
+func (c *schedulerCache) removeNamespaceFromCluster(cluster, key string) error {
+	clusterState, ok := c.clusters[cluster]
+	if !ok {
+		return fmt.Errorf("namespace %s has a placement to a cluster %s that does not exist", key, cluster)
+	}
+	return clusterState.RemoveNamespace(key)
+}
+
+func (c *schedulerCache) RemoveNamespace(namespace *Namespace) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.removeNamespaceWithoutLock(namespace)
+}
+
+func (c *schedulerCache) removeNamespaceWithoutLock(namespace *Namespace) error {
+	key := namespace.GetKey()
+	if _, ok := c.namespaces[key]; !ok {
+		return fmt.Errorf("namespace %s has been removed from the cache", key)
+	}
+	var err error
+	i := -1
+	for _, each := range namespace.schedule {
+		err = c.removeNamespaceFromCluster(each.cluster, key)
+		if err != nil {
+			break
+		}
+		i++
+	}
+
+	// Rollback if any error happens.
+	if err != nil {
+		for ; i > -1; i-- {
+			c.addNamespaceToCluster(namespace.schedule[i].cluster, key, namespace.schedule[i].num, namespace.quotaSlice)
+		}
+	} else {
+		delete(c.namespaces, key)
+	}
+
+	return err
+}
+
+// UpdateNamespace handles changing namespace scheduling result.
+// TODO: We need more detailed namespace update methods such as updating labels only.
+func (c *schedulerCache) UpdateNamespace(oldNamespace, newNamespace *Namespace) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var err error
+	if oldNamespace.GetKey() != newNamespace.GetKey() {
+		return fmt.Errorf("cannot update namespaces with different keys.")
+	}
+
+	err = c.removeNamespaceWithoutLock(oldNamespace)
+	if err != nil {
+		return err
+	}
+
+	err = c.addNamespaceWithoutLock(newNamespace)
+	if err != nil {
+		c.addNamespaceWithoutLock(oldNamespace)
+		return err
+	}
+	return nil
+}
+
+func (c *schedulerCache) AddCluster(cluster *Cluster) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if _, ok := c.clusters[cluster.name]; ok {
+		return fmt.Errorf("cluster %s was added to cache", cluster.name)
+	}
+	clone := cluster.DeepCopy()
+	c.clusters[cluster.name] = clone
+	return nil
+}
+
+func (c *schedulerCache) RemoveCluster(cluster *Cluster) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if _, ok := c.clusters[cluster.name]; !ok {
+		return fmt.Errorf("cluster %s was deleted from cache", cluster.name)
+	}
+	delete(c.clusters, cluster.name)
+	return nil
+}
+
+// TODO: Add cluster update methods.

--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/cache_test.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/cache_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	defaultTenant   = "tenant"
+	defaultCluster1 = "testcluster1"
+	defaultCluster2 = "testcluster2"
+)
+
+func TestNamespaceInterfaces(t *testing.T) {
+	defaultCapacity := v1.ResourceList{
+		"cpu":    resource.MustParse("2000M"),
+		"memory": resource.MustParse("4Gi"),
+	}
+
+	fullQuota := v1.ResourceList{
+		"cpu":    resource.MustParse("4000M"),
+		"memory": resource.MustParse("8Gi"),
+	}
+
+	defaultQuota := v1.ResourceList{
+		"cpu":    resource.MustParse("1000M"),
+		"memory": resource.MustParse("2Gi"),
+	}
+
+	defaultQuotaSlice := v1.ResourceList{
+		"cpu":    resource.MustParse("500M"),
+		"memory": resource.MustParse("1Gi"),
+	}
+
+	stop := make(chan struct{})
+	cache := NewSchedulerCache(stop)
+
+	cluster1 := NewCluster(defaultCluster1, nil, defaultCapacity)
+	cluster2 := NewCluster(defaultCluster2, nil, defaultCapacity)
+
+	cache.AddCluster(cluster1)
+	cache.AddCluster(cluster2)
+
+	testcases := map[string]struct {
+		namespace  *Namespace
+		allocAfter map[string]v1.ResourceList
+		succeed    bool
+	}{
+		"Succeed to add one namespace in two clusters": {
+			namespace: NewNamespace(defaultTenant, defaultNamespace, nil, defaultQuota, defaultQuotaSlice,
+				[]*Placement{
+					NewPlacement(defaultCluster1, 1),
+					NewPlacement(defaultCluster2, 1),
+				}),
+			allocAfter: map[string]v1.ResourceList{
+				defaultCluster1: v1.ResourceList{
+					"cpu":    resource.MustParse("500M"),
+					"memory": resource.MustParse("1Gi"),
+				},
+				defaultCluster2: v1.ResourceList{
+					"cpu":    resource.MustParse("500M"),
+					"memory": resource.MustParse("1Gi"),
+				},
+			},
+			succeed: true,
+		},
+
+		"Succeed to add one namespace in one cluster": {
+			namespace: NewNamespace(defaultTenant, defaultNamespace, nil, defaultQuota, defaultQuotaSlice,
+				[]*Placement{
+					NewPlacement(defaultCluster1, 2),
+				}),
+			allocAfter: map[string]v1.ResourceList{
+				defaultCluster1: v1.ResourceList{
+					"cpu":    resource.MustParse("1000M"),
+					"memory": resource.MustParse("2Gi"),
+				},
+				defaultCluster2: v1.ResourceList{
+					"cpu":    resource.MustParse("0M"),
+					"memory": resource.MustParse("0Gi"),
+				},
+			},
+			succeed: true,
+		},
+
+		"Fail to add one namespace due to missing schedule": {
+			namespace: NewNamespace(defaultTenant, defaultNamespace, nil, defaultQuota, defaultQuotaSlice,
+				[]*Placement{
+					NewPlacement(defaultCluster1, 1),
+				}),
+			allocAfter: map[string]v1.ResourceList{
+				defaultCluster1: v1.ResourceList{
+					"cpu":    resource.MustParse("0M"),
+					"memory": resource.MustParse("0Gi"),
+				},
+				defaultCluster2: v1.ResourceList{
+					"cpu":    resource.MustParse("0M"),
+					"memory": resource.MustParse("0Gi"),
+				},
+			},
+			succeed: false,
+		},
+
+		"Fail to add one namespace due to wrong cluster name": {
+			namespace: NewNamespace(defaultTenant, defaultNamespace, nil, defaultQuota, defaultQuotaSlice,
+				[]*Placement{
+					NewPlacement(defaultCluster1, 1),
+					NewPlacement("I am wrong", 1),
+				}),
+			allocAfter: map[string]v1.ResourceList{
+				defaultCluster1: v1.ResourceList{
+					"cpu":    resource.MustParse("0M"),
+					"memory": resource.MustParse("0Gi"),
+				},
+				defaultCluster2: v1.ResourceList{
+					"cpu":    resource.MustParse("0M"),
+					"memory": resource.MustParse("0Gi"),
+				},
+			},
+			succeed: false,
+		},
+
+		"Fail to add one namespace due to wrong schedule": {
+			namespace: NewNamespace(defaultTenant, defaultNamespace, nil, fullQuota, defaultQuotaSlice,
+				[]*Placement{
+					NewPlacement(defaultCluster1, 2),
+					NewPlacement(defaultCluster2, 6),
+				}),
+			allocAfter: map[string]v1.ResourceList{
+				defaultCluster1: v1.ResourceList{
+					"cpu":    resource.MustParse("0M"),
+					"memory": resource.MustParse("0Gi"),
+				},
+				defaultCluster2: v1.ResourceList{
+					"cpu":    resource.MustParse("0M"),
+					"memory": resource.MustParse("0Gi"),
+				},
+			},
+			succeed: false,
+		},
+
+		"Succeeed to add one namespace with full quota": {
+			namespace: NewNamespace(defaultTenant, defaultNamespace, nil, fullQuota, defaultQuotaSlice,
+				[]*Placement{
+					NewPlacement(defaultCluster1, 4),
+					NewPlacement(defaultCluster2, 4),
+				}),
+			allocAfter: map[string]v1.ResourceList{
+				defaultCluster1: v1.ResourceList{
+					"cpu":    resource.MustParse("2000M"),
+					"memory": resource.MustParse("4Gi"),
+				},
+				defaultCluster2: v1.ResourceList{
+					"cpu":    resource.MustParse("2000M"),
+					"memory": resource.MustParse("4Gi"),
+				},
+			},
+			succeed: true,
+		},
+	}
+
+	for k, tc := range testcases {
+		t.Run(k, func(t *testing.T) {
+			err := cache.AddNamespace(tc.namespace)
+			if tc.succeed && err != nil {
+				t.Errorf("test %s should succeed but fails with err %v", k, err)
+			}
+			if !tc.succeed && err == nil {
+				t.Errorf("test %s should fail but succeeds", k)
+			}
+			if !Equals(tc.allocAfter[defaultCluster1], cache.clusters[defaultCluster1].alloc) {
+				t.Errorf("The alloc of cluster 1 is not expected. Exp: %v, Got %v", tc.allocAfter[defaultCluster1], cache.clusters[defaultCluster1].alloc)
+			}
+			if !Equals(tc.allocAfter[defaultCluster2], cache.clusters[defaultCluster2].alloc) {
+				t.Errorf("The alloc of cluster 2 is not expected. Exp: %v, Got %v", tc.allocAfter[defaultCluster2], cache.clusters[defaultCluster2].alloc)
+			}
+			cache.RemoveNamespace(tc.namespace)
+		})
+
+	}
+
+}

--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/cluster_test.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/cluster_test.go
@@ -278,6 +278,6 @@ func TestDeepCopy(t *testing.T) {
 		!equality.Semantic.DeepEqual(clone.slices[defaultNamespace][0].size, cluster.slices[defaultNamespace][0].size) ||
 		clone.slices[defaultNamespace][0].cluster != cluster.slices[defaultNamespace][0].cluster ||
 		!equality.Semantic.DeepEqual(clone.pods[pod.GetNamespaceKey()], cluster.pods[pod.GetNamespaceKey()]) {
-		t.Errorf("deepcopy fails %v %v", clone.alloc, cluster.alloc)
+		t.Errorf("deepcopy fails %v %v", clone, cluster)
 	}
 }

--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/interface.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/interface.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+type Cache interface {
+	AddNamespace(*Namespace) error
+	RemoveNamespace(*Namespace) error
+	AddCluster(*Cluster) error
+	RemoveCluster(*Cluster) error
+	AddPod(*Pod) error
+	RemovePod(*Pod) error
+}


### PR DESCRIPTION
This change adds basic SchedulerCache structure and the common Cache interface. The current interface methods are implemented and more will be added later. 

The add/remove namespace operations are "atomic" when more than one cluster can be involved. This means all changes
are applied or none of them is applied in case any error happens. They will be hooked to controller event handler later.

Among all management operations, the cache updates will be the most tricky ones. More specific update methods will be added in future changes. 