### PR TITLE
[vc] adding support for vn-agent log follow

### DIFF
--- a/incubator/virtualcluster/pkg/vn-agent/server/translate.go
+++ b/incubator/virtualcluster/pkg/vn-agent/server/translate.go
@@ -47,6 +47,10 @@ func translateRawQuery(req *restful.Request, containerName string) {
 		switch k {
 		case "command":
 			query.Add("command", v[0])
+		case "follow":
+			if v[0] == "true" {
+				query.Add("follow", "true")
+			}
 		case "input":
 			if v[0] == "1" {
 				query.Add("stdin", "true")


### PR DESCRIPTION
This adds support for `--follow` and `-f` to the vn-agent.

Signed-off-by: Chris Hein <me@chrishein.com>