### PR TITLE
Make excluded namespace configurable

### DIFF
--- a/incubator/hnc/api/v1alpha2/hierarchy_types.go
+++ b/incubator/hnc/api/v1alpha2/hierarchy_types.go
@@ -43,6 +43,10 @@ const (
 	// LabelManagedByStandard will eventually replace our own managed-by annotation (we didn't know
 	// about this standard label when we invented our own).
 	LabelManagedByApps = "app.kubernetes.io/managed-by"
+
+	// LabelExcludedNamespace is the label added by users on the namespaces that
+	// should be excluded from our validators, e.g. "kube-system".
+	LabelExcludedNamespace = MetaGroup + "/excluded-namespace"
 )
 
 const (

--- a/incubator/hnc/config/manager/manager.yaml
+++ b/incubator/hnc/config/manager/manager.yaml
@@ -3,6 +3,12 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
+    # Add excluded namespace label on `hnc-system` namespace by default because
+    # without this label when installing HNC, there will be a deadlock that
+    # the object webhook fails close so the cert-rotator cannot create/update
+    # `hnc-webhook-server-cert` secret object for VWHConfiguration, thus the
+    # webhooks will never be ready.
+    hnc.x-k8s.io/excluded-namespace: "true"
   name: system
 ---
 apiVersion: apps/v1
@@ -44,6 +50,10 @@ spec:
         - "--apiserver-qps-throttle=50"
         - "--enable-internal-cert-management"
         - "--cert-restart-on-secret-refresh"
+        - "--excluded-namespace=kube-system"
+        - "--excluded-namespace=kube-public"
+        - "--excluded-namespace=hnc-system"
+        - "--excluded-namespace=kube-node-lease"
         image: controller:latest
         name: manager
         resources:

--- a/incubator/hnc/config/webhook/manifests.yaml
+++ b/incubator/hnc/config/webhook/manifests.yaml
@@ -100,7 +100,7 @@ webhooks:
       name: webhook-service
       namespace: system
       path: /validate-objects
-  failurePolicy: Ignore
+  failurePolicy: Fail
   name: objects.hnc.x-k8s.io
   rules:
   - apiGroups:

--- a/incubator/hnc/config/webhook/webhook_patch.yaml
+++ b/incubator/hnc/config/webhook/webhook_patch.yaml
@@ -7,6 +7,35 @@ webhooks:
 - name: objects.hnc.x-k8s.io
   timeoutSeconds: 2
   sideEffects: None
+  # We only filter out excluded namespaces from this object validator so that
+  # when HNC (webhook service specifically) is down, operations in the excluded
+  # namespaces won't be affected. Validators on HNC CRs are not filtered because
+  # they are supposed to prevent abuse of HNC CRs in excluded namespaces.
+  # Namespace validator is not filtered to prevent abuse of excluded namespace.
+  # Unfortunately, this means that when HNC is down, we will block updates on all
+  # namespaces, even "excluded" ones, but anyone who can update namespaces like
+  # `kube-system` should likely be able to delete the VWHConfiguration to make
+  # the updates.
+  namespaceSelector:
+    matchExpressions:
+    - key: hnc.x-k8s.io/excluded-namespace
+      operator: DoesNotExist
+  rules:
+  # This overwrites the rules specified in the object validator to patch object
+  # scope of `namespaced` since there's no kubebuilder marker for `scope`.
+  # There's no way to just patch "scope: Namespaced" to the first rule, since
+  # `rules` takes a list of rules and we can only patch the entire `rules`.
+  - apiGroups:
+    - '*'
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - '*'
+    scope: "Namespaced"
 - name: subnamespaceanchors.hnc.x-k8s.io
   sideEffects: None
 - name: hierarchyconfigurations.hnc.x-k8s.io

--- a/incubator/hnc/docs/user-guide/concepts.md
+++ b/incubator/hnc/docs/user-guide/concepts.md
@@ -498,7 +498,6 @@ objects, in addition to using the custom resources it defines.
 These annotations may be added to any namespaced object to define exceptions to
 propagation rules. More information to come.
 
-
 #### hnc.x-k8s.io/managed-by (annotation on namespaces)
 
 This annotation is mainly designed for use by external products such as GKE
@@ -529,6 +528,25 @@ namespace if this annotation already exists. The two are mutually exclusive.
 
 We are considering replacing this with the standard
 `app.kubernetes.io/managed-by` label in the future.
+
+<a name="excluded-namespace-label">
+
+#### hnc.x-k8s.io/excluded-namespace (label on namespaces)
+
+This label should be added to namespaces such as `kube-system` and `kube-public`
+so that HNC's validating webhook cannot accidentally prevent operations in these
+namespaces and block critical cluster operations.
+
+Before installing HNC, users can customize the excluded namespace list in the HNC
+deployment with a container arg called `excluded-namespace` in
+`config/manager/manager.yaml` and then set this label on the excluded namespaces.
+Setting this label on namespaces that are not
+listed in the HNC deployment as an `excluded-namespace` is not allowed.
+
+As of March 2021, the default excluded namespaces listed in [config/manager/manager.yaml](https://github.com/kubernetes-sigs/multi-tenancy/blob/master/incubator/hnc/config/manager/manager.yaml)
+are `kube-system`, `kube-public`, `hnc-system` and
+`kube-node-lease`. HNC adds this label to `hnc-system` namespace by default, so
+users will have to add this label to other excluded namespaces manually.
 
 <a name="admin-labels-set">
 

--- a/incubator/hnc/internal/config/default_config.go
+++ b/incubator/hnc/internal/config/default_config.go
@@ -1,18 +1,5 @@
 package config
 
-// EX is a map used by reconcilers and validators to exclude namespaces that shouldn't be reconciled
-// or validated. We explicitly exclude some default namespaces with constantly changing objects.
-//
-// TODO make the exclusion configurable -
-// https://github.com/kubernetes-sigs/multi-tenancy/issues/374
-var EX = map[string]bool{
-	"kube-system":     true,
-	"kube-public":     true,
-	"hnc-system":      true,
-	"cert-manager":    true,
-	"kube-node-lease": true,
-}
-
 // UnpropgatedAnnotations is a list of annotations on objects that should _not_ be propagated by HNC.
 // Much like HNC itself, other systems (such as GKE Config Sync) use annotations to "claim" an
 // object - such as deleting objects it doesn't recognize. By removing these annotations on
@@ -21,3 +8,10 @@ var EX = map[string]bool{
 // This value is controlled by the --unpropagated-annotation command line, which may be set multiple
 // times.
 var UnpropagatedAnnotations []string
+
+// ExcludedNamespaces is a list of namespaces used by reconcilers and validators
+// to exclude namespaces that shouldn't be reconciled or validated.
+//
+// This value is controlled by the --excluded-namespace command line, which may
+// be set multiple times.
+var ExcludedNamespaces map[string]bool

--- a/incubator/hnc/internal/reconcilers/anchor.go
+++ b/incubator/hnc/internal/reconcilers/anchor.go
@@ -75,9 +75,9 @@ func (r *AnchorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// Report "Forbidden" state and early exit if the namespace is not allowed to have subnamespaces
 	// but has bypassed the webhook and successfully created the anchor. Forbidden anchors won't have
 	// finalizers.
-	// TODO refactor/split the EX map for 1) reconciler exclusion and 2) subnamespaces exclusion
-	// purposes. See issue: https://github.com/kubernetes-sigs/multi-tenancy/issues/495
-	if config.EX[pnm] {
+	// TODO refactor/split the ExcludedNamespaces map for 1) reconciler exclusion and 2) subnamespaces exclusion
+	//  purposes. See issue: https://github.com/kubernetes-sigs/multi-tenancy/issues/495
+	if config.ExcludedNamespaces[pnm] {
 		inst.Status.State = api.Forbidden
 		return ctrl.Result{}, r.writeInstance(ctx, log, inst)
 	}

--- a/incubator/hnc/internal/reconcilers/anchor_test.go
+++ b/incubator/hnc/internal/reconcilers/anchor_test.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
+	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/config"
 )
 
 var _ = Describe("Anchor", func() {
@@ -50,6 +51,7 @@ var _ = Describe("Anchor", func() {
 	})
 
 	It("should set the anchor.status.state to Forbidden if the parent is not allowed to have subnamespaces", func() {
+		config.ExcludedNamespaces = map[string]bool{"kube-system": true}
 		kube_system_anchor_bar := newAnchor(barName, "kube-system")
 		updateAnchor(ctx, kube_system_anchor_bar)
 		Eventually(getAnchorState(ctx, "kube-system", barName)).Should(Equal(api.Forbidden))

--- a/incubator/hnc/internal/reconcilers/object.go
+++ b/incubator/hnc/internal/reconcilers/object.go
@@ -194,7 +194,7 @@ func (r *ObjectReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	resp := ctrl.Result{}
 	log := loggerWithRID(r.Log).WithValues("trigger", req.NamespacedName)
 
-	if config.EX[req.Namespace] {
+	if config.ExcludedNamespaces[req.Namespace] {
 		return resp, nil
 	}
 

--- a/incubator/hnc/internal/validators/anchor.go
+++ b/incubator/hnc/internal/validators/anchor.go
@@ -79,8 +79,13 @@ func (v *Anchor) handle(req *anchorRequest) admission.Response {
 	switch req.op {
 	case k8sadm.Create:
 		// Can't create subnamespaces in excluded namespaces
-		if config.EX[pnm] {
-			msg := fmt.Sprintf("The namespace %s is not allowed to create subnamespaces. Please create subnamespaces in a different namespace.", pnm)
+		if config.ExcludedNamespaces[pnm] {
+			msg := fmt.Sprintf("Cannot create a subnamespace in the excluded namespace %q", pnm)
+			return deny(metav1.StatusReasonForbidden, msg)
+		}
+		// Can't create subnamespaces using excluded namespace names
+		if config.ExcludedNamespaces[cnm] {
+			msg := fmt.Sprintf("Cannot create a subnamespace using the excluded namespace name %q", cnm)
 			return deny(metav1.StatusReasonForbidden, msg)
 		}
 
@@ -89,7 +94,7 @@ func (v *Anchor) handle(req *anchorRequest) admission.Response {
 		if cns.Exists() {
 			childIsMissingAnchor := (cns.Parent().Name() == pnm && cns.IsSub)
 			if !childIsMissingAnchor {
-				msg := fmt.Sprintf("The requested namespace %s already exists. Please use a different name.", cnm)
+				msg := fmt.Sprintf("Cannot create a subnamespace using an existing namespace name %q", cnm)
 				return deny(metav1.StatusReasonConflict, msg)
 			}
 		}

--- a/incubator/hnc/internal/validators/anchor_test.go
+++ b/incubator/hnc/internal/validators/anchor_test.go
@@ -5,7 +5,9 @@ import (
 
 	. "github.com/onsi/gomega"
 	k8sadm "k8s.io/api/admission/v1"
+
 	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
+	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/config"
 	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/foresttest"
 )
 
@@ -14,6 +16,7 @@ func TestCreateSubnamespaces(t *testing.T) {
 	// namespace "c".
 	f := foresttest.Create("-Aa")
 	h := &Anchor{Forest: f}
+	config.ExcludedNamespaces = map[string]bool{"kube-system": true}
 
 	tests := []struct {
 		name string
@@ -23,6 +26,7 @@ func TestCreateSubnamespaces(t *testing.T) {
 	}{
 		{name: "with a non-existing name", pnm: "a", cnm: "brumpf"},
 		{name: "in excluded ns", pnm: "kube-system", cnm: "brumpf", fail: true},
+		{name: "using excluded ns name", pnm: "brumpf", cnm: "kube-system", fail: true},
 		{name: "with an existing ns name (the ns is not a subnamespace of it)", pnm: "c", cnm: "b", fail: true},
 		{name: "for existing non-subns child", pnm: "a", cnm: "c", fail: true},
 		{name: "for existing subns", pnm: "a", cnm: "b"},

--- a/incubator/hnc/test/e2e/rolebinding_test.go
+++ b/incubator/hnc/test/e2e/rolebinding_test.go
@@ -40,6 +40,9 @@ var _ = Describe("HNC should delete and create a new Rolebinding instead of upda
 		// 5s fairly arbitrarily, but it works well. Feel free to try lower values it you like.
 		//   - aludwin, Sep 2020
 		MustRun("kubectl delete deployment --all -n hnc-system")
+		// Since the object webhook fails close, we need to remove VWHConfiguration
+		// so that the rolebinding object can be deleted later.
+		MustRun("kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io hnc-validating-webhook-configuration")
 		time.Sleep(5 * time.Second)
 
 		// Replace the source rolebinding


### PR DESCRIPTION
Fixes #374, #1023.
Part of #1443.
See design https://bit.ly/hnc-excluded-namespaces.

Add `excluded-namespace` container args in the
config/manager/manager.yaml to allow user defined excluded namespaces.
The default excluded namespaces are kube-system, kube-public, hnc-system
and kube-node-lease. Add excluded-namespace label to hnc-system by
default to avoid deadlock (between cert-rotator writing secret vs object
webhook failing CLOSE) when installing HNC. Let users to add
excluded-namespaces to other namespaces.

Replace the hard-coded `EX` excluded namespaces.

Add webhook patch only to the object validator with namespaceSelector to
filter excluded namespaces. Add comments on why not patching other
validators. Make object validator fail CLOSE now.

Patch object webhook to only apply on "namespaced" scope objects, so
that cert-rotator can insert certs to VWHConfiguration and namespaced
objects are indeed what we care in HNC.

Add webhook rules:
1) Do not allow creating/updating non-excluded namespace with excluded
label;
2) Do not allow excluded namespaces to be created as a subnamespace;
3) Do not allow setting an excluded namespace as a child.

Make hierarchyConfiguration reconciler remove excluded-namespace label
on non-excluded namespaces.

Add excluded-namespace label to user-guide/concepts.md doc.

Tested by make test and make test-e2e.