### PR TITLE
syncer: add option to disable service links

### DIFF
--- a/incubator/virtualcluster/cmd/syncer/app/options/options.go
+++ b/incubator/virtualcluster/cmd/syncer/app/options/options.go
@@ -106,6 +106,7 @@ func (o *ResourceSyncerOptions) Flags() cliflag.NamedFlagSets {
 	fs.StringVar(&o.ComponentConfig.ClientConnection.Kubeconfig, "super-master-kubeconfig", o.ComponentConfig.ClientConnection.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
 	fs.StringVar(&o.SyncerName, "syncer-name", o.SyncerName, "Syncer name (default vc).")
 	fs.BoolVar(&o.ComponentConfig.DisableServiceAccountToken, "disable-service-account-token", o.ComponentConfig.DisableServiceAccountToken, "DisableServiceAccountToken indicates whether disable service account token automatically mounted.")
+	fs.BoolVar(&o.ComponentConfig.DisablePodServiceLinks, "disable-service-links", o.ComponentConfig.DisablePodServiceLinks, "DisablePodServiceLinks indicates whether to disable the `EnableServiceLinks` field in pPod spec.")
 	fs.StringSliceVar(&o.ComponentConfig.DefaultOpaqueMetaDomains, "default-opaque-meta-domains", o.ComponentConfig.DefaultOpaqueMetaDomains, "DefaultOpaqueMetaDomains is the default opaque meta configuration for each Virtual Cluster.")
 	fs.StringSliceVar(&o.ComponentConfig.ExtraSyncingResources, "extra-syncing-resources", o.ComponentConfig.ExtraSyncingResources, "ExtraSyncingResources defines additional resources that need to be synced for each Virtual Cluster. (priorityclass, ingress, crd)")
 	fs.Var(cliflag.NewMapStringBool(&o.ComponentConfig.FeatureGates), "feature-gates", "A set of key=value pairs that describe featuregate gates for various features.")

--- a/incubator/virtualcluster/pkg/syncer/apis/config/types.go
+++ b/incubator/virtualcluster/pkg/syncer/apis/config/types.go
@@ -51,6 +51,12 @@ type SyncerConfiguration struct {
 	// DisableServiceAccountToken indicates whether disable service account token automatically mounted.
 	DisableServiceAccountToken bool
 
+	// DisablePodServiceLinks indicates whether to disable the `EnableServiceLinks` field in pPod spec.
+	// Defaults to false, it won‘t mutate the EnableServiceLinks field in pPod spec.
+	// If set to true, it will disable service links for all of the pPods to avoid massive env injections
+	// from syncer which replace the kubelet generated envs.
+	DisablePodServiceLinks bool
+
 	// VNAgentPort defines the port that the VN Agent is running on per host
 	VNAgentPort int32
 

--- a/incubator/virtualcluster/pkg/syncer/conversion/mutate.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/mutate.go
@@ -394,6 +394,15 @@ func PodMutateAutoMountServiceAccountToken(disable bool) PodMutator {
 	}
 }
 
+func PodMutateServiceLink(disableServiceLinks bool) PodMutator {
+	return func(p *podMutateCtx) error {
+		if disableServiceLinks {
+			p.pPod.Spec.EnableServiceLinks = pointer.BoolPtr(false)
+		}
+		return nil
+	}
+}
+
 type ServiceMutateInterface interface {
 	Mutate(vService *v1.Service)
 }

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/dws.go
@@ -199,6 +199,7 @@ func (c *controller) reconcilePodCreate(clusterName, targetNamespace, requestUID
 	}
 
 	var ms = []conversion.PodMutator{
+		conversion.PodMutateServiceLink(c.Config.DisablePodServiceLinks),
 		conversion.PodMutateDefault(vPod, pSecretMap, services, nameServer),
 		conversion.PodMutateAutoMountServiceAccountToken(c.Config.DisableServiceAccountToken),
 		// TODO: make extension configurable


### PR DESCRIPTION

    if set to true, it will disable service links for all of
    the pPods to avoid massive env injections from syncer
    which replace the kubelet generated envs

Signed-off-by: zhuangqh <zhuangqhc@gmail.com>