### PR TITLE
[HNC] Add envvar printout for debugging

### DIFF
--- a/incubator/hnc/hack/prow-e2e/Dockerfile
+++ b/incubator/hnc/hack/prow-e2e/Dockerfile
@@ -30,7 +30,9 @@ ENV CGO_ENABLED=0
 
 # Install Kind. Feel free to update this version whenever you're updating the
 # KRTE base image too.
-RUN go get sigs.k8s.io/kind@v0.9.0
+#
+# For the 'cd' thing, see https://maelvls.dev/go111module-everywhere/
+RUN (cd && go get sigs.k8s.io/kind@v0.9.0)
 
 # Add the actual script and set it as the default command for this image.
 COPY run-e2e-tests.sh run-e2e-tests.sh

--- a/incubator/hnc/hack/prow-e2e/run-e2e-tests.sh
+++ b/incubator/hnc/hack/prow-e2e/run-e2e-tests.sh
@@ -8,6 +8,8 @@ set -euf -o pipefail
 start_time="$(date -u +%s)"
 echo
 echo "Starting at $(date +%Y-%m-%d\ %H:%M:%S)"
+echo "Environment:"
+env
 
 echo
 # For periodics, we need to clone the repo ourselves. For postsubmits, it will


### PR DESCRIPTION
The postsubmits are now failing because Kind isn't in the path. Print
out all the env vars so we can figure out why.

Tested: image runs locally and prints out env. Image has already been
pushed to the registry.