### PR TITLE
[VC] Snapshot schedulercache for namespace scheduling

### DIFF
--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/cache.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/cache.go
@@ -189,7 +189,8 @@ func (c *schedulerCache) addNamespaceToCluster(cluster, key string, num int, sli
 	clusterState, exists := c.clusters[cluster]
 	if !exists {
 		klog.Warningf("namespace %s has a placement to a cluster %s that does not exist, create a shadow cluster", key, cluster)
-		clusterState = c.addShadowCluster(cluster)
+		clusterState = NewCluster(cluster, nil, constants.ShadowClusterCapacity)
+		clusterState.shadow = true
 	}
 	var slices []*Slice
 	for i := 0; i < num; i++ {
@@ -350,13 +351,6 @@ func (c *schedulerCache) updateClusterNonAllocationStates(curCluster, newCluster
 	}
 	curCluster.provisionItems = provisionItemsCopy
 	curCluster.provision = newCluster.provision.DeepCopy()
-}
-
-func (c *schedulerCache) addShadowCluster(name string) *Cluster {
-	shadowCluster := NewCluster(name, nil, constants.ShadowClusterCapacity)
-	shadowCluster.shadow = true
-	c.clusters[name] = shadowCluster
-	return shadowCluster
 }
 
 func (c *schedulerCache) AddCluster(cluster *Cluster) error {

--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/interface.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/interface.go
@@ -34,5 +34,6 @@ type Cache interface {
 	AddProvision(string, string, []*Slice) error
 	RemoveProvision(string, string) error
 	UpdateClusterCapacity(string, v1.ResourceList) error
+	SnapshotForNamespaceSched(...*Namespace) (*NamespaceSchedSnapshot, error)
 	Dump() string
 }

--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/snapshot.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/snapshot.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func MaxAlloc(a v1.ResourceList, b v1.ResourceList) v1.ResourceList {
+	ret := a.DeepCopy()
+	for key, value1 := range a {
+		value2 := b[key]
+		if value1.Cmp(value2) < 0 {
+			ret[key] = value2.DeepCopy()
+		}
+	}
+	return ret
+}
+
+type ClusterUsage struct {
+	capacity  v1.ResourceList
+	alloc     v1.ResourceList
+	provision v1.ResourceList
+}
+
+type NamespaceSchedSnapshot struct {
+	clusterUsageMap map[string]*ClusterUsage
+}
+
+func (s *NamespaceSchedSnapshot) AddSlices(slices []*Slice) error {
+	for _, each := range slices {
+		cur, exists := s.clusterUsageMap[each.cluster]
+		if !exists {
+			return fmt.Errorf("slices are added to nonexistence cluster")
+		}
+		for k, v := range each.unit {
+			val := cur.alloc[k].DeepCopy()
+			val.Add(v)
+			cur.alloc[k] = val
+		}
+	}
+	return nil
+}
+
+func (s *NamespaceSchedSnapshot) RemoveSlices(slices []*Slice) error {
+	for _, each := range slices {
+		cur, exists := s.clusterUsageMap[each.cluster]
+		if !exists {
+			continue
+		}
+		for k, v := range each.unit {
+			val := cur.alloc[k].DeepCopy()
+			if val.Cmp(v) == -1 {
+				return fmt.Errorf("slices removal causes negative allocation")
+			}
+			val.Sub(v)
+			cur.alloc[k] = val
+		}
+	}
+	return nil
+}
+
+func NewNamespaceSchedSnapshot() *NamespaceSchedSnapshot {
+	return &NamespaceSchedSnapshot{
+		clusterUsageMap: make(map[string]*ClusterUsage),
+	}
+}
+
+func (c *schedulerCache) SnapshotForNamespaceSched(nsToRemove ...*Namespace) (*NamespaceSchedSnapshot, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	s := NewNamespaceSchedSnapshot()
+	for n, cluster := range c.clusters {
+		if cluster.shadow {
+			continue
+		}
+		s.clusterUsageMap[n] = &ClusterUsage{
+			capacity:  cluster.capacity.DeepCopy(),
+			alloc:     cluster.alloc.DeepCopy(),
+			provision: cluster.provision.DeepCopy(),
+		}
+	}
+
+	// in case of rescheduling, the old namespace needs to be removed from the snapshot
+	for _, each := range nsToRemove {
+		if each == nil {
+			continue
+		}
+		curState, exists := c.namespaces[each.GetKey()]
+		if !exists {
+			continue
+		}
+		var slicesToRemove []*Slice
+		for cluster, _ := range curState.GetPlacementMap() {
+			if _, exists := s.clusterUsageMap[cluster]; !exists {
+				continue
+			}
+			if _, exists := c.clusters[cluster].allocItems[each.GetKey()]; !exists {
+				return nil, fmt.Errorf("fatal: cache is inconsistent")
+			}
+			slicesToRemove = append(slicesToRemove, c.clusters[cluster].allocItems[each.GetKey()]...)
+		}
+		if err := s.RemoveSlices(slicesToRemove); err != nil {
+			return nil, err
+		}
+	}
+	return s, nil
+}

--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/snapshot_test.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/snapshot_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestSnapshotForNamespaceSched(t *testing.T) {
+	defaultCapacity := v1.ResourceList{
+		"cpu":    resource.MustParse("4"),
+		"memory": resource.MustParse("8Gi"),
+	}
+
+	defaultQuota := v1.ResourceList{
+		"cpu":    resource.MustParse("2"),
+		"memory": resource.MustParse("4Gi"),
+	}
+
+	defaultQuotaSlice := v1.ResourceList{
+		"cpu":    resource.MustParse("0.5"),
+		"memory": resource.MustParse("1Gi"),
+	}
+
+	stop := make(chan struct{})
+	cache := NewSchedulerCache(stop).(*schedulerCache)
+
+	cluster1 := NewCluster(defaultCluster1, nil, defaultCapacity)
+	cluster2 := NewCluster(defaultCluster2, nil, defaultCapacity)
+
+	cache.AddCluster(cluster1)
+	cache.AddCluster(cluster2)
+
+	testcases := map[string]struct {
+		namespace    *Namespace
+		remove       bool
+		provision    map[string]v1.ResourceList
+		snapAllocMax map[string]v1.ResourceList
+	}{
+		"Snapshot with one namespace, two clusters": {
+			namespace: NewNamespace(defaultTenant, defaultNamespace, nil, defaultQuota, defaultQuotaSlice,
+				[]*Placement{
+					NewPlacement(defaultCluster1, 3),
+					NewPlacement(defaultCluster2, 1),
+				}),
+			remove: false,
+			provision: map[string]v1.ResourceList{
+				defaultCluster1: nil,
+				defaultCluster2: nil,
+			},
+			snapAllocMax: map[string]v1.ResourceList{
+				defaultCluster1: v1.ResourceList{
+					"cpu":    resource.MustParse("1.5"),
+					"memory": resource.MustParse("3Gi"),
+				},
+				defaultCluster2: v1.ResourceList{
+					"cpu":    resource.MustParse("0.5"),
+					"memory": resource.MustParse("1Gi"),
+				},
+			},
+		},
+
+		"Snapshot with one namespace, and a shadow cluster": {
+			namespace: NewNamespace(defaultTenant, defaultNamespace, nil, defaultQuota, defaultQuotaSlice,
+				[]*Placement{
+					NewPlacement(defaultCluster1, 2),
+					NewPlacement("shadow", 2),
+				}),
+			remove: false,
+			provision: map[string]v1.ResourceList{
+				defaultCluster1: nil,
+				defaultCluster2: nil,
+			},
+			snapAllocMax: map[string]v1.ResourceList{
+				defaultCluster1: v1.ResourceList{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2Gi"),
+				},
+				defaultCluster2: v1.ResourceList{
+					"cpu":    resource.MustParse("0"),
+					"memory": resource.MustParse("0"),
+				},
+			},
+		},
+
+		"Snapshot with one namespace, and a pre-provisioned cluster": {
+			namespace: NewNamespace(defaultTenant, defaultNamespace, nil, defaultQuota, defaultQuotaSlice,
+				[]*Placement{
+					NewPlacement(defaultCluster1, 2),
+					NewPlacement(defaultCluster2, 2),
+				}),
+			remove: false,
+			provision: map[string]v1.ResourceList{
+				defaultCluster1: nil,
+				defaultCluster2: v1.ResourceList{
+					"cpu":    resource.MustParse("4"),
+					"memory": resource.MustParse("1Gi"),
+				},
+			},
+			snapAllocMax: map[string]v1.ResourceList{
+				defaultCluster1: v1.ResourceList{
+					"cpu":    resource.MustParse("1"),
+					"memory": resource.MustParse("2Gi"),
+				},
+				defaultCluster2: v1.ResourceList{
+					"cpu":    resource.MustParse("4"),
+					"memory": resource.MustParse("2Gi"),
+				},
+			},
+		},
+
+		"Snapshot with one namespace (to be removed), and a provisioned cluster": {
+			namespace: NewNamespace(defaultTenant, defaultNamespace, nil, defaultQuota, defaultQuotaSlice,
+				[]*Placement{
+					NewPlacement(defaultCluster1, 2),
+					NewPlacement(defaultCluster2, 2),
+				}),
+			remove: true,
+			provision: map[string]v1.ResourceList{
+				defaultCluster1: nil,
+				defaultCluster2: v1.ResourceList{
+					"cpu":    resource.MustParse("4"),
+					"memory": resource.MustParse("1Gi"),
+				},
+			},
+			snapAllocMax: map[string]v1.ResourceList{
+				defaultCluster1: v1.ResourceList{
+					"cpu":    resource.MustParse("0"),
+					"memory": resource.MustParse("0"),
+				},
+				defaultCluster2: v1.ResourceList{
+					"cpu":    resource.MustParse("4"),
+					"memory": resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+
+	for k, tc := range testcases {
+		t.Run(k, func(t *testing.T) {
+			cache.AddNamespace(tc.namespace)
+			cache.clusters[defaultCluster1].provision = tc.provision[defaultCluster1]
+			cache.clusters[defaultCluster2].provision = tc.provision[defaultCluster2]
+			var s *NamespaceSchedSnapshot
+			if !tc.remove {
+				s, _ = cache.SnapshotForNamespaceSched()
+			} else {
+				s, _ = cache.SnapshotForNamespaceSched(tc.namespace)
+			}
+
+			max1 := MaxAlloc(s.clusterUsageMap[defaultCluster1].alloc, s.clusterUsageMap[defaultCluster1].provision)
+			max2 := MaxAlloc(s.clusterUsageMap[defaultCluster2].alloc, s.clusterUsageMap[defaultCluster2].provision)
+
+			if !Equals(max1, tc.snapAllocMax[defaultCluster1]) || !Equals(max2, tc.snapAllocMax[defaultCluster2]) {
+				t.Errorf("snapshot is wrong. Exp: %v, Got %v %v", tc.snapAllocMax, max1, max2)
+			}
+
+			if _, exists := cache.clusters["shadow"]; exists {
+				if _, exists := s.clusterUsageMap["shadow"]; exists {
+					t.Errorf("shadow cluster should not be in the snapshot")
+				}
+			}
+			cache.RemoveNamespace(tc.namespace)
+			cache.clusters[defaultCluster1].provision = nil
+			cache.clusters[defaultCluster2].provision = nil
+		})
+
+	}
+
+}

--- a/incubator/virtualcluster/experiment/pkg/scheduler/engine/schedulerengine.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/engine/schedulerengine.go
@@ -104,6 +104,8 @@ func (e *schedulerEngine) ScheduleNamespace(namespace *internalcache.Namespace) 
 	_ = GetSlicesToSchedule(namespace, oldPlacements)
 
 	var newPlacement map[string]int
+	e.cache.SnapshotForNamespaceSched(curState)
+
 	// TODO: schedule the slicesToSchedule, and update newPlacements with the result if successful
 
 	ret := namespace.DeepCopy()


### PR DESCRIPTION
This change adds snapshot support for namespace scheduling. The snapshot is one of the inputs to the algorithm. Only the cluster capacity and the total allocations are needed in the snapshot.