### PR TITLE
[VC] Retry synchronizing cluster state and allow updating existing objects

### DIFF
--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/cluster.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/cluster.go
@@ -27,6 +27,7 @@ type Cluster struct {
 	name     string
 	labels   map[string]string
 	capacity v1.ResourceList
+	shadow   bool // a shadow cluster has a fake capacity, hence is not involved in scheduling
 
 	alloc  v1.ResourceList
 	slices map[string][]*Slice            // ns key -> slice array

--- a/incubator/virtualcluster/experiment/pkg/scheduler/constants/constants.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/constants/constants.go
@@ -17,8 +17,12 @@ limitations under the License.
 package constants
 
 import (
+	"fmt"
+	"math"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/version"
 )
 
@@ -39,3 +43,9 @@ const (
 )
 
 var SchedulerUserAgent = "scheduler" + version.BriefVersion()
+
+// shadowcluster has a fake "unlimited" capacity
+var ShadowClusterCapacity = v1.ResourceList{
+	v1.ResourceCPU:    resource.MustParse(fmt.Sprintf("%d", math.MaxInt32)),
+	v1.ResourceMemory: resource.MustParse(fmt.Sprintf("%dGi", math.MaxInt32)),
+}

--- a/incubator/virtualcluster/experiment/pkg/scheduler/scheduler.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/scheduler.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
@@ -265,7 +264,8 @@ func (s *Scheduler) Bootstrap() error {
 	}
 	for _, each := range superList {
 		if err := util.SyncSuperClusterState(s.metaClusterClient, each, s.schedulerCache); err != nil {
-			DirtySuperClusters.Store(types.NamespacedName{Name: each.Name, Namespace: each.Namespace}, struct{}{})
+			key, _ := cache.DeletionHandlingMetaNamespaceKeyFunc(each)
+			DirtySuperClusters.Store(key, struct{}{})
 			// retry in super workerqueue
 			s.enqueueSuperCluster(each)
 		}
@@ -278,7 +278,8 @@ func (s *Scheduler) Bootstrap() error {
 
 	for _, each := range vcList {
 		if err := util.SyncVirtualClusterState(s.metaClusterClient, each, s.schedulerCache); err != nil {
-			DirtyVirtualClusters.Store(types.NamespacedName{Name: each.Name, Namespace: each.Namespace}, struct{}{})
+			key, _ := cache.DeletionHandlingMetaNamespaceKeyFunc(each)
+			DirtyVirtualClusters.Store(key, struct{}{})
 			// retry in vc workerqueue
 			s.enqueueVirtualCluster(each)
 		}


### PR DESCRIPTION
This change adds retry logic in vc and super cluster reconcilers when scheduler cache has not been synchronized for the 
corresponding cluster. This change also allow existing objects to be updated using Add interfaces.  

To avoid an offline super cluster to block entire scheduler cache synchronization, we introduce a shadow cluster with infinite capacity. The shadow cluster will not participate in scheduling until the correct capacity is updated when the super cluster becomes online again. The namespace placements are still accounted in the shadow cluster so that the virtualcluster state synchronization can proceed even if the placed supercluster is offline.