### PR TITLE
[VC] Get services of default namespace from tenant when enabling SuperClusterPooling

### DIFF
--- a/incubator/virtualcluster/pkg/syncer/conversion/helper.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/helper.go
@@ -242,5 +242,11 @@ func IsControlPlaneService(service *v1.Service, cluster string) bool {
 		kubernetesService = "apiserver-svc"
 	}
 
+	// If the super cluster pooling is enabled, the service in tenant default namepsace
+	// is used.
+	if featuregate.DefaultFeatureGate.Enabled(featuregate.SuperClusterPooling) {
+		kubernetesNamespace = metav1.NamespaceDefault
+		kubernetesService = "kubernetes"
+	}
 	return service.Namespace == kubernetesNamespace && service.Name == kubernetesService
 }

--- a/incubator/virtualcluster/pkg/syncer/conversion/mutate.go
+++ b/incubator/virtualcluster/pkg/syncer/conversion/mutate.go
@@ -255,6 +255,9 @@ func getServiceEnvVarMap(ns, cluster string, enableServiceLinks *bool, services 
 		// We also add environment variables for other services in the same
 		// namespace, if enableServiceLinks is true.
 		if IsControlPlaneService(service, cluster) {
+			// TODO: If superclusterpooling feature is enabled, an external loadbalancer is
+			// expected for the APIserver service. Hence, we should use the Ingress IP instead
+			// of the ClusterIP.
 			apiServerService = service.Spec.ClusterIP
 			if _, exists := serviceMap[serviceName]; !exists {
 				serviceMap[serviceName] = service

--- a/incubator/virtualcluster/pkg/syncer/resources/pod/dws.go
+++ b/incubator/virtualcluster/pkg/syncer/resources/pod/dws.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/constants"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/conversion"
 	"sigs.k8s.io/multi-tenancy/incubator/virtualcluster/pkg/syncer/metrics"
@@ -280,9 +282,27 @@ func (c *controller) getPodRelatedServices(cluster string, pPod *v1.Pod) ([]*v1.
 		services = append(services, apiserver)
 	}
 
-	list, err := c.serviceLister.Services(conversion.ToSuperMasterNamespace(cluster, metav1.NamespaceDefault)).List(labels.Everything())
-	if err != nil {
-		return nil, err
+	var list []*v1.Service
+	var err error
+	if featuregate.DefaultFeatureGate.Enabled(featuregate.SuperClusterPooling) {
+		// In case of super cluster pooling, it is possible that the tenant default namespace is not synced to current super cluster.
+		// We need to query the tenant apiserver to get the services in tenant default namespace.
+		// Note that the cluster ip in the service from the tenant default namespace can be a bogus value.
+		// We expect an external loadbalancer is used for each tenant service.
+		var serviceListObj interface{}
+		serviceListObj, err = c.MultiClusterController.ListByObjectType(cluster, &v1.Service{}, client.InNamespace(metav1.NamespaceDefault))
+		if err != nil {
+			return nil, err
+		}
+		serviceList := serviceListObj.(*v1.ServiceList)
+		for i, _ := range serviceList.Items {
+			list = append(list, &serviceList.Items[i])
+		}
+	} else {
+		list, err = c.serviceLister.Services(conversion.ToSuperMasterNamespace(cluster, metav1.NamespaceDefault)).List(labels.Everything())
+		if err != nil {
+			return nil, err
+		}
 	}
 	services = append(services, list...)
 


### PR DESCRIPTION
As explained in the change comments, in case of super cluster pooling, it is possible that the tenant default namespace is not synced to current super cluster. We need to query the tenant apiserver to get the services in tenant default namespace. 

With this change, the Pods created in namespaces other than the default namespace can be synchronized to super cluster successfully. 

```
kubectl get pod -A --kubeconfig=vc-sample-1.kubeconfig
NAMESPACE   NAME                     READY   STATUS    RESTARTS   AGE
test        golang-fcffb8587-c7sxg   1/1     Running   0          17s
test        golang-fcffb8587-jf4sn   1/1     Running   0          17s
test        golang-fcffb8587-kbrwc   1/1     Running   0          17s
test        golang-fcffb8587-kcngn   1/1     Running   0          17s
```
