### PR TITLE
[VC] Sync cache when new Cluster or VC CR is created

### DIFF
--- a/incubator/virtualcluster/experiment/config/setup/setup-supercluster-minikube.sh
+++ b/incubator/virtualcluster/experiment/config/setup/setup-supercluster-minikube.sh
@@ -34,7 +34,7 @@ cat > $KUBECONFIG_PATH << EOL
 apiVersion: v1
 clusters:
 - cluster:
-    certificate-authority-data: $(cat $HOME/.minikube/ca.crt |base64)
+    certificate-authority-data: $(cat $HOME/.minikube/ca.crt |base64 |tr -d \\n)
     server: https://$(minikube ip -p ${CLUSTER_ID}):8443
   name: ${CLUSTER_ID}
 contexts:
@@ -49,8 +49,8 @@ preferences: {}
 users:
 - name: ${CLUSTER_ID}
   user:
-    client-certificate-data: $(cat $HOME/.minikube/profiles/$CLUSTER_ID/client.crt |base64)
-    client-key-data: $(cat $HOME/.minikube/profiles/$CLUSTER_ID/client.key |base64)
+    client-certificate-data: $(cat $HOME/.minikube/profiles/$CLUSTER_ID/client.crt |base64 |tr -d \\n)
+    client-key-data: $(cat $HOME/.minikube/profiles/$CLUSTER_ID/client.key |base64 |tr -d \\n)
 EOL
 
 log "generate vc-syncer kubeconfig secret"

--- a/incubator/virtualcluster/experiment/config/setup/syncer.yaml.sed
+++ b/incubator/virtualcluster/experiment/config/setup/syncer.yaml.sed
@@ -134,7 +134,7 @@ spec:
       containers:
         - command:
             - syncer
-            - --deployment-on-meta
+            - --deployment-on-meta=true
             - --super-master-kubeconfig=/etc/supercluster/config
             - --syncer-name=SYNCER_NAME
             - --feature-gates

--- a/incubator/virtualcluster/experiment/pkg/scheduler/reconciler.go
+++ b/incubator/virtualcluster/experiment/pkg/scheduler/reconciler.go
@@ -170,6 +170,11 @@ func (s *Scheduler) addVirtualCluster(key string, vc *v1alpha1.VirtualCluster) e
 	s.virtualClusterSet[key] = tenantCluster
 	s.virtualClusterLock.Unlock()
 
+	// note that the cache will be updated twice when scheduler restarts, to be improved
+	if err := util.SyncVirtualClusterState(s.metaClusterClient, vc, s.schedulerCache); err != nil {
+		return fmt.Errorf("failed to update the scheduler cache for the added virtual cluster %s:%v", key, err)
+	}
+
 	go s.syncVirtualClusterCache(tenantCluster, vc)
 
 	return nil
@@ -335,6 +340,11 @@ func (s *Scheduler) addSuperCluster(key string, super *v1alpha4.Cluster) error {
 	s.superClusterLock.Lock()
 	s.superClusterSet[key] = superCluster
 	s.superClusterLock.Unlock()
+
+	// note that the cache will be updated twice when scheduler restarts, to be improved
+	if err := util.SyncSuperClusterState(s.metaClusterClient, super, s.schedulerCache); err != nil {
+		return fmt.Errorf("failed to update the scheduler cache for super cluster %s:%v", key, err)
+	}
 
 	go s.syncSuperClusterCache(superCluster, super)
 


### PR DESCRIPTION
This change fixes a problem such that the scheduler cache is not updated when creating new VC or Cluster CR. 

The solution is simple but not ideal since the cache will be updated twice when scheduler restarts. We may fix it later if this is really a concern for performance.

The change also fixes a few script problem.