### PR TITLE
[vc] adding ResourceSyncerOptions as a param to NewSyncerCommand

### DIFF
--- a/incubator/virtualcluster/cmd/syncer/app/server.go
+++ b/incubator/virtualcluster/cmd/syncer/app/server.go
@@ -40,12 +40,7 @@ import (
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/version/verflag"
 )
 
-func NewSyncerCommand(stopChan <-chan struct{}) *cobra.Command {
-	s, err := options.NewResourceSyncerOptions()
-	if err != nil {
-		klog.Fatalf("unable to initialize command options: %v", err)
-	}
-
+func NewSyncerCommand(stopChan <-chan struct{}, s *options.ResourceSyncerOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "syncer",
 		Long: `The resource syncer is a daemon that watches tenant clusters to

--- a/incubator/virtualcluster/cmd/syncer/main.go
+++ b/incubator/virtualcluster/cmd/syncer/main.go
@@ -23,8 +23,10 @@ import (
 
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/component-base/logs"
+	"k8s.io/klog"
 
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/cmd/syncer/app"
+	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/cmd/syncer/app/options"
 )
 
 func main() {
@@ -35,7 +37,13 @@ func main() {
 
 	stopChan := genericapiserver.SetupSignalHandler()
 
-	if err := app.NewSyncerCommand(stopChan).Execute(); err != nil {
+	s, err := options.NewResourceSyncerOptions()
+	if err != nil {
+		klog.Fatalf("unable to initialize command options: %v", err)
+		os.Exit(1)
+	}
+
+	if err := app.NewSyncerCommand(stopChan, s).Execute(); err != nil {
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This allows the resource syncer options to be mutated outside of the syncer server package making it easier to add non-in-tree functionality. This will be extended in a later PR to add the ability to attach more "runnable" packages that can load up the built in informer caches and will run be maintained with the other goroutines.

Signed-off-by: Chris Hein <me@chrishein.com>