### PR TITLE
[vc] cleaning logging in extra syncers

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/resources/crd/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/crd/checker.go
@@ -94,12 +94,9 @@ func (c *controller) checkCRDOfTenantCluster(clusterName string) {
 		klog.Errorf("error listing CRD from cluster %s informer cache: %v", clusterName, err)
 		return
 	}
-	klog.V(4).Infof("check crd consistency in cluster %s", clusterName)
 
 	crdList := listObj.(*v1beta1.CustomResourceDefinitionList)
-
 	vcrestconfig := c.multiClusterCrdController.GetCluster(clusterName).GetRestConfig()
-
 	var vcapiextensionsClient apiextensionclientset.CustomResourceDefinitionsGetter
 
 	if vcrestconfig == nil {

--- a/incubator/virtualcluster/pkg/syncer/resources/priorityclass/checker.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/priorityclass/checker.go
@@ -95,7 +95,7 @@ func (c *controller) checkPriorityClassOfTenantCluster(clusterName string) {
 		klog.Errorf("error listing priorityclass from cluster %s informer cache: %v", clusterName, err)
 		return
 	}
-	klog.V(4).Infof("check priorityclass consistency in cluster %s", clusterName)
+
 	scList := listObj.(*v1.PriorityClassList)
 	for i, vPriorityClass := range scList.Items {
 		pPriorityClass, err := c.priorityclassLister.Get(vPriorityClass.Name)


### PR DESCRIPTION
This removes a couple overly verbose loggers in the crs and priority class syncers.

Signed-off-by: Chris Hein <me@chrishein.com>