### PR TITLE
[VC] fix: only check known cluster in differ

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/patrol/differ/handler.go
+++ b/incubator/virtualcluster/pkg/syncer/patrol/differ/handler.go
@@ -86,19 +86,19 @@ func (h FilteringHandler) OnDelete(obj ClusterObject) {
 	h.Handler.OnDelete(obj)
 }
 
-func DefaultDifferFilter(blockedClusterSet sets.String) func(obj ClusterObject) bool {
+func DefaultDifferFilter(knownClusterSet sets.String) func(obj ClusterObject) bool {
 	return func(obj ClusterObject) bool {
 		// vObj
 		if obj.OwnerCluster != "" {
-			if blockedClusterSet.Has(obj.OwnerCluster) {
-				return false
+			if knownClusterSet.Has(obj.OwnerCluster) {
+				return true
 			}
-			return true
+			return false
 		}
 
 		// pObj
 		clusterName, vNamespace := conversion.GetVirtualOwner(obj)
-		if clusterName != "" && vNamespace != "" && !blockedClusterSet.Has(clusterName) {
+		if clusterName != "" && vNamespace != "" && knownClusterSet.Has(clusterName) {
 			return true
 		}
 		return false

--- a/incubator/virtualcluster/pkg/syncer/resources/endpoints/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/endpoints/checker.go
@@ -67,13 +67,13 @@ func (c *controller) PatrollerDo() {
 		pSet.Insert(differ.ClusterObject{Object: p, Key: differ.DefaultClusterObjectKey(p, "")})
 	}
 
-	blockedClusterSet := sets.NewString()
+	knownClusterSet := sets.NewString(clusterNames...)
 	vSet := differ.NewDiffSet()
 	for _, cluster := range clusterNames {
 		listObj, err := c.MultiClusterController.List(cluster)
 		if err != nil {
 			klog.Errorf("error listing endpoints from cluster %s informer cache: %v", cluster, err)
-			blockedClusterSet.Insert(cluster)
+			knownClusterSet.Delete(cluster)
 			continue
 		}
 		vList := listObj.(*v1.EndpointsList)
@@ -104,7 +104,7 @@ func (c *controller) PatrollerDo() {
 
 	vSet.Difference(pSet, differ.FilteringHandler{
 		Handler:    d,
-		FilterFunc: differ.DefaultDifferFilter(blockedClusterSet),
+		FilterFunc: differ.DefaultDifferFilter(knownClusterSet),
 	})
 
 	metrics.CheckerMissMatchStats.WithLabelValues("MissingEndPoints").Set(float64(numMissingEndPoints))

--- a/incubator/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/persistentvolumeclaim/checker.go
@@ -66,13 +66,13 @@ func (c *controller) PatrollerDo() {
 		pSet.Insert(differ.ClusterObject{Object: p, Key: differ.DefaultClusterObjectKey(p, "")})
 	}
 
-	blockedClusterSet := sets.NewString()
+	knownClusterSet := sets.NewString(clusterNames...)
 	vSet := differ.NewDiffSet()
 	for _, cluster := range clusterNames {
 		listObj, err := c.MultiClusterController.List(cluster)
 		if err != nil {
 			klog.Errorf("error listing pvc from cluster %s informer cache: %v", cluster, err)
-			blockedClusterSet.Insert(cluster)
+			knownClusterSet.Delete(cluster)
 			continue
 		}
 		vList := listObj.(*v1.PersistentVolumeClaimList)
@@ -125,7 +125,7 @@ func (c *controller) PatrollerDo() {
 
 	vSet.Difference(pSet, differ.FilteringHandler{
 		Handler:    d,
-		FilterFunc: differ.DefaultDifferFilter(blockedClusterSet),
+		FilterFunc: differ.DefaultDifferFilter(knownClusterSet),
 	})
 
 	metrics.CheckerMissMatchStats.WithLabelValues("MissMatchedPVCs").Set(float64(numMissMatchedPVCs))

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/checker.go
@@ -152,13 +152,13 @@ func (c *controller) PatrollerDo() {
 		pSet.Insert(differ.ClusterObject{Object: p, Key: differ.DefaultClusterObjectKey(p, "")})
 	}
 
-	blockedClusterSet := sets.NewString()
+	knownClusterSet := sets.NewString(clusterNames...)
 	vSet := differ.NewDiffSet()
 	for _, cluster := range clusterNames {
 		listObj, err := c.MultiClusterController.List(cluster)
 		if err != nil {
 			klog.Errorf("error listing pod from cluster %s informer cache: %v", cluster, err)
-			blockedClusterSet.Insert(cluster)
+			knownClusterSet.Insert(cluster)
 			continue
 		}
 		vList := listObj.(*v1.PodList)
@@ -284,7 +284,7 @@ func (c *controller) PatrollerDo() {
 					c.updateClusterVNodePodMap(obj.GetOwnerCluster(), vPod.Spec.NodeName, string(vPod.UID), reconciler.UpdateEvent)
 				}
 			}
-			return differ.DefaultDifferFilter(blockedClusterSet)(obj)
+			return differ.DefaultDifferFilter(knownClusterSet)(obj)
 		},
 	})
 

--- a/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/serviceaccount/checker.go
@@ -61,13 +61,13 @@ func (c *controller) PatrollerDo() {
 		pSet.Insert(differ.ClusterObject{Object: p, Key: differ.DefaultClusterObjectKey(p, "")})
 	}
 
-	blockedClusterSet := sets.NewString()
+	knownClusterSet := sets.NewString(clusterNames...)
 	vSet := differ.NewDiffSet()
 	for _, cluster := range clusterNames {
 		listObj, err := c.MultiClusterController.List(cluster)
 		if err != nil {
 			klog.Errorf("error listing serviceaccount from cluster %s informer cache: %v", cluster, err)
-			blockedClusterSet.Insert(cluster)
+			knownClusterSet.Insert(cluster)
 			continue
 		}
 		vList := listObj.(*v1.ServiceAccountList)
@@ -110,6 +110,6 @@ func (c *controller) PatrollerDo() {
 
 	vSet.Difference(pSet, differ.FilteringHandler{
 		Handler:    d,
-		FilterFunc: differ.DefaultDifferFilter(blockedClusterSet),
+		FilterFunc: differ.DefaultDifferFilter(knownClusterSet),
 	})
 }


### PR DESCRIPTION
if the cluster cache is not loaded, vSet is missing them,
but pSet object is exists, differ will delete the pObj.
left the redundant object gc by ns checker.

Signed-off-by: zhuangqh <zhuangqhc@gmail.com>