### PR TITLE
[VC] Add cache dump functionality

### DIFF
--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/cache.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/cache.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
@@ -333,4 +334,27 @@ func (c *schedulerCache) RemoveProvision(clustername, key string) error {
 		return fmt.Errorf("cluster %s is not in cache, cannot remove provision for %s", clustername, key)
 	}
 	return clusterState.RemoveProvision(key)
+}
+
+func (c *schedulerCache) Dump() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := strings.Builder{}
+	out.WriteString("-- Dump Super Clusters --")
+	for k, v := range c.clusters {
+		out.WriteByte('\n')
+		out.WriteString(k)
+		out.WriteByte(' ')
+		out.WriteString(v.Dump())
+	}
+
+	out.WriteString("\n")
+	out.WriteString("-- Dump Namespaces --")
+	for k, v := range c.namespaces {
+		out.WriteByte('\n')
+		out.WriteString(k)
+		out.WriteByte(' ')
+		out.WriteString(v.Dump())
+	}
+	return out.String()
 }

--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/interface.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/interface.go
@@ -25,4 +25,5 @@ type Cache interface {
 	RemovePod(*Pod) error
 	AddProvision(string, string, []*Slice) error
 	RemoveProvision(string, string) error
+	Dump() string
 }

--- a/incubator/virtualcluster/experiment/pkg/scheduler/scheduler.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/scheduler.go
@@ -271,6 +271,12 @@ func (s *Scheduler) Run(stopChan <-chan struct{}) {
 		<-stopChan
 
 	}()
+
+	go wait.Until(s.Dump, 1*time.Minute, stopChan)
+}
+
+func (s *Scheduler) Dump() {
+	klog.Infof("Start dumping scheduler cache\n%s", s.schedulerCache.Dump())
 }
 
 // The dirty sets are used in bootstrap and in handling cluster offline. If a cluster was in dirty set and becomes online again,


### PR DESCRIPTION
This change adds dumping cache functionality, mainly used for debugging. For now, the cache state will be dumped every minute, which is subject to change in the future. 

New dump structures are introduced which are the same as internal cache objects except that all fields are exported. 
Then we can leverage json marshal capability to make "pretty print" for the cache content.