### PR TITLE
[VC] Support adopting supercluster services

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/constants/constants.go
+++ b/incubator/virtualcluster/pkg/syncer/constants/constants.go
@@ -65,6 +65,10 @@ const (
 	// PublicObjectKey is a label key which marks the super master object that should be populated to every tenant master.
 	PublicObjectKey = "tenancy.x-k8s.io/super.public"
 
+	// AdoptableObjectKey is a label key that marks super master object as reclaimable via setting UID
+	// this uses the transparency. subdomain to force this label to not sync to the tenant
+	AdoptableObjectKey = "transparency.tenancy.x-k8s.io/super.adoptable"
+
 	LabelVirtualNode = "tenancy.x-k8s.io/virtualnode"
 
 	// DefaultvNodeGCGracePeriod is the grace period of time before deleting an orphan vNode in tenant master.


### PR DESCRIPTION
This extends #1395 to support adopting services that could be created in the super cluster, this is gated by the feature flag introduced in #1395 and expects that the super cluster service has a non-upward synced annotation set to `transparency.tenancy.x-k8s.io/super.adoptable`.

Following this, I'll be implementing a webhook that all the tenant control planes could be configured to for mutating Service objects prior to saving in etcd.

Blocked by #1395 
Ref #1394 

Signed-off-by: Chris Hein <me@chrishein.com>