### PR TITLE
[VC] Use new listener interface in Scheduler

### DIFF
--- a/incubator/virtualcluster/experiment/pkg/scheduler/manager/manager.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/manager/manager.go
@@ -35,7 +35,7 @@ func New() *WatchManager {
 
 // ResourceWatcher is the interface used by WatchManager to manage multiple resource watchers.
 type ResourceWatcher interface {
-	listener.ClusterChangeListener
+	GetListener() listener.ClusterChangeListener
 	Start(stopCh <-chan struct{}) error
 }
 
@@ -44,7 +44,11 @@ type ResourceWatcherNew func(*schedulerconfig.SchedulerConfiguration) (ResourceW
 // AddResourceWatcher adds a resource watcher to the WatchManager.
 func (m *WatchManager) AddResourceWatcher(s ResourceWatcher) {
 	m.resourceWatchers[s] = struct{}{}
-	m.listeners = append(m.listeners, s)
+	l := s.GetListener()
+	if l == nil {
+		panic("resource watcher should provide listener")
+	}
+	m.listeners = append(m.listeners, l)
 }
 
 func (m *WatchManager) GetListeners() []listener.ClusterChangeListener {

--- a/incubator/virtualcluster/experiment/pkg/scheduler/reconciler.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/reconciler.go
@@ -184,6 +184,9 @@ func (s *Scheduler) syncVirtualClusterCache(cluster *cluster.Cluster, vc *v1alph
 		return
 	}
 	cluster.SetSynced()
+	for _, clusterChangeListener := range s.virtualClusterWatcher.GetListeners() {
+		clusterChangeListener.WatchCluster(cluster)
+	}
 }
 
 type superclusterGetter struct {
@@ -343,4 +346,7 @@ func (s *Scheduler) syncSuperClusterCache(cluster *cluster.Cluster, super *v1alp
 		return
 	}
 	cluster.SetSynced()
+	for _, clusterChangeListener := range s.superClusterWatcher.GetListeners() {
+		clusterChangeListener.WatchCluster(cluster)
+	}
 }


### PR DESCRIPTION
This change follows up previous refactor changes and uses the new listener interface in the scheduler. The listener startup workflow in the scheduler thus is consistent with that in the vc syncer.