### PR TITLE
[VC] Add supercluster namespace reconciler

### DIFF
--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/cache.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/cache.go
@@ -308,4 +308,29 @@ func (c *schedulerCache) RemoveCluster(cluster *Cluster) error {
 	return nil
 }
 
-// TODO: Add cluster update methods.
+func (c *schedulerCache) AddProvision(clustername, key string, slices []*Slice) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	clusterState, ok := c.clusters[clustername]
+	if !ok {
+		return fmt.Errorf("cluster %s is not in cache, cannot add provision for %s", clustername, key)
+	}
+
+	// clear old state if any
+	if err := clusterState.RemoveProvision(key); err != nil {
+		return err
+	}
+	return clusterState.AddProvision(key, slices)
+}
+
+func (c *schedulerCache) RemoveProvision(clustername, key string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	clusterState, ok := c.clusters[clustername]
+	if !ok {
+		return fmt.Errorf("cluster %s is not in cache, cannot remove provision for %s", clustername, key)
+	}
+	return clusterState.RemoveProvision(key)
+}

--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/cluster.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/cluster.go
@@ -142,11 +142,11 @@ func (c *Cluster) AddNamespace(key string, slices []*Slice) error {
 }
 
 func (c *Cluster) removeItem(key string, items map[string][]*Slice, alloc v1.ResourceList) (v1.ResourceList, error) {
+	allocCopy := alloc.DeepCopy()
 	slices, ok := items[key]
 	if !ok {
-		return nil, fmt.Errorf("key %s is not in cluster %s, cannot remove twice", key, c.name)
+		return allocCopy, nil
 	}
-	allocCopy := alloc.DeepCopy()
 	for _, s := range slices {
 		for k, v := range s.size {
 			each, _ := allocCopy[k]

--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/interface.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/interface.go
@@ -23,4 +23,6 @@ type Cache interface {
 	RemoveCluster(*Cluster) error
 	AddPod(*Pod) error
 	RemovePod(*Pod) error
+	AddProvision(string, string, []*Slice) error
+	RemoveProvision(string, string) error
 }

--- a/incubator/virtualcluster/experiment/pkg/scheduler/constants/constants.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/constants/constants.go
@@ -40,6 +40,8 @@ const (
 	SuperClusterWorker   = 3
 
 	KubeconfigAdminSecretName = "admin-kubeconfig"
+
+	LabelSchedulerCache = "tenancy.x-k8s.io/schedulercache"
 )
 
 var SchedulerUserAgent = "scheduler" + version.BriefVersion()

--- a/incubator/virtualcluster/experiment/pkg/scheduler/scheduler.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/scheduler.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scheduler
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -144,7 +145,8 @@ func New(
 	superWatcher := manager.New()
 	scheduler.superClusterWatcher = superWatcher
 	// register super cluster resources
-	initContext := &plugin.InitContext{Config: config}
+	ctx := context.WithValue(context.Background(), constants.LabelSchedulerCache, scheduler.schedulerCache)
+	initContext := &plugin.InitContext{Context: ctx, Config: config}
 	for _, p := range SuperClusterResourceRegister.List() {
 		klog.Infof("loading super cluster resource plugin %q...", p.ID)
 

--- a/incubator/virtualcluster/pkg/util/cluster/cluster.go
+++ b/incubator/virtualcluster/pkg/util/cluster/cluster.go
@@ -314,6 +314,10 @@ func (c *Cluster) SetSynced() {
 	c.synced = true
 }
 
+func (c *Cluster) SetKey(k string) {
+	c.key = k
+}
+
 // Stop send a msg to stopCh, stop the cache.
 func (c *Cluster) Stop() {
 	close(c.stopCh)


### PR DESCRIPTION
This change adds the reconciler for supercluster namespace. The goal is to update the cluster provision namespace information in the scheduler cache.

This change also adjusts the clustername used in the mccontroller. Using id as the clustername instead of the CR full name simplifies the reconciling logic. Otherwise, we have to fetch the configmap in the super cluster during the reconciling.