### PR TITLE
[VC] Use event sinker in mccontroller

### DIFF
--- a/incubator/virtualcluster/experiment/pkg/scheduler/resource/virtualcluster/namespace/controller.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/resource/virtualcluster/namespace/controller.go
@@ -164,6 +164,12 @@ func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, e
 	// some (or all) slices need to be scheduled/rescheduled
 	ret, err := c.SchedulerEngine.ScheduleNamespace(candidate)
 	if err != nil {
+		c.MultiClusterController.Eventf(request.ClusterName, &v1.ObjectReference{
+			Kind:      "Namespace",
+			Name:      namespace.Name,
+			Namespace: namespace.Name,
+			UID:       namespace.UID,
+		}, v1.EventTypeNormal, "Failed", "Failed to schedule namespace %s: %v", request.Name, err)
 		return reconciler.Result{}, fmt.Errorf("failed to schedule namespace %s in %s: %v", request.Name, request.ClusterName, err)
 	}
 	// update virtualcluster namespace with the scheduling result.
@@ -189,6 +195,12 @@ func (c *controller) Reconcile(request reconciler.Request) (reconciler.Result, e
 	})
 	if err == nil {
 		klog.Infof("Successfully schedule namespace %s/%s with placement %s", request.ClusterName, request.Name, string(updatedPlacement))
+		err = c.MultiClusterController.Eventf(request.ClusterName, &v1.ObjectReference{
+			Kind:      "Namespace",
+			Name:      namespace.Name,
+			Namespace: namespace.Name,
+			UID:       namespace.UID,
+		}, v1.EventTypeNormal, "Scheduled", "Successfully schedule namespace %s with placement %s", request.Name, string(updatedPlacement))
 	}
 	return reconciler.Result{}, err
 }

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/dws.go
@@ -80,6 +80,7 @@ func (c *controller) Reconcile(request reconciler.Request) (res reconciler.Resul
 			}
 			c.MultiClusterController.Eventf(request.ClusterName, &v1.ObjectReference{
 				Kind:      "Pod",
+				Name:      vPod.Name,
 				Namespace: vPod.Namespace,
 				UID:       vPod.UID,
 			}, v1.EventTypeWarning, "FailedCreate", "Error creating: %v", err)
@@ -164,6 +165,7 @@ func (c *controller) reconcilePodCreate(clusterName, targetNamespace, requestUID
 		// For now, we skip vPod that has NodeName set to prevent tenant from deploying DaemonSet or DaemonSet alike CRDs.
 		err := c.MultiClusterController.Eventf(clusterName, &v1.ObjectReference{
 			Kind:      "Pod",
+			Name:      vPod.Name,
 			Namespace: vPod.Namespace,
 			UID:       vPod.UID,
 		}, v1.EventTypeWarning, "NotSupported", "The Pod has nodeName set in the spec which is not supported for now")

--- a/incubator/virtualcluster/pkg/util/record/event.go
+++ b/incubator/virtualcluster/pkg/util/record/event.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package record
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	clientgorecord "k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/record/util"
+)
+
+type EventSinker struct {
+	correlator *clientgorecord.EventCorrelator
+}
+
+var EventSinkerInstance = NewEventSinker(clientgorecord.CorrelatorOptions{})
+
+func NewEventSinker(options clientgorecord.CorrelatorOptions) *EventSinker {
+	return &EventSinker{correlator: clientgorecord.NewEventCorrelatorWithOptions(options)}
+}
+
+func (e *EventSinker) RecordToSink(sink clientgorecord.EventSink, event *v1.Event) error {
+	var newEvent *v1.Event
+	var err error
+
+	result, err := e.correlator.EventCorrelate(event)
+	if err != nil {
+		return err
+	}
+	if result.Skip {
+		return nil
+	}
+
+	updateExisting := result.Event.Count > 1
+	if updateExisting {
+		newEvent, err = sink.Patch(result.Event, result.Patch)
+	}
+	// Update can fail because the event may have been removed and it no longer exists.
+	if !updateExisting || (updateExisting && util.IsKeyNotFoundError(err)) {
+		// Making sure that ResourceVersion is empty on creation
+		event.ResourceVersion = ""
+		newEvent, err = sink.Create(result.Event)
+	}
+	if err == nil {
+		// we need to update our event correlator with the server returned state to handle name/resourceversion
+		e.correlator.UpdateState(newEvent)
+		return nil
+	}
+
+	if errors.IsAlreadyExists(err) {
+		return nil
+	}
+	return err
+}


### PR DESCRIPTION
This change uses client-go EventCorrelator to filter/throttle the same/similar events sent to the tenant control plane.

This change does not use the client-go EventBroadcaster since it uses a heavy weight event dispatch mechanism and it has to be created for each tenant control plane, which means the event cache (a fixed size LRU cache) has to be duplicated for every tenant control plane.

In this implementation, one event cache is used by all tenant control planes with a default 4K entries. Later, we can make the cache size configurable if there are too many virtual clusters.

The scheduler uses the event sinker to notify the tenant control plane about the scheduling result. For example:

```
kubectl get event -A --kubeconfig=vc-sample-1.kubeconfig
NAMESPACE   LAST SEEN   TYPE     REASON      OBJECT      MESSAGE
test        24s         Normal   Scheduled   namespace   Successfully schedule namespace test with placement {"root-cluster-00001":1}
```