### PR TITLE
[VC] Update SchedulerCache when vc or cluster CRs are added/removed

### DIFF
--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/cache_test.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/cache_test.go
@@ -52,6 +52,7 @@ func TestAddRemoveNamespace(t *testing.T) {
 
 	stop := make(chan struct{})
 	cache := NewSchedulerCache(stop).(*schedulerCache)
+	cache.AddTenant(defaultTenant)
 
 	cluster1 := NewCluster(defaultCluster1, nil, defaultCapacity)
 	cluster2 := NewCluster(defaultCluster2, nil, defaultCapacity)
@@ -222,6 +223,7 @@ func TestUpdateNamespace(t *testing.T) {
 
 	stop := make(chan struct{})
 	cache := NewSchedulerCache(stop).(*schedulerCache)
+	cache.AddTenant(defaultTenant)
 
 	cluster1 := NewCluster(defaultCluster1, nil, defaultCapacity)
 	cluster2 := NewCluster(defaultCluster2, nil, defaultCapacity)
@@ -349,6 +351,7 @@ func TestShadowCluster(t *testing.T) {
 
 	stop := make(chan struct{})
 	cache := NewSchedulerCache(stop).(*schedulerCache)
+	cache.AddTenant(defaultTenant)
 
 	cluster1 := NewCluster(defaultCluster1, nil, defaultCapacity)
 	cluster2 := NewCluster(defaultCluster2, nil, defaultCapacity)

--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/cluster.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/cluster.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type Cluster struct {
@@ -37,6 +38,8 @@ type Cluster struct {
 	// provision and provisionItems record the observed namespaces from the super cluster
 	provision      v1.ResourceList
 	provisionItems map[string][]*Slice
+
+	lastUpdateTime metav1.Time
 }
 
 func NewCluster(name string, labels map[string]string, capacity v1.ResourceList) *Cluster {
@@ -56,6 +59,7 @@ func NewCluster(name string, labels map[string]string, capacity v1.ResourceList)
 		pods:           make(map[string]map[string]struct{}),
 		provision:      zeroRes,
 		provisionItems: make(map[string][]*Slice),
+		lastUpdateTime: metav1.Now(),
 	}
 }
 
@@ -208,10 +212,6 @@ func (c *Cluster) RemovePod(pod *Pod) {
 	}
 }
 
-func (c *Cluster) UpdateCapacity(newCapacity v1.ResourceList) {
-	c.capacity = newCapacity.DeepCopy()
-}
-
 func (c *Cluster) Dump() string {
 	o := map[string]interface{}{
 		"Name":           c.name,
@@ -223,6 +223,7 @@ func (c *Cluster) Dump() string {
 		"Pods":           c.pods,
 		"Provision":      c.provision,
 		"ProvisionItems": c.provisionItems,
+		"LastUpdateTime": c.lastUpdateTime,
 	}
 
 	b, err := json.MarshalIndent(o, "", "\t")

--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/interface.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/interface.go
@@ -21,12 +21,14 @@ import (
 )
 
 type Cache interface {
+	AddTenant(string)
+	RemoveTenant(string) error
 	GetNamespace(string) *Namespace
 	AddNamespace(*Namespace) error
 	RemoveNamespace(*Namespace) error
 	UpdateNamespace(*Namespace, *Namespace) error
 	AddCluster(*Cluster) error
-	RemoveCluster(*Cluster) error
+	RemoveCluster(string) error
 	AddPod(*Pod) error
 	RemovePod(*Pod) error
 	AddProvision(string, string, []*Slice) error

--- a/incubator/virtualcluster/experiment/pkg/scheduler/util/helper.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/util/helper.go
@@ -291,6 +291,8 @@ func GetSchedulingInfo(namespace *v1.Namespace) (map[string]int, v1.ResourceList
 
 func SyncVirtualClusterState(metaClient clientset.Interface, vc *v1alpha1.VirtualCluster, cache internalcache.Cache) error {
 	clustername := conversion.ToClusterKey(vc)
+	cache.AddTenant(clustername)
+
 	client, err := GetClientFromSecret(metaClient, syncerconst.KubeconfigAdminSecretName, clustername)
 	if err != nil {
 		return fmt.Errorf("failed to get client for virtual cluster %s/%s: %v", vc.Namespace, vc.Name, err)


### PR DESCRIPTION
This change handles the cache updates when VC or Cluster CRs are added or removed. 

Since we have shadow cluster objects to handle super cluster offline, the shadow cluster may exist even after the super cluster CR is removed. A periodic checker is added to clean up old shadow clusters. 