### PR TITLE
Attempt to fix HNC postsubmits

### DIFF
--- a/incubator/hnc/hack/prow-e2e/Dockerfile
+++ b/incubator/hnc/hack/prow-e2e/Dockerfile
@@ -13,7 +13,13 @@
 #
 # Source: https://github.com/kubernetes/test-infra/tree/master/images/krte
 FROM gcr.io/k8s-testimages/krte:v20210129-3799a64-master
-WORKDIR /repo
+
+# For postsubmits, Prow will start the test in its own workdir (e.g.
+# /home/prow/go/src/sigs.k8s.io/multi-tenancy, though we shouldn't depend on
+# that). For periodics, I don't think Prow overrides the workdir. Either way,
+# set up the workdir in a place that makes sense for the periodics, but also
+# allows us to easily find the test script even if it's changed.
+WORKDIR /start
 
 # I'm not sure if the following two env vars are needed for HNC; they're probably not. GO111MODULE=on
 # should be redundant outside of GOPATH (which we are) on any post-1.13 version of Go (which we have);
@@ -29,6 +35,3 @@ RUN go get sigs.k8s.io/kind@v0.9.0
 # Add the actual script and set it as the default command for this image.
 COPY run-e2e-tests.sh run-e2e-tests.sh
 RUN chmod +x ./run-e2e-tests.sh
-
-# This needs to be re-specified in Prow
-CMD ["wrapper.sh", "./run-e2e-tests.sh"]

--- a/incubator/hnc/hack/prow-e2e/Makefile
+++ b/incubator/hnc/hack/prow-e2e/Makefile
@@ -7,7 +7,7 @@ build:
 # ctrl-c while the tests are still running.
 run: build
 	@echo STARTING THE POSTSUBMIT TESTS IN THE CONTAINER
-	docker run -e IMAGE=${IMG_NAME} -e DOCKER_IN_DOCKER_ENABLED=true -v /var/run/docker.sock:/var/run/docker.sock --network="host" -it ${IMG_NAME}
+	docker run -e DOCKER_IN_DOCKER_ENABLED=true -v /var/run/docker.sock:/var/run/docker.sock --network="host" -it ${IMG_NAME} /start/run-e2e-tests.sh
 
 # After calling 'make run', the Kind cluster will still be present on the
 # *host* even though the Docker container has exited. Run this to find and

--- a/incubator/hnc/hack/prow-e2e/run-e2e-tests.sh
+++ b/incubator/hnc/hack/prow-e2e/run-e2e-tests.sh
@@ -10,9 +10,16 @@ echo
 echo "Starting at $(date +%Y-%m-%d\ %H:%M:%S)"
 
 echo
-echo "Cloning repo into ${PWD}"
-git clone https://github.com/kubernetes-sigs/multi-tenancy
-cd multi-tenancy/incubator/hnc
+# For periodics, we need to clone the repo ourselves. For postsubmits, it will
+# already be there.
+if [ ! -d "incubator/hnc" ]; then
+  echo "Not in repo; cloning into ${PWD}"
+  git clone https://github.com/kubernetes-sigs/multi-tenancy
+  cd multi-tenancy
+else
+  echo "Repo already exists in ${PWD}"
+fi
+cd incubator/hnc
 
 # No-one else seems to clean up their Kind clusters, so I don't think we need to
 # either? Does Prow handle it? To make it easier to debug locally, let's just


### PR DESCRIPTION
Our first run of the HNC postsubmits failed, most likely because the
workdir is modified by Prow (based on the messages I'm seeing). This
change updates the Dockerfile and test script to _not_ assume a specific
workdir, and also allows Prow to set up the repo when appropriate.

Tested: script runs locally but there's no good way for me to test on
Prow. As soon as this is merged, the postsubmits themselves will tell me
if I got this right or not.