### PR TITLE
[VC] Adding support for vn-agent to have featuregates via flags

### DIFF
--- a/incubator/virtualcluster/cmd/syncer/app/options/options.go
+++ b/incubator/virtualcluster/cmd/syncer/app/options/options.go
@@ -107,7 +107,7 @@ func (o *ResourceSyncerOptions) Flags() cliflag.NamedFlagSets {
 	fs.StringSliceVar(&o.ComponentConfig.DefaultOpaqueMetaDomains, "default-opaque-meta-domains", o.ComponentConfig.DefaultOpaqueMetaDomains, "DefaultOpaqueMetaDomains is the default opaque meta configuration for each Virtual Cluster.")
 	fs.StringSliceVar(&o.ComponentConfig.ExtraSyncingResources, "extra-syncing-resources", o.ComponentConfig.ExtraSyncingResources, "ExtraSyncingResources defines additional resources that need to be synced for each Virtual Cluster. (priorityclass, ingress, crd)")
 	fs.Int32Var(&o.ComponentConfig.VNAgentPort, "vn-agent-port", 10550, "Port the vn-agent listens on")
-	fs.Var(cliflag.NewMapStringBool(&o.ComponentConfig.FeatureGates), "feature-gates", "A set of key=value pairs that describe featuregate gates for various features. ")
+	fs.Var(cliflag.NewMapStringBool(&o.ComponentConfig.FeatureGates), "feature-gates", "A set of key=value pairs that describe featuregate gates for various features.")
 
 	serverFlags := fss.FlagSet("metricsServer")
 	serverFlags.StringVar(&o.Address, "address", o.Address, "The server address.")

--- a/incubator/virtualcluster/cmd/syncer/builtins_extra.go
+++ b/incubator/virtualcluster/cmd/syncer/builtins_extra.go
@@ -17,7 +17,7 @@ limitations under the License.
 package main
 
 import (
+	_ "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/resources/crd"
 	_ "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/resources/ingress"
 	_ "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/resources/priorityclass"
-	_ "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/resources/crd"
 )


### PR DESCRIPTION
This adds support for the vn-agent to support getting `featuregates` in later PRs I'll have a new feature added into the vn-agent for customized native vnode objects. 

Signed-off-by: Chris Hein <me@chrishein.com>