### PR TITLE
MTB: changed flag input format

### DIFF
--- a/benchmarks/kubectl-mtb/go.sum
+++ b/benchmarks/kubectl-mtb/go.sum
@@ -1528,6 +1528,7 @@ sigs.k8s.io/multi-tenancy v0.0.0-20200731200539-a59bb770c223 h1:3LVSAKupidlml1n/
 sigs.k8s.io/multi-tenancy v0.0.0-20200801023540-26dab8a69fdf h1:dDCjPiT9NuwVCDq2vrolp4NuMXxxmHnTIL33gS+LgzQ=
 sigs.k8s.io/multi-tenancy v0.0.0-20200814013421-cc628b7d4b3c h1:NGsWcOyTy/jqf89Vl8j5naRPZuYmKcu3q6fE8RFCAok=
 sigs.k8s.io/multi-tenancy v0.0.0-20200905025541-6fc00ca178aa h1:wCLGAVyP/UN0hwikjcLWTqktGG9v4NIKk5DTdFdb9WQ=
+sigs.k8s.io/multi-tenancy v0.0.0-20210126064634-548afcdd4f21 h1:p5a4ucmnyajBxLy/ZBN4/gCQ6Ez/8G8CP1ydapqMqj4=
 sigs.k8s.io/multi-tenancy/benchmarks v0.0.0-20200707060558-ea14282f3be6 h1:V4K5fPHAgNnYTFmhKlU4cp03o7/nuZbbVqFnEHvcyHk=
 sigs.k8s.io/multi-tenancy/benchmarks v0.0.0-20200710152148-20515322b4e5 h1:h21E7xB6JQ19Hy5ypObM90L4xScjwiNQxrOACXJ409w=
 sigs.k8s.io/multi-tenancy/benchmarks v0.0.0-20200713220920-829ca66edf83 h1:nmcpLotBZVRnlvDDd3q9b2J9VuW2rfkCRBl+1x/0rfk=
@@ -1538,6 +1539,7 @@ sigs.k8s.io/multi-tenancy/benchmarks v0.0.0-20200731200539-a59bb770c223 h1:fVp4S
 sigs.k8s.io/multi-tenancy/benchmarks v0.0.0-20200801023540-26dab8a69fdf h1:vcFCmxTMwNH1679Jpdb7Wir0mcMJKyzdaDr0q68nhR0=
 sigs.k8s.io/multi-tenancy/benchmarks v0.0.0-20200814013421-cc628b7d4b3c h1:GzAJuIsKlyPwurCLzsQt6loxuFqrbkb2ohhkAabcONk=
 sigs.k8s.io/multi-tenancy/benchmarks v0.0.0-20200905025541-6fc00ca178aa h1:dg/6jbQc1SCtXWxdoT8B1jEzAOUZL+zi2YcK0WHxu2U=
+sigs.k8s.io/multi-tenancy/benchmarks v0.0.0-20210126064634-548afcdd4f21 h1:kmA7eTok+yYxFhRC04LYKAusn7kpGMydLi5ujezN+tw=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0 h1:dOmIZBMfhcHS09XZkMyUgkq5trg3/jRyJYFZUiaOp8E=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=

--- a/benchmarks/kubectl-mtb/internal/kubectl-mtb/run.go
+++ b/benchmarks/kubectl-mtb/internal/kubectl-mtb/run.go
@@ -134,15 +134,15 @@ func validateFlags(cmd *cobra.Command) error {
 	tenantNamespaces, _ := cmd.Flags().GetStringSlice("namespace")
 
 	if len(tenants) < 1 || len(tenantNamespaces) < 1 {
-		return fmt.Errorf("please provide tenant or tenant namespace")
+		return fmt.Errorf("user and namespace required")
 	}
 
 	if len(tenants) != len(tenantNamespaces) {
-		return fmt.Errorf("please provide same number of tenant and tenantNamespaces")
+		return fmt.Errorf("user and namespace counts must be equal")
 	}
 
 	if len(tenants) > 2 || len(tenantNamespaces) > 2 {
-		return fmt.Errorf("support for more than 2 tenants is not available yet")
+		return fmt.Errorf("user and namespace counts cannot exceed 2")
 	}
 
 	benchmarkRunOptions.Tenant = tenants[0]


### PR DESCRIPTION
`kubectl-mtb run -n test1,test --as nody,bob`

Right now hardcoded for 2 tenants but can be made dynamic, will do when we will get that requirement as it will lead to a major change in generic way of writing code of a benchmark.

/assign @JimBugwadia 