### PR TITLE
[VC] Adding vn-agent deployment feature

### DIFF
--- a/incubator/virtualcluster/cmd/syncer/app/options/options.go
+++ b/incubator/virtualcluster/cmd/syncer/app/options/options.go
@@ -83,9 +83,11 @@ func NewResourceSyncerOptions() (*ResourceSyncerOptions, error) {
 			DefaultOpaqueMetaDomains:   []string{"kubernetes.io", "k8s.io"},
 			ExtraSyncingResources:      []string{},
 			VNAgentPort:                int32(10550),
+			VNAgentNamespacedName:      "vc-manager/vn-agent",
 			FeatureGates: map[string]bool{
 				featuregate.SuperClusterPooling:        false,
 				featuregate.SuperClusterServiceNetwork: false,
+				featuregate.VNodeProviderService:       false,
 			},
 		},
 		SyncerName: "vc",
@@ -106,8 +108,9 @@ func (o *ResourceSyncerOptions) Flags() cliflag.NamedFlagSets {
 	fs.BoolVar(&o.ComponentConfig.DisableServiceAccountToken, "disable-service-account-token", o.ComponentConfig.DisableServiceAccountToken, "DisableServiceAccountToken indicates whether disable service account token automatically mounted.")
 	fs.StringSliceVar(&o.ComponentConfig.DefaultOpaqueMetaDomains, "default-opaque-meta-domains", o.ComponentConfig.DefaultOpaqueMetaDomains, "DefaultOpaqueMetaDomains is the default opaque meta configuration for each Virtual Cluster.")
 	fs.StringSliceVar(&o.ComponentConfig.ExtraSyncingResources, "extra-syncing-resources", o.ComponentConfig.ExtraSyncingResources, "ExtraSyncingResources defines additional resources that need to be synced for each Virtual Cluster. (priorityclass, ingress, crd)")
-	fs.Int32Var(&o.ComponentConfig.VNAgentPort, "vn-agent-port", 10550, "Port the vn-agent listens on")
 	fs.Var(cliflag.NewMapStringBool(&o.ComponentConfig.FeatureGates), "feature-gates", "A set of key=value pairs that describe featuregate gates for various features.")
+	fs.Int32Var(&o.ComponentConfig.VNAgentPort, "vn-agent-port", 10550, "Port the vn-agent listens on")
+	fs.StringVar(&o.ComponentConfig.VNAgentNamespacedName, "vn-agent-namespace-name", "vc-manager/vn-agent", "Namespace/Name of the vn-agent running in cluster, used for VNodeProviderService")
 
 	serverFlags := fss.FlagSet("metricsServer")
 	serverFlags.StringVar(&o.Address, "address", o.Address, "The server address.")

--- a/incubator/virtualcluster/pkg/syncer/apis/config/types.go
+++ b/incubator/virtualcluster/pkg/syncer/apis/config/types.go
@@ -54,6 +54,10 @@ type SyncerConfiguration struct {
 	// VNAgentPort defines the port that the VN Agent is running on per host
 	VNAgentPort int32
 
+	// VNAgentNamespacedName defines the namespace/name of the VN Agent Kubernetes
+	// service, this is used for feature VNodeProviderService.
+	VNAgentNamespacedName string
+
 	// FeatureGates enabled by the user.
 	FeatureGates map[string]bool
 

--- a/incubator/virtualcluster/pkg/syncer/resources/node/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/node/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/manager"
 	uw "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/uwcontroller"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/vnode"
-	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/vnode/native"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/vnode/provider"
 	mc "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/util/mccontroller"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/util/plugin"
 )
@@ -59,7 +59,7 @@ type controller struct {
 	// super master node lister/synced function
 	nodeLister    listersv1.NodeLister
 	nodeSynced    cache.InformerSynced
-	vnodeProvider vnode.VirtualNodeProvider
+	vnodeProvider provider.VirtualNodeProvider
 }
 
 func NewNodeController(config *config.SyncerConfiguration,
@@ -74,7 +74,7 @@ func NewNodeController(config *config.SyncerConfiguration,
 		},
 		nodeNameToCluster: make(map[string]map[string]struct{}),
 		nodeClient:        client.CoreV1(),
-		vnodeProvider:     native.NewNativeVirtualNodeProvider(config.VNAgentPort),
+		vnodeProvider:     vnode.GetNodeProvider(config, client),
 	}
 
 	var err error
@@ -120,7 +120,7 @@ func NewNodeController(config *config.SyncerConfiguration,
 	return c, nil
 }
 
-func (c *controller) SetVNodeProvider(provider vnode.VirtualNodeProvider) {
+func (c *controller) SetVNodeProvider(provider provider.VirtualNodeProvider) {
 	c.Lock()
 	c.vnodeProvider = provider
 	c.Unlock()

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ import (
 	pa "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/patrol"
 	uw "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/uwcontroller"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/vnode"
-	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/vnode/native"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/vnode/provider"
 	mc "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/util/mccontroller"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/util/plugin"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/util/reconciler"
@@ -74,7 +74,7 @@ type controller struct {
 	clusterVNodeGCMap  map[string]map[string]VNodeGCStatus
 	vNodeGCGracePeriod time.Duration
 	// vnodeProvider manages vnode object.
-	vnodeProvider vnode.VirtualNodeProvider
+	vnodeProvider provider.VirtualNodeProvider
 }
 
 type VirtulNodeDeletionPhase string
@@ -104,7 +104,7 @@ func NewPodController(config *config.SyncerConfiguration,
 		clusterVNodePodMap: make(map[string]map[string]map[string]struct{}),
 		clusterVNodeGCMap:  make(map[string]map[string]VNodeGCStatus),
 		vNodeGCGracePeriod: constants.DefaultvNodeGCGracePeriod,
-		vnodeProvider:      native.NewNativeVirtualNodeProvider(config.VNAgentPort),
+		vnodeProvider:      vnode.GetNodeProvider(config, client),
 	}
 
 	var err error
@@ -268,7 +268,7 @@ func (c *controller) updateClusterVNodePodMap(clusterName, nodeName, requestUID 
 	}
 }
 
-func (c *controller) SetVNodeProvider(provider vnode.VirtualNodeProvider) {
+func (c *controller) SetVNodeProvider(provider provider.VirtualNodeProvider) {
 	c.Lock()
 	c.vnodeProvider = provider
 	c.Unlock()

--- a/incubator/virtualcluster/pkg/syncer/util/featuregate/gate.go
+++ b/incubator/virtualcluster/pkg/syncer/util/featuregate/gate.go
@@ -40,11 +40,17 @@ const (
 	// SuperClusterPooling is an experimental feature that allows the syncer to
 	// pool multiple super clusters for use with the experimental scheduler
 	SuperClusterPooling = "SuperClusterPooling"
+
+	// VNodeProviderService is an experimental feature that allows the
+	// vn-agent to run as a load balanced deployment proxy to the super
+	// cluster API Server
+	VNodeProviderService = "VNodeProviderService"
 )
 
 var defaultFeatures = FeatureList{
 	SuperClusterPooling:        {Default: false},
 	SuperClusterServiceNetwork: {Default: false},
+	VNodeProviderService:       {Default: false},
 }
 
 type Feature string

--- a/incubator/virtualcluster/pkg/syncer/vnode/provider/provider.go
+++ b/incubator/virtualcluster/pkg/syncer/vnode/provider/provider.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+// NodeProvider is the interface used for registering the node address.
+type VirtualNodeProvider interface {
+	GetNodeDaemonEndpoints(node *v1.Node) (v1.NodeDaemonEndpoints, error)
+	GetNodeAddress(node *v1.Node) ([]v1.NodeAddress, error)
+}

--- a/incubator/virtualcluster/pkg/syncer/vnode/service/provider_test.go
+++ b/incubator/virtualcluster/pkg/syncer/vnode/service/provider_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func newNode() *v1.Node {
+	return &v1.Node{
+		Status: v1.NodeStatus{
+			Addresses: []v1.NodeAddress{
+				v1.NodeAddress{
+					Type:    v1.NodeInternalIP,
+					Address: "192.168.0.2",
+				},
+			},
+		},
+	}
+}
+
+func newClient() clientset.Interface {
+	return fake.NewSimpleClientset(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vn-agent",
+			Namespace: "vc-manager",
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP: "192.168.0.5",
+		},
+	})
+}
+
+func Test_provider_GetNodeAddress(t *testing.T) {
+	type fields struct {
+		vnAgentPort          int32
+		vnAgentNamespaceName string
+		client               clientset.Interface
+	}
+	type args struct {
+		node *v1.Node
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    []v1.NodeAddress
+		wantErr bool
+	}{
+		{
+			name: "TestWithNoService",
+			fields: fields{
+				vnAgentNamespaceName: "default/vn-agent",
+				client:               newClient(),
+			},
+			args:    args{newNode()},
+			want:    []v1.NodeAddress{},
+			wantErr: true,
+		},
+		{
+			name: "TestWithService",
+			fields: fields{
+				vnAgentNamespaceName: "vc-manager/vn-agent",
+				client:               newClient(),
+			},
+			args: args{newNode()},
+			want: []v1.NodeAddress{
+				v1.NodeAddress{
+					Type:    v1.NodeInternalIP,
+					Address: "192.168.0.5",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &provider{
+				vnAgentPort:          tt.fields.vnAgentPort,
+				vnAgentNamespaceName: tt.fields.vnAgentNamespaceName,
+				client:               tt.fields.client,
+			}
+			got, err := p.GetNodeAddress(tt.args.node)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("provider.GetNodeAddress() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if len(tt.want) != 0 && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("provider.GetNodeAddress() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
These changes make it so that you can use the vn-agent as a Kubernetes deployment when not using the direct to Kubelet proxy mechanism. All you need to do is deploy the vn-agent as a `Deployment`, then you create a new `ClusterIP` Service (this could potentially also be a LoadBalancer later to support the experimental scheduler with a couple tweaks) once that is setup you deploy the syncer with the flags `--vn-agent-namespace` and `--vn-agent-service-name` and it will fetch the service clusterIP at node creation to register with the virtual node resource.

Signed-off-by: Chris Hein <me@chrishein.com>