### PR TITLE
Ensure excluded-namespaces are properly configured before e2e tests

### DIFF
--- a/incubator/hnc/Makefile
+++ b/incubator/hnc/Makefile
@@ -247,7 +247,28 @@ kind-deploy:
 # Go test suite has a 10m timeout, and the flag disables that timeout (as of
 # July 2020, these tests take ~15m and that number is expected to grow).
 .PHONY: test-e2e
-test-e2e:
+test-e2e: exclude-system-namespaces
+	go clean -testcache
+	go test -v -timeout 0 ./test/e2e/...
+
+# This batch test will run e2e tests N times on the current cluster the user
+# deployed (either kind or a kubernetes cluster), e.g. "make test-e2e-batch N=10"
+.PHONY: test-e2e-batch
+test-e2e-batch: exclude-system-namespaces
+	number=1 ; while [[ $$number -le $N ]] ; do \
+		echo $$number ; \
+    ((number = number + 1)) ; \
+		go clean -testcache ; \
+		go test -v -timeout 0 ./test/e2e/... ; \
+	done
+
+exclude-system-namespaces:
+	@echo
+	@echo "Ensuring all system namespaces are excluded from HNC..."
+	@kubectl label ns hnc-system hnc.x-k8s.io/excluded-namespace=true --overwrite
+	@kubectl label ns kube-node-lease hnc.x-k8s.io/excluded-namespace=true --overwrite
+	@kubectl label ns kube-public hnc.x-k8s.io/excluded-namespace=true --overwrite
+	@kubectl label ns kube-system hnc.x-k8s.io/excluded-namespace=true --overwrite
 	@echo
 	@echo "If these tests fail due to the webhook not being ready, wait 30s and try again. Note that webhooks can take up to 30s to become ready"
 	@echo "after HNC is first deployed in a cluster."
@@ -260,8 +281,6 @@ ifndef HNC_REPAIR
 	@echo
 	@sleep 5
 endif
-	go clean -testcache
-	go test -v -timeout 0 ./test/e2e/...
 
 ###################### RELEASE ACTIONS #########################
 # Build the container image by Cloud Build and build YAMLs locally

--- a/incubator/hnc/README.md
+++ b/incubator/hnc/README.md
@@ -272,7 +272,7 @@ Within the `reconcilers` directory, there are four reconcilers:
 HNC uses Prow to run tests, which is configured
 [here](https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-sigs/wg-multi-tenancy).
 The presubmits run `hack/ci-test.sh` in this repo, and the postsubmits and
-periodics run `hack/prow-e2e`.  Results are displayed on
+periodics run `hack/prow-run-e2e.sh`.  Results are displayed on
 [testgrid](https://k8s-testgrid.appspot.com/wg-multi-tenancy-hnc) and are
 configured
 [here](https://github.com/kubernetes/test-infra/tree/master/config/testgrids/kubernetes/wg-multi-tenancy).


### PR DESCRIPTION
Part of #1480 

Force adding excluded-namespace labels to excluded namespaces before
running the e2e test so that it won't break the cluster. E.g. HNC object
webhook denies any object changes in namespaces without this label, it
could break `kube-system` namespace if the label is missing.

Add `test-e2e-batch` target and factor out the messages before e2e
tests for regular `test-e2e` and `test-e2e-batch`. Add link to
excluded-namespace concept.

Tested by `make test-e2e` and `make test-e2e-batch N=3`.

Prow config is unchanged because in `hack/prow-run-e2e.sh` for
postsubmit and periodic e2e tests, it's already using `test-e2e` target.

The output for `make test-e2e-batch N=10` looks like [this](https://gist.github.com/yiqigao217/d4b04bfe70afadae0fa31460e54752c5).