### PR TITLE
Changes detect namespace deletion  into object validator

### DIFF
--- a/incubator/hnc/internal/forest/namespace.go
+++ b/incubator/hnc/internal/forest/namespace.go
@@ -51,10 +51,6 @@ type Namespace struct {
 	// tree label of itself. The key is the tree label without ".tree.hnc.x-k8s.io/depth" suffix.
 	// The value is the depth.
 	ExternalTreeLabels map[string]int
-
-	// IsDeleting is set to true if the namespace has a non-zero deletion timestamp. This allows the
-	// object validators to skip certain checks to allow the objects in a namespace to be emptied out.
-	IsDeleting bool
 }
 
 // Name returns the name of the namespace, of "<none>" if the namespace is nil.

--- a/incubator/hnc/internal/reconcilers/hierarchy_config.go
+++ b/incubator/hnc/internal/reconcilers/hierarchy_config.go
@@ -216,9 +216,6 @@ func (r *HierarchyConfigReconciler) syncWithForest(log logr.Logger, nsInst *core
 	hadCrit := ns.HasLocalCritCondition()
 	ns.ClearConditions()
 
-	// Record whether the namespace is being deleted; this is useful for object validators.
-	ns.IsDeleting = !nsInst.DeletionTimestamp.IsZero()
-
 	// Set external tree labels in the forest if this is an external namespace.
 	r.syncExternalNamespace(log, nsInst, ns)
 
@@ -301,7 +298,7 @@ func (r *HierarchyConfigReconciler) syncSubnamespaceParent(log logr.Logger, inst
 	// We could also add an exception to allow K8s SAs to override the object validator (and we
 	// probably should), but this prevents us from getting into a war with K8s and is sufficient for
 	// v0.5.
-	if pnm != "" && ns.IsDeleting {
+	if pnm != "" && !nsInst.DeletionTimestamp.IsZero() {
 		log.V(1).Info("Subnamespace is being deleted; ignoring SubnamespaceOf annotation", "parent", inst.Spec.Parent, "annotation", pnm)
 		pnm = ""
 	}


### PR DESCRIPTION
This PR changes detect namespace deletion that was done in reconciler 
into object validator by utilizing controller-runtime's client

fixes #1241 
supersede PR #1284 

test:
make test