### PR TITLE
[VC] Using labels for super.public crds

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/resources/crd/controller.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/crd/controller.go
@@ -215,7 +215,7 @@ func (c *controller) GetListener() listener.ClusterChangeListener {
 
 func publicCRD(e *v1beta1.CustomResourceDefinition) bool {
 	// We only backpopulate specific crds to tenant masters
-	return e.Annotations[constants.PublicObjectKey] == "true"
+	return e.Labels[constants.PublicObjectKey] == "true"
 }
 
 func (c *controller) enqueueCRD(obj interface{}) {


### PR DESCRIPTION
Looks like we might have use `annotations` where all other shared resources use `labels` see - https://github.com/kubernetes-sigs/multi-tenancy/search?q=PublicObjectKey

Signed-off-by: Chris Hein <me@chrishein.com>