### PR TITLE
[VC] Clean up: Remove UID from Pod in scheduler cache

### DIFF
--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/cluster_test.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/cluster_test.go
@@ -298,7 +298,7 @@ func TestDeepCopy(t *testing.T) {
 	}
 
 	cluster := NewCluster(defaultCluster, map[string]string{"k": "v"}, defaultCapacity)
-	pod := NewPod("tenant", defaultNamespace, "pod-1", "123456", defaultCluster, defaultRequest)
+	pod := NewPod("tenant", defaultNamespace, "pod-1", defaultCluster, defaultRequest)
 
 	cluster.AddPod(pod)
 	slices := []*Slice{NewSlice(defaultNamespace, defaultQuotaSlice, defaultCluster)}

--- a/incubator/virtualcluster/experiment/pkg/scheduler/cache/pod.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/cache/pod.go
@@ -27,26 +27,20 @@ type Pod struct {
 	owner     string //tenant cluster name
 	namespace string
 	name      string
-	uid       string
 
 	request v1.ResourceList
 
 	cluster string // the scheduled cluster
 }
 
-func NewPod(owner, namespace, name, uid, cluster string, request v1.ResourceList) *Pod {
+func NewPod(owner, namespace, name, cluster string, request v1.ResourceList) *Pod {
 	return &Pod{
 		owner:     owner,
 		namespace: namespace,
 		name:      name,
-		uid:       uid,
 		request:   request,
 		cluster:   cluster,
 	}
-}
-
-func (p *Pod) GetUID() string {
-	return p.uid
 }
 
 func (p *Pod) GetCluster() string {
@@ -62,7 +56,7 @@ func (p *Pod) SetCluster(cluster string) {
 }
 
 func (p *Pod) DeepCopy() *Pod {
-	return NewPod(p.owner, p.namespace, p.name, p.uid, p.cluster, p.request.DeepCopy())
+	return NewPod(p.owner, p.namespace, p.name, p.cluster, p.request.DeepCopy())
 }
 
 func (p *Pod) GetNamespaceKey() string {
@@ -78,7 +72,6 @@ func (p *Pod) Dump() string {
 		"Owner":     p.owner,
 		"Namespace": p.namespace,
 		"Name":      p.name,
-		"UID":       p.uid,
 		"Cluster":   p.cluster,
 		"Request":   p.request,
 	}

--- a/incubator/virtualcluster/experiment/pkg/scheduler/engine/schedulerengine.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/engine/schedulerengine.go
@@ -33,7 +33,6 @@ type Engine interface {
 	DeScheduleNamespace(key string) error
 	SchedulePod(pod *internalcache.Pod) (*internalcache.Pod, error)
 	DeSchedulePod(key string) error
-	GetPod(key string) *internalcache.Pod
 }
 
 var _ Engine = &schedulerEngine{}
@@ -201,10 +200,4 @@ func (e *schedulerEngine) DeSchedulePod(key string) error {
 		klog.V(4).Infof("the pod %s has been removed, deschedule is not needed", key)
 	}
 	return nil
-}
-
-func (e *schedulerEngine) GetPod(key string) *internalcache.Pod {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	return e.cache.GetPod(key)
 }

--- a/incubator/virtualcluster/experiment/pkg/scheduler/resource/virtualcluster/pod/controller.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/resource/virtualcluster/pod/controller.go
@@ -119,7 +119,7 @@ func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, e
 		return reconciler.Result{}, nil
 	}
 
-	candidate := internalcache.NewPod(request.ClusterName, pod.Namespace, pod.Name, string(pod.UID), "", util.GetPodRequirements(pod))
+	candidate := internalcache.NewPod(request.ClusterName, pod.Namespace, pod.Name, "", util.GetPodRequirements(pod))
 	ret, err := c.SchedulerEngine.SchedulePod(candidate)
 	if err != nil {
 		return reconciler.Result{}, fmt.Errorf("failed to schedule pod %s in %s: %v", request.Name, request.ClusterName, err)

--- a/incubator/virtualcluster/experiment/pkg/scheduler/util/helper.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/util/helper.go
@@ -372,7 +372,7 @@ func SyncVirtualClusterState(metaClient clientset.Interface, vc *v1alpha1.Virtua
 				// TODO: Pod scheduling result is inconsistent, we need to delete the Pod or send warnings.
 				continue
 			}
-			cPod := internalcache.NewPod(clustername, each.Name, pod.Name, string(pod.UID), supercluster, GetPodRequirements(&pod))
+			cPod := internalcache.NewPod(clustername, each.Name, pod.Name, supercluster, GetPodRequirements(&pod))
 			// If the pod already exists, AddPod will update the cache with latest schedule.
 			if err := cache.AddPod(cPod); err != nil {
 				return fmt.Errorf("failed to add pod to cache: %s/%s/%s with error %v", clustername, each.Name, pod.Name, err)


### PR DESCRIPTION
This change removes Pod UID from scheduler cache since it is not used anyway. The unused GetPod method is also removed from the Engine interface.