### PR TITLE
[VC] Add Namespace update synchronization for scheduling placement

### DIFF
--- a/incubator/virtualcluster/experiment/doc/demo.md
+++ b/incubator/virtualcluster/experiment/doc/demo.md
@@ -106,7 +106,7 @@ Assuming we have created two super clusters: r1 and r2 and one virtual cluster f
 we use the `default` namespace in the virtual cluster to do the experiment.
 
 First, we configure the namespace slice, which is the scheduling unit used in the namespace scheduler, by
-adding an annotation `scheduler.tenancy.x-k8s.io/slice: '{"cpu":"100m", "memory":"100Mi"}'` to the `default` namespace.
+adding an annotation `scheduler.virtualcluster.io/slice: '{"cpu":"100m", "memory":"100Mi"}'` to the `default` namespace.
 
 Then we create a resource quota in the `default` namespace, which has the capacity of two slices in total.
 
@@ -123,7 +123,7 @@ spec:
 ```
 
 The namespace scheduler should update the scheduling result in the `default` namespace's annotation shortly
-using the key `scheduler.tenancy.x-k8s.io/placements`.
+using the key `scheduler.virtualcluster.io/placements`.
 
 ```bash
 $ kubectl --kubeconfig vc-1.kubeconfig get ns default -o yaml
@@ -131,8 +131,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
-    scheduler.tenancy.x-k8s.io/placements: '{"r1":1,"r2":1}'
-    scheduler.tenancy.x-k8s.io/slice: '{"cpu":"100m", "memory":"100Mi"}'
+    scheduler.virtualcluster.io/placements: '{"r1":1,"r2":1}'
+    scheduler.virtualcluster.io/slice: '{"cpu":"100m", "memory":"100Mi"}'
   creationTimestamp: "2021-03-25T02:20:20Z"
   name: default
   resourceVersion: "356"
@@ -189,7 +189,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    scheduler.tenancy.x-k8s.io/superCluster: r1
+    scheduler.virtualcluster.io/superCluster: r1
   creationTimestamp: "2021-03-25T16:09:33Z"
   generateName: zhijin-test-2-684cc8d565-
   labels:

--- a/incubator/virtualcluster/pkg/syncer/conversion/equality.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/equality.go
@@ -709,3 +709,13 @@ func (e vcEquality) CheckPVSpecEquality(pObj, vObj *v1.PersistentVolumeSpec) *v1
 	}
 	return updatedPVSpec
 }
+
+func (e vcEquality) CheckNamespaceEquality(pObj, vObj *v1.Namespace) *v1.Namespace {
+	var updated *v1.Namespace
+	updatedMeta := e.CheckDWObjectMetaEquality(&pObj.ObjectMeta, &vObj.ObjectMeta)
+	if updatedMeta != nil {
+		updated = pObj.DeepCopy()
+		updated.ObjectMeta = *updatedMeta
+	}
+	return updated
+}

--- a/incubator/virtualcluster/pkg/util/constants/constants.go
+++ b/incubator/virtualcluster/pkg/util/constants/constants.go
@@ -31,13 +31,13 @@ const (
 
 const (
 	// LabelScheduledCluster is the super cluster the pod schedules to.
-	LabelScheduledCluster = "scheduler.tenancy.x-k8s.io/superCluster"
+	LabelScheduledCluster = "scheduler.virtualcluster.io/superCluster"
 
 	// LabelScheduledPlacements is the scheduled placements the namespace schedules to.
-	LabelScheduledPlacements = "scheduler.tenancy.x-k8s.io/placements"
+	LabelScheduledPlacements = "scheduler.virtualcluster.io/placements"
 
 	// LabelScheduledSlice is the scheduled slice size of the namespace.
-	LabelNamespaceSlice = "scheduler.tenancy.x-k8s.io/slice"
+	LabelNamespaceSlice = "scheduler.virtualcluster.io/slice"
 )
 
 var DefaultNamespaceSlice = v1.ResourceList{


### PR DESCRIPTION
We need to update the placement results to super cluster namespace so that the scheduler cache can be updated correctly. 

This change handles the tenant namespace update event to populate metadata to the super cluster. In addition, the syncer disallows to populate label/annotation keys that have keyword "k8s.io", hence we need to rename the constant keys used in the scheduler.
