### PR TITLE
Add reinstall kubebuilder info in test and README

### DIFF
--- a/incubator/hnc/Makefile
+++ b/incubator/hnc/Makefile
@@ -93,6 +93,10 @@ all: test docker-build
 # Run tests
 test: build
 	./hack/crd_patches/ensure-all-served-for-envtest.sh
+	@echo
+	@echo "If tests fail due to no matches for kind \"CustomResourceDefinition\" in version \"apiextensions.k8s.io/v1\","
+	@echo "please remove the old kubebuilder and reinstall it - https://book.kubebuilder.io/quick-start.html#installation"
+	@echo
 	go test ${DIRS} -coverprofile cover.out
 
 # Builds all binaries (manager and kubectl) and manifests

--- a/incubator/hnc/README.md
+++ b/incubator/hnc/README.md
@@ -139,6 +139,8 @@ cycle looks like the following:
       special-purpose directories in `test/`. These are basically glorified
       `bash` scripts with better error checking, and directly invoke `kubectl`.
   - Ensure `make test` passes - this runs unit tests only.
+    - If you see all tests fail with `no matches for v1/CRD` [error](https://gist.github.com/yiqigao217/9394c2aadaa515e82184684a005187af)
+      , remove your `/usr/local/kubebuilder/` directory and [reinstall kubebuilder](https://book.kubebuilder.io/quick-start.html#installation).
   - Deploy to your cluster with `make deploy`
   - Test your changes by hand and verify that your changes are working
     correctly. Some ways you can do that are:


### PR DESCRIPTION
Fixes #1371

If you have older version of kubebuilder installed locally on your
computer, the envtest would load older version of etcd and
kube-apiserver from your /usr/local/kubebuilder/bin for tests. Since we
just migrated from v1beta1 to v1 for CRDs, K8s < v1.16 would not know
v1/CRD. Thus the tests would all fail.

Add reinstall kubebuilder info in `make test` and README for developers.

Failed tests look like this - https://gist.github.com/yiqigao217/9394c2aadaa515e82184684a005187af
Passed tests look like this - https://gist.github.com/yiqigao217/d8d097c99df54997915c57fda17f96bb