### PR TITLE
Create e2e test image for Prow

### DIFF
--- a/incubator/hnc/hack/prow-e2e/Dockerfile
+++ b/incubator/hnc/hack/prow-e2e/Dockerfile
@@ -1,0 +1,26 @@
+FROM golang:1.14.2-alpine
+WORKDIR /repo
+
+# Since go modules isn't enabled by default.
+ENV GO111MODULE=on
+
+# Build static binaries; otherwise go test complains.
+ENV CGO_ENABLED=0
+
+# Install all basic dependencies. Bash is there in case you need to debug.
+# Curl, Docker, git and make are not included in the golang image.
+RUN apk add --no-cache bash curl docker git make
+#  bash curl docker gcc git jq make openssh-client
+
+# Install Kind
+RUN go get sigs.k8s.io/kind@v0.9.0
+
+# Install kubectl and make sure it's available in the PATH.
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+RUN chmod +x ./kubectl
+RUN mv ./kubectl /bin
+
+# Add the actual script and set it as the default command for this image.
+COPY run-e2e.sh run-e2e.sh
+RUN chmod +x ./run-e2e.sh
+CMD ["./run-e2e.sh"]

--- a/incubator/hnc/hack/prow-e2e/Makefile
+++ b/incubator/hnc/hack/prow-e2e/Makefile
@@ -1,0 +1,20 @@
+IMG_NAME ?= gcr.io/k8s-staging-multitenancy/hnc-postsubmit-tests:latest
+
+build:
+	docker build . -t ${IMG_NAME}
+
+# This is for local debugging. The '-it' arg is needed to allow you to hit
+# ctrl-c while the tests are still running.
+run: build
+	@echo STARTING THE POSTSUBMIT TESTS IN THE CONTAINER
+	docker run -v /var/run/docker.sock:/var/run/docker.sock --network="host" -it ${IMG_NAME}
+
+# After calling 'make run', the Kind cluster will still be present on the
+# *host* even though the Docker container has exited. Run this to find and
+# delete any Kind cluster starting with 'hnc-postsubmit-'
+clean:
+	kind get clusters | grep hnc-postsubmit- | xargs kind delete clusters
+
+# You need permission to push to k8s-staging-multitenancy for this to work.
+push: build
+	docker push ${IMG_NAME}

--- a/incubator/hnc/hack/prow-e2e/README.md
+++ b/incubator/hnc/hack/prow-e2e/README.md
@@ -1,0 +1,14 @@
+This directory contains the files required to run HNC e2e tests on Prow using
+Kind.
+
+Files:
+* Makefile: contains `build`, `run` and `clean` targets. `run` includes `build`.
+  * Also 'push', which requires that you have permission to push to
+    gcr.io/k8s-staging-multitenancy.
+* Dockerfile: creates the image that contains Kind and everything else required
+  to run the tests.
+* run-e2e.sh: included in the Docker image; pulls the repo, creates a Kind
+  cluster, deploys HNC and runs the tests.
+
+To run the tests in the container (i.e., debug the container), type `make run`,
+followed by `make clean` if it doesn't finish successfully.

--- a/incubator/hnc/hack/prow-e2e/run-e2e.sh
+++ b/incubator/hnc/hack/prow-e2e/run-e2e.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# This script is designed to be run in the hnc-postsubmit-tests container. See
+# https://github.com/kubernetes-sigs/multi-tenancy/blob/master/incubator/hnc/hack/prow-e2e/README.md
+# for details.
+
+set -euf -o pipefail
+
+start_time="$(date -u +%s)"
+echo
+echo "Starting at $(date +%Y-%m-%d\ %H:%M:%S)"
+
+echo
+echo "Cloning repo into ${PWD}"
+git clone https://github.com/kubernetes-sigs/multi-tenancy
+cd multi-tenancy/incubator/hnc
+
+# No-one else seems to clean up their Kind clusters, so I don't think we need to
+# either? Does Prow handle it? To make it easier to debug locally, let's just
+# give the cluster a random name (max 32k). This should match the name we look
+# for in the "clean" target in the Makefile in this directory in the git repo.
+CLUSTERNAME="hnc-postsubmit-${RANDOM}"
+echo
+echo "Creating KIND cluster '${CLUSTERNAME}' and setting kubectl context"
+kind create cluster --name ${CLUSTERNAME}
+
+echo
+echo "Building HNC artifacts"
+# Because we don't use the default Kind cluster name, the builtin "docker push"
+# in the makefile won't work here.
+CONFIG=kind make manifests
+CONFIG=kind make kubectl
+CONFIG=kind make docker-build
+
+# Load image into Kind and deploy
+export HNC_REPAIR="${PWD}/manifests/hnc-manager.yaml"
+echo
+echo "Setting HNC_REPAIR to ${HNC_REPAIR} and deploying HNC"
+# Assume the default value of ${HNC_IMG} in the makefile is used
+kind load docker-image --name ${CLUSTERNAME} hnc-manager:kind-local
+kubectl apply -f ${HNC_REPAIR}
+
+# The webhooks take about 30 load
+echo
+echo "Waiting 30s for HNC to be alive"
+sleep 10
+echo "... still waiting ..."
+sleep 10
+echo "... almost done ..."
+sleep 10
+
+echo
+echo "Running the tests"
+make test-e2e
+
+# Note that this won't run if the tests fail - see above. But we may as well
+# *try* to clean up after ourselves.
+kind delete clusters ${CLUSTERNAME}
+
+echo "Finished at $(date +%Y-%m-%d\ %H:%M:%S)"
+end_time="$(date -u +%s)"
+elapsed="$(($end_time-$start_time))"
+echo "Script took $elapsed seconds"


### PR DESCRIPTION
This change will allow Prow to run all HNC e2e tests as postsubmits or
periodic tests. Prow configs will be submitted in a followup commit in
the appropriate repo.

Tested: 'make run' successfully runs all HNC e2e tests (excluding the
NetworkPolicy test, which is expected) in a Kind cluster triggered from
the container image that will run in Prow.