### PR TITLE
[VC] Fix vNodeGC and Pod checker bugs when enabling SuperClusterPooling feature

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/constants/constants.go
+++ b/incubator/virtualcluster/pkg/syncer/constants/constants.go
@@ -66,6 +66,8 @@ const (
 	PublicObjectKey = "tenancy.x-k8s.io/super.public"
 
 	LabelVirtualNode = "tenancy.x-k8s.io/virtualnode"
+	// LabelSuperClusterID is a label key added to the vNode object in tenant when SuperClusterPooling feature is enabled.
+	LabelSuperClusterID = "tenancy.x-k8s.io/superclusterid"
 
 	// DefaultvNodeGCGracePeriod is the grace period of time before deleting an orphan vNode in tenant master.
 	DefaultvNodeGCGracePeriod = time.Second * 120

--- a/incubator/virtualcluster/pkg/syncer/vnode/vnode.go
+++ b/incubator/virtualcluster/pkg/syncer/vnode/vnode.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/vnode/native"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/vnode/provider"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/vnode/service"
+	utilconstants "sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/util/constants"
 )
 
 func GetNodeProvider(config *config.SyncerConfiguration, client clientset.Interface) provider.VirtualNodeProvider {
@@ -66,6 +67,11 @@ func NewVirtualNode(provider provider.VirtualNodeProvider, node *v1.Node) (vnode
 	labels := map[string]string{
 		constants.LabelVirtualNode: "true",
 	}
+
+	if featuregate.DefaultFeatureGate.Enabled(featuregate.SuperClusterPooling) {
+		labels[constants.LabelSuperClusterID] = utilconstants.SuperClusterID
+	}
+
 	for k, v := range node.GetLabels() {
 		if _, isWellKnown := wellKnownNodeLabelsMap[k]; isWellKnown {
 			labels[k] = v


### PR DESCRIPTION
This change fixes two problems when enabling SuperClusterPooling feature.

1) The Pod checker needs to exclude vPod that is not scheduled to the syncer's cluster;
2) The vNodeGC module should not check the vNode that does not belong to the syncer's cluster;

The checkers of other resources should be fixed as well, which will be done later.