### PR TITLE
[VC] Add health check and update super cluster capacity periodically

### DIFF
--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/cache.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/cache.go
@@ -336,6 +336,18 @@ func (c *schedulerCache) RemoveProvision(clustername, key string) error {
 	return clusterState.RemoveProvision(key)
 }
 
+func (c *schedulerCache) UpdateClusterCapacity(clustername string, newCapacity v1.ResourceList) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	clusterState, ok := c.clusters[clustername]
+	if !ok {
+		return fmt.Errorf("cluster %s is not in cache, cannot update the cluster capacity")
+	}
+	clusterState.UpdateCapacity(newCapacity)
+	return nil
+}
+
 func (c *schedulerCache) Dump() string {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/cluster.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/cluster.go
@@ -207,6 +207,10 @@ func (c *Cluster) RemovePod(pod *Pod) {
 	}
 }
 
+func (c *Cluster) UpdateCapacity(newCapacity v1.ResourceList) {
+	c.capacity = newCapacity.DeepCopy()
+}
+
 // dump structure is used for debugging
 type ClusterDump struct {
 	Name     string

--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/interface.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/interface.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package cache
 
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
 type Cache interface {
 	AddNamespace(*Namespace) error
 	RemoveNamespace(*Namespace) error
@@ -25,5 +29,6 @@ type Cache interface {
 	RemovePod(*Pod) error
 	AddProvision(string, string, []*Slice) error
 	RemoveProvision(string, string) error
+	UpdateClusterCapacity(string, v1.ResourceList) error
 	Dump() string
 }

--- a/incubator/virtualcluster/experiment/pkg/scheduler/health.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/health.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
+
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/scheduler/metrics"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/scheduler/util"
+	mc "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/util/mccontroller"
+)
+
+var (
+	numHealthSuperCluster     uint64
+	numUnHealthSuperCluster   uint64
+	numHealthVirtualCluster   uint64
+	numUnHealthVirtualCluster uint64
+)
+
+func (s *Scheduler) superClusterHealthPatrol() {
+	var clusters []mc.ClusterInterface
+	s.superClusterLock.Lock()
+	for _, c := range s.superClusterSet {
+		clusters = append(clusters, c)
+	}
+	s.superClusterLock.Unlock()
+
+	numUnHealthSuperCluster = 0
+	numHealthSuperCluster = 0
+
+	if len(clusters) != 0 {
+		wg := sync.WaitGroup{}
+		for _, c := range clusters {
+			wg.Add(1)
+			go func(cluster mc.ClusterInterface) {
+				defer wg.Done()
+				s.checkSuperClusterHealth(cluster)
+			}(c)
+		}
+		wg.Wait()
+	}
+
+	metrics.SuperClusterHealthStats.WithLabelValues("health").Set(float64(numHealthSuperCluster))
+	metrics.SuperClusterHealthStats.WithLabelValues("unhealth").Set(float64(numUnHealthSuperCluster))
+}
+
+// checkSuperClusterHealth attempts to get the node list from the super cluster, it will update the scheduler cache as well
+func (s *Scheduler) checkSuperClusterHealth(cluster mc.ClusterInterface) {
+	cs, err := cluster.GetClientSet()
+	if err != nil {
+		klog.Warningf("[checkSuperClusterHealth] fails to get cluster %v clientset: %v", cluster.GetClusterName(), err)
+		return
+	}
+
+	var capacity v1.ResourceList
+	capacity, err = util.GetSuperClusterCapacity(cs)
+	if err != nil {
+		klog.Warningf("[checkSuperClusterHealth] fails to get cluster %v capacity: %v", cluster.GetClusterName(), err)
+		atomic.AddUint64(&numUnHealthSuperCluster, 1)
+
+		ns, name, uid := cluster.GetOwnerInfo()
+		s.recorder.Eventf(&v1.ObjectReference{
+			Kind:      "Cluster",
+			Namespace: ns,
+			Name:      name,
+			UID:       types.UID(uid),
+		}, v1.EventTypeWarning, "ClusterUnHealth", "SuperCluster %v unhealth: %v", cluster.GetClusterName(), err.Error())
+
+		// mark super cluster dirty and add to super cluster queue to resync the cache
+		key := fmt.Sprintf("%s/%s", ns, name)
+		DirtySuperClusters.Store(key, struct{}{})
+		s.superClusterQueue.Add(key)
+		return
+	}
+	atomic.AddUint64(&numHealthSuperCluster, 1)
+	// update scheduler cache
+	s.schedulerCache.UpdateClusterCapacity(cluster.GetClusterName(), capacity)
+}
+
+func (s *Scheduler) virtualClusterHealthPatrol() {
+	var clusters []mc.ClusterInterface
+	s.virtualClusterLock.Lock()
+	for _, c := range s.virtualClusterSet {
+		clusters = append(clusters, c)
+	}
+	s.virtualClusterLock.Unlock()
+
+	numUnHealthVirtualCluster = 0
+	numHealthVirtualCluster = 0
+
+	if len(clusters) != 0 {
+		wg := sync.WaitGroup{}
+		for _, c := range clusters {
+			wg.Add(1)
+			go func(cluster mc.ClusterInterface) {
+				defer wg.Done()
+				s.checkVirtualClusterHealth(cluster)
+			}(c)
+		}
+		wg.Wait()
+	}
+
+	metrics.VirtualClusterHealthStats.WithLabelValues("health").Set(float64(numHealthVirtualCluster))
+	metrics.VirtualClusterHealthStats.WithLabelValues("unhealth").Set(float64(numUnHealthVirtualCluster))
+}
+
+func (s *Scheduler) checkVirtualClusterHealth(cluster mc.ClusterInterface) {
+	cs, err := cluster.GetClientSet()
+	if err != nil {
+		klog.Warningf("[checkVirtualClusterHealth] fails to get cluster %v clientset: %v", cluster.GetClusterName(), err)
+		return
+	}
+
+	_, err = cs.Discovery().ServerVersion()
+	if err != nil {
+		klog.Warningf("[checkVirtualClusterHealth] fails to get cluster %v version: %v", cluster.GetClusterName(), err)
+		atomic.AddUint64(&numUnHealthVirtualCluster, 1)
+
+		ns, name, uid := cluster.GetOwnerInfo()
+		s.recorder.Eventf(&v1.ObjectReference{
+			Kind:      "VirtualCluster",
+			Namespace: ns,
+			Name:      name,
+			UID:       types.UID(uid),
+		}, v1.EventTypeWarning, "ClusterUnHealth", "VirtualCluster %v unhealth: %v", cluster.GetClusterName(), err.Error())
+
+		// mark virtual cluster dirty and add to virtual cluster queue to resync the cache
+		key := fmt.Sprintf("%s/%s", ns, name)
+		DirtyVirtualClusters.Store(key, struct{}{})
+		s.virtualClusterQueue.Add(key)
+		return
+	}
+	atomic.AddUint64(&numHealthVirtualCluster, 1)
+}

--- a/incubator/virtualcluster/experiment/pkg/scheduler/metrics/metrics.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/metrics/metrics.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	_ "k8s.io/component-base/metrics/prometheus/workqueue"
+)
+
+const (
+	SchedulerSubsystem      = "scheduler"
+	SuperClusterHealthKey   = "super_cluster_health"
+	VirtualClusterHealthKey = "virtual_cluster_health"
+)
+
+var (
+	SuperClusterHealthStats = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: SchedulerSubsystem,
+			Name:      SuperClusterHealthKey,
+			Help:      "Last health scan status for super clusters.",
+		},
+		[]string{"status"},
+	)
+	VirtualClusterHealthStats = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: SchedulerSubsystem,
+			Name:      VirtualClusterHealthKey,
+			Help:      "Last health scan status for virtual clusters.",
+		},
+		[]string{"status"},
+	)
+)
+
+var registerMetrics sync.Once
+
+// Register all metrics.
+func Register() {
+	registerMetrics.Do(func() {
+		prometheus.MustRegister(SuperClusterHealthStats)
+		prometheus.MustRegister(VirtualClusterHealthStats)
+	})
+}

--- a/incubator/virtualcluster/experiment/pkg/scheduler/scheduler.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/scheduler.go
@@ -273,6 +273,8 @@ func (s *Scheduler) Run(stopChan <-chan struct{}) {
 	}()
 
 	go wait.Until(s.Dump, 1*time.Minute, stopChan)
+	go wait.Until(s.superClusterHealthPatrol, 1*time.Minute, stopChan)
+	go wait.Until(s.virtualClusterHealthPatrol, 1*time.Minute, stopChan)
 }
 
 func (s *Scheduler) Dump() {


### PR DESCRIPTION
This change adds health check for the virtual clusters and super clusters. Some basic metrics are added to the scheduler.
We leverage the super cluster health check to update the super cluster capacity in case the capacity changes due to adding/removing nodes or node errors. We may tune this later if a single node failure needs to be notified to the scheduler immediately. 