### PR TITLE
[VC] Adding super cluster networking feature

### DIFF
--- a/incubator/virtualcluster/cmd/syncer/app/options/options.go
+++ b/incubator/virtualcluster/cmd/syncer/app/options/options.go
@@ -83,7 +83,10 @@ func NewResourceSyncerOptions() (*ResourceSyncerOptions, error) {
 			DefaultOpaqueMetaDomains:   []string{"kubernetes.io", "k8s.io"},
 			ExtraSyncingResources:      []string{},
 			VNAgentPort:                int32(10550),
-			FeatureGates:               map[string]bool{featuregate.SuperClusterPooling: false},
+			FeatureGates: map[string]bool{
+				featuregate.SuperClusterPooling:        false,
+				featuregate.SuperClusterServiceNetwork: false,
+			},
 		},
 		SyncerName: "vc",
 		Address:    "",

--- a/incubator/virtualcluster/pkg/syncer/conversion/mutate.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/mutate.go
@@ -240,9 +240,6 @@ func getServiceEnvVarMap(ns, cluster string, enableServiceLinks *bool, services 
 		apiServerService string
 	)
 
-	// the master service namespace of the given virtualcluster
-	tenantMasterSvcNs := ToSuperMasterNamespace(cluster, masterServiceNamespace)
-
 	// project the services in namespace ns onto the master services
 	for i := range services {
 		service := services[i]
@@ -252,12 +249,12 @@ func getServiceEnvVarMap(ns, cluster string, enableServiceLinks *bool, services 
 		}
 		serviceName := service.Name
 
-		// We always want to add environment variabled for master services
+		// We always want to add environment variables for master services
 		// from the corresponding master service namespace of the virtualcluster,
 		// even if enableServiceLinks is false.
 		// We also add environment variables for other services in the same
 		// namespace, if enableServiceLinks is true.
-		if service.Namespace == tenantMasterSvcNs && masterServices.Has(serviceName) {
+		if IsControlPlaneService(service, cluster) {
 			apiServerService = service.Spec.ClusterIP
 			if _, exists := serviceMap[serviceName]; !exists {
 				serviceMap[serviceName] = service

--- a/incubator/virtualcluster/pkg/syncer/util/featuregate/gate.go
+++ b/incubator/virtualcluster/pkg/syncer/util/featuregate/gate.go
@@ -30,12 +30,17 @@ type FeatureGate interface {
 }
 
 const (
+	// SuperClusterServiceNetwork is an experimental feature that allows the
+	// services to share the same ClusterIPs as the super cluster.
+	SuperClusterServiceNetwork = "SuperClusterServiceNetwork"
+
 	// SuperClusterPooling is an experimental feature
 	SuperClusterPooling = "SuperClusterPooling"
 )
 
 var defaultFeatures = FeatureList{
-	SuperClusterPooling: {Default: false},
+	SuperClusterPooling:        {Default: false},
+	SuperClusterServiceNetwork: {Default: false},
 }
 
 type Feature string


### PR DESCRIPTION
This adds a new featuregate - `featuregate.SuperClusterServiceNetwork` which when turned on will use the superclusters tenant control plane service `ClusterIP` for configuring the `KUBERNETES_SERVICE_HOST` environment variable. This allows controllers deployed into virtualclusters to route to the correct control plane without needing the forked CoreDNS.

Ref #1394 

Signed-off-by: Chris Hein <me@chrishein.com>