### PR TITLE
[VC] Make UID in reconcile request optional

### DIFF
--- a/incubator/virtualcluster/experiment/pkg/scheduler/resource/supercluster/namespace/controller.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/resource/supercluster/namespace/controller.go
@@ -73,7 +73,7 @@ func (c *controller) Start(stopCh <-chan struct{}) error {
 }
 
 func (c *controller) GetListener() listener.ClusterChangeListener {
-	return listener.NewMCControllerListener(c.MultiClusterController)
+	return listener.NewMCControllerListener(c.MultiClusterController, mc.WatchOptions{})
 }
 
 func (c *controller) GetMCController() *mc.MultiClusterController {

--- a/incubator/virtualcluster/experiment/pkg/scheduler/resource/virtualcluster/namespace/controller.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/resource/virtualcluster/namespace/controller.go
@@ -82,7 +82,7 @@ func (c *controller) Start(stopCh <-chan struct{}) error {
 }
 
 func (c *controller) GetListener() listener.ClusterChangeListener {
-	return listener.NewMCControllerListener(c.MultiClusterController)
+	return listener.NewMCControllerListener(c.MultiClusterController, mc.WatchOptions{})
 }
 
 func (c *controller) GetMCController() *mc.MultiClusterController {

--- a/incubator/virtualcluster/experiment/pkg/scheduler/resource/virtualcluster/resourcequota/controller.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/resource/virtualcluster/resourcequota/controller.go
@@ -76,7 +76,7 @@ func (c *controller) GetMCController() *mc.MultiClusterController {
 }
 
 func (c *controller) GetListener() listener.ClusterChangeListener {
-	return listener.NewMCControllerListener(c.MultiClusterController)
+	return listener.NewMCControllerListener(c.MultiClusterController, mc.WatchOptions{})
 }
 
 func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, error) {

--- a/incubator/virtualcluster/pkg/syncer/manager/manager.go
+++ b/incubator/virtualcluster/pkg/syncer/manager/manager.go
@@ -102,7 +102,7 @@ func (b *BaseResourceSyncer) PatrollerDo() {
 }
 
 func (b *BaseResourceSyncer) GetListener() listener.ClusterChangeListener {
-	return listener.NewMCControllerListener(b.MultiClusterController)
+	return listener.NewMCControllerListener(b.MultiClusterController, mc.WatchOptions{AttachUID: true})
 }
 
 func (b *BaseResourceSyncer) GetMCController() *mc.MultiClusterController {

--- a/incubator/virtualcluster/pkg/util/handler/enqueue_object.go
+++ b/incubator/virtualcluster/pkg/util/handler/enqueue_object.go
@@ -25,6 +25,7 @@ import (
 type EnqueueRequestForObject struct {
 	ClusterName string
 	Queue       Queue
+	AttachUID   bool
 }
 
 func (e *EnqueueRequestForObject) enqueue(obj interface{}) {
@@ -37,7 +38,9 @@ func (e *EnqueueRequestForObject) enqueue(obj interface{}) {
 	r.ClusterName = e.ClusterName
 	r.Namespace = o.GetNamespace()
 	r.Name = o.GetName()
-	r.UID = string(o.GetUID())
+	if e.AttachUID {
+		r.UID = string(o.GetUID())
+	}
 
 	e.Queue.Add(r)
 }

--- a/incubator/virtualcluster/pkg/util/handler/enqueue_object_test.go
+++ b/incubator/virtualcluster/pkg/util/handler/enqueue_object_test.go
@@ -56,6 +56,7 @@ func TestEnqueueRequestForObject(t *testing.T) {
 	queue := &EnqueueRequestForObject{
 		ClusterName: clusterName,
 		Queue:       internalQueue,
+		AttachUID:   true,
 	}
 
 	queue.OnAdd(invalidAPIObject{A: "a"})

--- a/incubator/virtualcluster/pkg/util/listener/adapter.go
+++ b/incubator/virtualcluster/pkg/util/listener/adapter.go
@@ -24,17 +24,18 @@ import (
 
 type MCControllerListener struct {
 	c *mc.MultiClusterController
+	o mc.WatchOptions
 }
 
 var _ ClusterChangeListener = &MCControllerListener{}
 
-func NewMCControllerListener(c *mc.MultiClusterController) ClusterChangeListener {
-	return &MCControllerListener{c: c}
+func NewMCControllerListener(c *mc.MultiClusterController, o mc.WatchOptions) ClusterChangeListener {
+	return &MCControllerListener{c: c, o: o}
 }
 
 func (m MCControllerListener) AddCluster(cluster mc.ClusterInterface) {
 	klog.Infof("%s add cluster %s for %s resource", m.c.GetControllerName(), cluster.GetClusterName(), m.c.GetObjectKind())
-	err := m.c.RegisterClusterResource(cluster, mc.WatchOptions{})
+	err := m.c.RegisterClusterResource(cluster, m.o)
 	if err != nil {
 		klog.Errorf("failed to add cluster %s %s event: %v", cluster.GetClusterName(), m.c.GetObjectKind(), err)
 	}
@@ -47,7 +48,7 @@ func (m MCControllerListener) RemoveCluster(cluster mc.ClusterInterface) {
 
 func (m MCControllerListener) WatchCluster(cluster mc.ClusterInterface) {
 	klog.Infof("%s watch cluster %s for %s resource", m.c.GetControllerName(), cluster.GetClusterName(), m.c.GetObjectKind())
-	err := m.c.WatchClusterResource(cluster, mc.WatchOptions{})
+	err := m.c.WatchClusterResource(cluster, m.o)
 	if err != nil {
 		klog.Errorf("failed to watch cluster %s %s event: %v", cluster.GetClusterName(), m.c.GetObjectKind(), err)
 	}

--- a/incubator/virtualcluster/pkg/util/mccontroller/mccontroller.go
+++ b/incubator/virtualcluster/pkg/util/mccontroller/mccontroller.go
@@ -149,6 +149,7 @@ func NewMCController(objectType, objectListType runtime.Object, rc reconciler.DW
 // WatchOptions is used as an argument of WatchResource methods (just a placeholder for now).
 // TODO: consider implementing predicates.
 type WatchOptions struct {
+	AttachUID bool // the object UID will be added to the reconciler request if it is true
 }
 
 // WatchClusterResource configures the Controller to watch resources of the same Kind as objectType,
@@ -165,7 +166,7 @@ func (c *MultiClusterController) WatchClusterResource(cluster ClusterInterface, 
 		return nil
 	}
 
-	h := &handler.EnqueueRequestForObject{ClusterName: cluster.GetClusterName(), Queue: c.Queue}
+	h := &handler.EnqueueRequestForObject{ClusterName: cluster.GetClusterName(), Queue: c.Queue, AttachUID: o.AttachUID}
 	return cluster.AddEventHandler(c.objectType, h)
 }
 


### PR DESCRIPTION
In Syncer, the UID has to be put in the reconcile request to make the objects in super cluster and tenant control plane consistent. But in scheduler, adding UID in reconcile request may lead to parallel scheduling for Pods with the same name but different UIDs (think of a case where a Pod is created/deleted/created).

In this change, the scheduler reconcile request will exclude the Pod UID. 