### PR TITLE
[VC] Finish reconciling super cluster CR in scheduler

### DIFF
--- a/incubator/virtualcluster/experiment/cmd/scheduler/app/server.go
+++ b/incubator/virtualcluster/experiment/cmd/scheduler/app/server.go
@@ -94,8 +94,9 @@ func Run(cc *schedulerappconfig.CompletedConfig, stopCh <-chan struct{}) error {
 
 	// Start all informers.
 	go cc.VirtualClusterInformer.Informer().Run(stopCh)
-	cc.MetaClusterInformerFactory.Start(stopCh)
+	go cc.SuperClusterInformer.Informer().Run(stopCh)
 
+	cc.MetaClusterInformerFactory.Start(stopCh)
 	// Wait for all caches to sync before resource sync.
 	cc.MetaClusterInformerFactory.WaitForCacheSync(stopCh)
 

--- a/incubator/virtualcluster/experiment/config/crd/cluster.x-k8s.io_clusters.yaml
+++ b/incubator/virtualcluster/experiment/config/crd/cluster.x-k8s.io_clusters.yaml
@@ -1,0 +1,164 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: clusters.cluster.x-k8s.io
+spec:
+  group: cluster.x-k8s.io
+  names:
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    singular: cluster
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            clusterNetwork:
+              properties:
+                apiServerPort:
+                  format: int32
+                  type: integer
+                pods:
+                  properties:
+                    cidrBlocks:
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - cidrBlocks
+                  type: object
+                serviceDomain:
+                  type: string
+                services:
+                  properties:
+                    cidrBlocks:
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - cidrBlocks
+                  type: object
+              type: object
+            controlPlaneEndpoint:
+              properties:
+                host:
+                  type: string
+                port:
+                  format: int32
+                  type: integer
+              required:
+              - host
+              - port
+              type: object
+            controlPlaneRef:
+              properties:
+                apiVersion:
+                  type: string
+                fieldPath:
+                  type: string
+                kind:
+                  type: string
+                name:
+                  type: string
+                namespace:
+                  type: string
+                resourceVersion:
+                  type: string
+                uid:
+                  type: string
+              type: object
+            infrastructureRef:
+              properties:
+                apiVersion:
+                  type: string
+                fieldPath:
+                  type: string
+                kind:
+                  type: string
+                name:
+                  type: string
+                namespace:
+                  type: string
+                resourceVersion:
+                  type: string
+                uid:
+                  type: string
+              type: object
+            paused:
+              type: boolean
+          type: object
+        status:
+          properties:
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  severity:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            controlPlaneInitialized:
+              type: boolean
+            controlPlaneReady:
+              type: boolean
+            failureDomains:
+              additionalProperties:
+                properties:
+                  attributes:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  controlPlane:
+                    type: boolean
+                type: object
+              type: object
+            failureMessage:
+              type: string
+            failureReason:
+              type: string
+            infrastructureReady:
+              type: boolean
+            observedGeneration:
+              format: int64
+              type: integer
+            phase:
+              type: string
+          type: object
+      type: object
+  version: v1alpha4
+  versions:
+  - name: v1alpha4
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/incubator/virtualcluster/experiment/config/setup/all_in_one.yaml
+++ b/incubator/virtualcluster/experiment/config/setup/all_in_one.yaml
@@ -1,0 +1,98 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vc-scheduler
+  namespace: vc-manager
+  labels:
+    app: vc-scheduler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vc-scheduler
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: vc-scheduler
+    spec:
+      serviceAccountName: vc-scheduler
+      containers:
+        - command:
+            - scheduler
+          image: virtualcluster/scheduler-amd64
+          imagePullPolicy: Always
+          name: vc-scheduler
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vc-scheduler-role
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - secrets
+    - configmaps
+  verbs:
+    - get
+    - list
+    - create
+    - update  
+- apiGroups:
+    - ""
+    - storage.k8s.io
+  resources:
+    - events
+  verbs:
+    - create
+    - patch
+- apiGroups:
+    - tenancy.x-k8s.io
+  resources:
+    - virtualclusters
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - tenancy.x-k8s.io
+  resources:
+    - virtualclusters/status
+  verbs:
+    - get
+- apiGroups:
+    - cluster.x-k8s.io
+  resources:
+    - clusters
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - cluster.x-k8s.io
+  resources:
+    - clusters/status
+  verbs:
+    - get
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vc-scheduler-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vc-scheduler-role
+subjects:
+  - kind: ServiceAccount
+    name: vc-scheduler
+    namespace: vc-manager
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vc-scheduler
+  namespace: vc-manager

--- a/incubator/virtualcluster/pkg/syncer/syncer.go
+++ b/incubator/virtualcluster/pkg/syncer/syncer.go
@@ -63,11 +63,6 @@ var (
 	numUnHealthCluster uint64
 )
 
-const (
-	SuperClusterInfoCfgMap = "supercluster-info"
-	SuperClusterIDKey      = "id"
-)
-
 type Syncer struct {
 	config            *config.SyncerConfiguration
 	superClient       v1core.CoreV1Interface
@@ -179,14 +174,14 @@ func (s *Syncer) enqueueVirtualCluster(obj interface{}) {
 func (s *Syncer) Run(stopChan <-chan struct{}) {
 	if featuregate.DefaultFeatureGate.Enabled(featuregate.SuperClusterPooling) {
 		klog.Infof("SuperClusterPooling featuregate is enabled!")
-		cfg, err := s.superClient.ConfigMaps("kube-system").Get(context.TODO(), SuperClusterInfoCfgMap, metav1.GetOptions{})
+		cfg, err := s.superClient.ConfigMaps("kube-system").Get(context.TODO(), utilconst.SuperClusterInfoCfgMap, metav1.GetOptions{})
 		if err != nil {
-			klog.Infof("Fail to get configmap kube-system/%v from super cluster which is required for SuperClusterPooling feature. Quit!", SuperClusterInfoCfgMap)
+			klog.Infof("Fail to get configmap kube-system/%v from super cluster which is required for SuperClusterPooling feature. Quit!", utilconst.SuperClusterInfoCfgMap)
 			os.Exit(1)
 		}
 		var ok bool
-		if utilconst.SuperClusterID, ok = cfg.Data[SuperClusterIDKey]; ok == false {
-			klog.Infof("Fail to get ID value from configmap kube-system/%v. Quit!", SuperClusterInfoCfgMap)
+		if utilconst.SuperClusterID, ok = cfg.Data[utilconst.SuperClusterIDKey]; ok == false {
+			klog.Infof("Fail to get ID value from configmap kube-system/%v. Quit!", utilconst.SuperClusterInfoCfgMap)
 			os.Exit(1)
 		}
 	}

--- a/incubator/virtualcluster/pkg/util/constants/constants.go
+++ b/incubator/virtualcluster/pkg/util/constants/constants.go
@@ -23,6 +23,11 @@ import (
 )
 
 const (
+	SuperClusterInfoCfgMap = "supercluster-info"
+	SuperClusterIDKey      = "id"
+)
+
+const (
 	// LabelScheduledCluster is the super cluster the pod schedules to.
 	LabelScheduledCluster = "scheduler.tenancy.x-k8s.io/superCluster"
 


### PR DESCRIPTION
This change adds the logic to retrieve the kubeconfig of the super cluster so that the scheduler is able to access the super cluster. We assume the kubeconfig is saved in a secret in the super cluster CR's namespace using the CR's name. This is not exactly matching the CAPI recommendation but is consistent with how VC handles the kubeconfig. We may refactor this part later to follow CAPI's convention.

This change also adds the yaml file to deploy the scheduler in vc-manager namespace using a deployment.