### PR TITLE
VC: syncer: start watch cluster event after cache sync

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/syncer.go
+++ b/incubator/virtualcluster/pkg/syncer/syncer.go
@@ -326,7 +326,7 @@ func (s *Syncer) addCluster(key string, vc *v1alpha1.VirtualCluster) error {
 		return fmt.Errorf("failed to new tenant cluster %s/%s: %v", vc.Namespace, vc.Name, err)
 	}
 
-	// for each resource type of the newly added VirtualCluster, we add a listener
+	// for each resource type of the newly added VirtualCluster, we add the object to informer cache.
 	for _, clusterChangeListener := range listener.Listeners {
 		clusterChangeListener.AddCluster(tenantCluster)
 	}
@@ -361,6 +361,12 @@ func (s *Syncer) runCluster(cluster *cluster.Cluster, vc *v1alpha1.VirtualCluste
 		return
 	}
 	cluster.SetSynced()
+	klog.Infof("cluster %s cache sync done", cluster.GetClusterName())
+
+	// start watching cluster resource event after cache sync done.
+	for _, clusterChangeListener := range listener.Listeners {
+		clusterChangeListener.WatchCluster(cluster)
+	}
 }
 
 func (s *Syncer) healthPatrol() {

--- a/incubator/virtualcluster/pkg/syncer/util/test/runDWS.go
+++ b/incubator/virtualcluster/pkg/syncer/util/test/runDWS.go
@@ -129,6 +129,7 @@ func RunDownwardSync(
 
 	// register tenant cluster to controller.
 	resourceSyncer.GetListener().AddCluster(tenantCluster)
+	resourceSyncer.GetListener().WatchCluster(tenantCluster)
 	defer resourceSyncer.GetListener().RemoveCluster(tenantCluster)
 
 	stopCh := make(chan struct{})

--- a/incubator/virtualcluster/pkg/syncer/util/test/runPatrol.go
+++ b/incubator/virtualcluster/pkg/syncer/util/test/runPatrol.go
@@ -147,6 +147,7 @@ func RunPatrol(
 
 	// register tenant cluster to controller.
 	resourceSyncer.GetListener().AddCluster(tenantCluster)
+	resourceSyncer.GetListener().WatchCluster(tenantCluster)
 	defer resourceSyncer.GetListener().RemoveCluster(tenantCluster)
 
 	stopCh := make(chan struct{})

--- a/incubator/virtualcluster/pkg/syncer/util/test/runUWS.go
+++ b/incubator/virtualcluster/pkg/syncer/util/test/runUWS.go
@@ -114,6 +114,7 @@ func RunUpwardSync(
 
 	// register tenant cluster to controller.
 	resourceSyncer.GetListener().AddCluster(tenantCluster)
+	resourceSyncer.GetListener().WatchCluster(tenantCluster)
 	defer resourceSyncer.GetListener().RemoveCluster(tenantCluster)
 
 	stopCh := make(chan struct{})

--- a/incubator/virtualcluster/pkg/util/cluster/cluster.go
+++ b/incubator/virtualcluster/pkg/util/cluster/cluster.go
@@ -268,6 +268,22 @@ func (c *Cluster) AddEventHandler(objectType runtime.Object, handler clientgocac
 	return nil
 }
 
+// GetInformer fetches or constructs an informer for the given object that corresponds to a single
+// API kind and resource.
+func (c *Cluster) GetInformer(objectType runtime.Object) (cache.Informer, error) {
+	ca, err := c.getCache()
+	if err != nil {
+		return nil, err
+	}
+
+	i, err := ca.GetInformer(context.TODO(), objectType)
+	if err != nil {
+		return nil, err
+	}
+
+	return i, nil
+}
+
 // Start starts the Cluster's cache and blocks,
 // until an empty struct is sent to the stop channel.
 func (c *Cluster) Start() error {

--- a/incubator/virtualcluster/pkg/util/cluster/fake_cluster.go
+++ b/incubator/virtualcluster/pkg/util/cluster/fake_cluster.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientset "k8s.io/client-go/kubernetes"
 	clientgocache "k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/apis/tenancy/v1alpha1"
@@ -70,6 +71,10 @@ func (c *fakeCluster) GetDelegatingClient() (client.Client, error) {
 func (c *fakeCluster) AddEventHandler(runtime.Object, clientgocache.ResourceEventHandler) error {
 	// do nothing. we manually enqueue event in test.
 	return nil
+}
+
+func (c *fakeCluster) GetInformer(objectType runtime.Object) (cache.Informer, error) {
+	return nil, nil
 }
 
 func (c *fakeCluster) Start() error {

--- a/incubator/virtualcluster/pkg/util/listener/adapter.go
+++ b/incubator/virtualcluster/pkg/util/listener/adapter.go
@@ -33,14 +33,22 @@ func NewMCControllerListener(c *mc.MultiClusterController) ClusterChangeListener
 }
 
 func (m MCControllerListener) AddCluster(cluster mc.ClusterInterface) {
-	klog.Infof("%s watch cluster %s for %s resource", m.c.GetControllerName(), cluster.GetClusterName(), m.c.GetObjectKind())
-	err := m.c.WatchClusterResource(cluster, mc.WatchOptions{})
+	klog.Infof("%s add cluster %s for %s resource", m.c.GetControllerName(), cluster.GetClusterName(), m.c.GetObjectKind())
+	err := m.c.RegisterClusterResource(cluster, mc.WatchOptions{})
 	if err != nil {
-		klog.Errorf("failed to watch cluster %s %s event: %v", cluster.GetClusterName(), m.c.GetObjectKind(), err)
+		klog.Errorf("failed to add cluster %s %s event: %v", cluster.GetClusterName(), m.c.GetObjectKind(), err)
 	}
 }
 
 func (m MCControllerListener) RemoveCluster(cluster mc.ClusterInterface) {
 	klog.Infof("%s stop watching cluster %s for %s resource", m.c.GetControllerName(), cluster.GetClusterName(), m.c.GetObjectKind())
 	m.c.TeardownClusterResource(cluster)
+}
+
+func (m MCControllerListener) WatchCluster(cluster mc.ClusterInterface) {
+	klog.Infof("%s watch cluster %s for %s resource", m.c.GetControllerName(), cluster.GetClusterName(), m.c.GetObjectKind())
+	err := m.c.WatchClusterResource(cluster, mc.WatchOptions{})
+	if err != nil {
+		klog.Errorf("failed to watch cluster %s %s event: %v", cluster.GetClusterName(), m.c.GetObjectKind(), err)
+	}
 }

--- a/incubator/virtualcluster/pkg/util/listener/listener.go
+++ b/incubator/virtualcluster/pkg/util/listener/listener.go
@@ -24,6 +24,7 @@ var Listeners []ClusterChangeListener
 
 type ClusterChangeListener interface {
 	AddCluster(cluster mc.ClusterInterface)
+	WatchCluster(cluster mc.ClusterInterface)
 	RemoveCluster(cluster mc.ClusterInterface)
 }
 


### PR DESCRIPTION
for now, we add the event handler before cluster cache synced done. event go through mccontroller will be dropped

```
E0126 04:36:02.339414       1 mccontroller.go:473] kube-system/pod-garbage-collector dws request reconcile failed: The client cache has not been synced yet.
E0126 04:36:02.341958       1 mccontroller.go:473] kube-system/horizontal-pod-autoscaler-token-n87mg dws request reconcile failed: The client cache has not been synced yet.
E0126 04:36:02.342283       1 mccontroller.go:473] kube-system/node-controller-token-nzfb8 dws request reconcile failed: The client cache has not been synced yet.
E0126 04:36:02.342377       1 mccontroller.go:473] kube-system/pod-garbage-collector-token-2vqsn dws request reconcile failed: The client cache has not been synced yet.
E0126 04:36:02.342486       1 mccontroller.go:473] kube-system/namespace-controller dws request reconcile failed: The client cache has not been synced yet.
E0126 04:36:02.342860       1 mccontroller.go:473] kube-system/disruption-controller dws request reconcile failed: The client cache has not been synced yet.
E0126 04:36:02.343316       1 mccontroller.go:473] /kube-system dws request reconcile failed: The client cache has not been synced yet.
E0126 04:36:02.343585       1 mccontroller.go:473] /kube-node-lease dws request reconcile failed: The client cache has not been synced yet.
E0126 04:36:02.343524       1 mccontroller.go:473] /kube-public dws request reconcile failed: The client cache has not been synced yet.
E0126 04:36:02.344363       1 mccontroller.go:473] default/kubernetes dws request reconcile failed: fail to query service from tenant master default-44afb5-vc-sample-1
E0126 04:36:02.344409       1 mccontroller.go:473] default/kubernetes dws request reconcile failed: The client cache has not been synced yet.
E0126 04:36:02.344853       1 mccontroller.go:473] kube-system/extension-apiserver-authentication dws request reconcile failed: The client cache has not been synced yet.
E0126 04:36:02.350146       1 mccontroller.go:473] kube-system/extension-apiserver-authentication dws request reconcile failed: The client cache has not been synced yet.
E0126 04:36:02.355141       1 mccontroller.go:473] default/kubernetes dws request reconcile failed: The client cache has not been synced yet.
E0126 04:36:02.355224       1 mccontroller.go:473] default/kubernetes dws request reconcile failed: fail to query service from tenant master default-44afb5-vc-sample-1
E0126 04:36:02.360219       1 mccontroller.go:473] kube-system/extension-apiserver-authentication dws request reconcile failed: The client cache has not been synced yet.
```


Signed-off-by: zhuangqh <zhuangqhc@gmail.com>