### PR TITLE
[VC] Implement major workflows in SchedulerEngine

### DIFF
--- a/incubator/virtualcluster/experiment/pkg/scheduler/algorithm/types.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/algorithm/types.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package algorithm
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+// SliceInfo is the input to the algorithm
+type SliceInfo struct {
+	Namespace string // namespace key
+	Request   v1.ResourceList
+	Mandatory string // if not empty, it is the cluster that the slice should go if all checks are passed
+	Hint      string // if not empty, it is the preferred cluster
+
+	Result string // scheduled cluster name
+	Err    error
+}
+
+type SliceInfoArray []*SliceInfo
+
+func (s *SliceInfoArray) Repeat(n int, namespace string, request v1.ResourceList, mandatory, hint string) {
+	for i := 0; i < n; i++ {
+		*s = append(*s, &SliceInfo{
+			Namespace: namespace,
+			Request:   request.DeepCopy(),
+			Mandatory: mandatory,
+			Hint:      hint,
+		})
+	}
+}

--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/cache.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/cache.go
@@ -120,6 +120,12 @@ func (c *schedulerCache) RemovePod(pod *Pod) error {
 
 }
 
+func (c *schedulerCache) GetNamespace(key string) *Namespace {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.namespaces[key]
+}
+
 func (c *schedulerCache) addNamespaceToCluster(cluster, key string, num int, slice v1.ResourceList) error {
 	if num == 0 {
 		return nil

--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/cache_test.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/cache_test.go
@@ -51,7 +51,7 @@ func TestAddRemoveNamespace(t *testing.T) {
 	}
 
 	stop := make(chan struct{})
-	cache := NewSchedulerCache(stop)
+	cache := NewSchedulerCache(stop).(*schedulerCache)
 
 	cluster1 := NewCluster(defaultCluster1, nil, defaultCapacity)
 	cluster2 := NewCluster(defaultCluster2, nil, defaultCapacity)
@@ -221,7 +221,7 @@ func TestUpdateNamespace(t *testing.T) {
 	}
 
 	stop := make(chan struct{})
-	cache := NewSchedulerCache(stop)
+	cache := NewSchedulerCache(stop).(*schedulerCache)
 
 	cluster1 := NewCluster(defaultCluster1, nil, defaultCapacity)
 	cluster2 := NewCluster(defaultCluster2, nil, defaultCapacity)
@@ -348,7 +348,7 @@ func TestShadowCluster(t *testing.T) {
 	}
 
 	stop := make(chan struct{})
-	cache := NewSchedulerCache(stop)
+	cache := NewSchedulerCache(stop).(*schedulerCache)
 
 	cluster1 := NewCluster(defaultCluster1, nil, defaultCapacity)
 	cluster2 := NewCluster(defaultCluster2, nil, defaultCapacity)

--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/cluster_test.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/cluster_test.go
@@ -30,24 +30,6 @@ const (
 	defaultCluster   = "testcluster"
 )
 
-func Equals(a v1.ResourceList, b v1.ResourceList) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	for key, value1 := range a {
-		value2, found := b[key]
-		if !found {
-			return false
-		}
-		if value1.Cmp(value2) != 0 {
-			return false
-		}
-	}
-
-	return true
-}
-
 func TestAddNamespace(t *testing.T) {
 	defaultCapacity := v1.ResourceList{
 		"cpu":    resource.MustParse("2000M"),

--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/interface.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/interface.go
@@ -21,8 +21,10 @@ import (
 )
 
 type Cache interface {
+	GetNamespace(string) *Namespace
 	AddNamespace(*Namespace) error
 	RemoveNamespace(*Namespace) error
+	UpdateNamespace(*Namespace, *Namespace) error
 	AddCluster(*Cluster) error
 	RemoveCluster(*Cluster) error
 	AddPod(*Pod) error

--- a/incubator/virtualcluster/experiment/pkg/scheduler/engine/schedulerengine_test.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/engine/schedulerengine_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/scheduler/algorithm"
+	internalcache "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/experiment/pkg/scheduler/cache"
+)
+
+func classifySlicesInfoArray(in algorithm.SliceInfoArray) (map[string]int, map[string]int, int) {
+	mandatory := make(map[string]int)
+	hint := make(map[string]int)
+	regular := 0
+	for _, each := range in {
+		if each.Mandatory != "" {
+			mandatory[each.Mandatory] = mandatory[each.Mandatory] + 1
+		} else if each.Hint != "" {
+			hint[each.Hint] = hint[each.Hint] + 1
+		} else {
+			regular++
+		}
+	}
+	return mandatory, hint, regular
+}
+
+func TestGetSlicesToSchedule(t *testing.T) {
+
+	defaultQuota := v1.ResourceList{
+		"cpu":    resource.MustParse("10"),
+		"memory": resource.MustParse("10Gi"),
+	}
+
+	defaultQuotaSlice := v1.ResourceList{
+		"cpu":    resource.MustParse("1"),
+		"memory": resource.MustParse("1Gi"),
+	}
+
+	namespace := internalcache.NewNamespace("testcluster", "testnamespace", nil, defaultQuota, defaultQuotaSlice, nil)
+
+	testcases := map[string]struct {
+		mandatoryPlacements map[string]int
+		oldPlacements       map[string]int
+		mandatory           map[string]int
+		hint                map[string]int
+		regular             int
+	}{
+		"all regualr": {
+			mandatoryPlacements: map[string]int{},
+			oldPlacements:       map[string]int{},
+			mandatory:           map[string]int{},
+			hint:                map[string]int{},
+			regular:             10,
+		},
+		"a few mandatory (increase quota)": {
+			mandatoryPlacements: map[string]int{
+				"a": 2,
+				"b": 4,
+			},
+			oldPlacements: map[string]int{},
+			mandatory: map[string]int{
+				"a": 2,
+				"b": 4,
+			},
+			hint:    map[string]int{},
+			regular: 4,
+		},
+		"more mandatory (increase quota)": {
+			mandatoryPlacements: map[string]int{
+				"a": 20,
+			},
+			oldPlacements: map[string]int{},
+			mandatory: map[string]int{
+				"a": 10,
+			},
+			hint:    map[string]int{},
+			regular: 0,
+		},
+		"a few hints (increase quota)": {
+			mandatoryPlacements: map[string]int{},
+			oldPlacements: map[string]int{
+				"c": 1,
+				"d": 3,
+			},
+			mandatory: map[string]int{},
+			hint: map[string]int{
+				"c": 1,
+				"d": 3,
+			},
+			regular: 6,
+		},
+		"more hints (decrease quota)": {
+			mandatoryPlacements: map[string]int{},
+			oldPlacements: map[string]int{
+				"c": 13,
+			},
+			mandatory: map[string]int{},
+			hint: map[string]int{
+				"c": 10,
+			},
+			regular: 0,
+		},
+		"Mix mandatory and hints": {
+			mandatoryPlacements: map[string]int{
+				"a": 1,
+				"b": 2,
+			},
+			oldPlacements: map[string]int{
+				"c": 1,
+				"d": 3,
+			},
+			mandatory: map[string]int{
+				"a": 1,
+				"b": 2,
+			},
+			hint: map[string]int{
+				"c": 1,
+				"d": 3,
+			},
+			regular: 3,
+		},
+		"Mix mandatory and hints - partial overlapping": {
+			mandatoryPlacements: map[string]int{
+				"a": 1,
+				"b": 2,
+			},
+			oldPlacements: map[string]int{
+				"a": 1,
+				"d": 3,
+			},
+			mandatory: map[string]int{
+				"a": 1,
+				"b": 2,
+			},
+			hint: map[string]int{
+				"d": 3,
+			},
+			regular: 4,
+		},
+		"Mix mandatory and hints - full overlapping": {
+			mandatoryPlacements: map[string]int{
+				"a": 1,
+				"b": 2,
+			},
+			oldPlacements: map[string]int{
+				"a": 3,
+				"b": 4,
+			},
+			mandatory: map[string]int{
+				"a": 1,
+				"b": 2,
+			},
+			hint: map[string]int{
+				"a": 2,
+				"b": 2,
+			},
+			regular: 3,
+		},
+	}
+
+	for k, tc := range testcases {
+		t.Run(k, func(t *testing.T) {
+			namespace.SetNewPlacements(tc.mandatoryPlacements)
+			slicesToSchedule := GetSlicesToSchedule(namespace, tc.oldPlacements)
+			mandatory, hint, regular := classifySlicesInfoArray(slicesToSchedule)
+			if !reflect.DeepEqual(mandatory, tc.mandatory) || !reflect.DeepEqual(hint, tc.hint) || regular != tc.regular {
+				t.Errorf("test %s should succeed but fails: %v(%v), %v(%v), %d(%d)", k, mandatory, tc.mandatory, hint, tc.hint, regular, tc.regular)
+			}
+		})
+	}
+
+}

--- a/incubator/virtualcluster/experiment/pkg/scheduler/util/helper.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/util/helper.go
@@ -38,6 +38,13 @@ import (
 	utilconst "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/util/constants"
 )
 
+func Min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
 func GetClientFromSecret(metaClient clientset.Interface, name, namespace string) (*clientset.Clientset, error) {
 	adminKubeConfigSecret, err := metaClient.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {


### PR DESCRIPTION
This change has refactored the interfaces in SchedulerEngine to satisfy the tenant namespace reconciler. It seems that we don't need the rollback mechanism if the scheduling result is failed to be updated to tenant namespace. Instead, we can retry later while keeping the placement in the scheduler cache. 

This change also implements the major workflows in the SchedulerEngine interfaces. The only missing part is to call the scheduling algorithm. The ScheduleNamespace interface covers the following scenarios: 
- Schedule for a new namespace (with quota)
- Schedule extra slices if a namespace's quota is increased.
- Determine the new placement if a namespace's quota is reduced.
- Reschedule if the placement result is modified (e.g., remove the stale schedule to a cluster that is unhealthy)