### PR TITLE
Handle bypassed webhook rules on excluded namespaces

### DIFF
--- a/incubator/hnc/api/v1alpha2/hierarchy_types.go
+++ b/incubator/hnc/api/v1alpha2/hierarchy_types.go
@@ -59,6 +59,7 @@ const (
 	ReasonDeletingCRD   string = "DeletingCRD"
 	ReasonInCycle       string = "InCycle"
 	ReasonParentMissing string = "ParentMissing"
+	ReasonIllegalParent string = "IllegalParent"
 	ReasonAnchorMissing string = "SubnamespaceAnchorMissing"
 )
 
@@ -71,6 +72,7 @@ var AllConditions = map[string][]string{
 		ReasonDeletingCRD,
 		ReasonInCycle,
 		ReasonParentMissing,
+		ReasonIllegalParent,
 	},
 	ConditionBadConfiguration: {
 		ReasonAnchorMissing,

--- a/incubator/hnc/internal/kubectl/describe.go
+++ b/incubator/hnc/internal/kubectl/describe.go
@@ -39,7 +39,7 @@ var describeCmd = &cobra.Command{
 		nnm := args[0]
 		fmt.Printf("Hierarchy configuration for namespace %s\n", nnm)
 		hier := client.getHierarchy(nnm)
-		anms := client.getAnchorNames(nnm)
+		as := client.getAnchorStatus(nnm)
 
 		// Parent
 		if hier.Spec.Parent != "" {
@@ -53,11 +53,11 @@ var describeCmd = &cobra.Command{
 		for _, cn := range hier.Status.Children {
 			childrenAndStatus[cn] = ""
 		}
-		for _, cn := range anms {
+		for cn, st := range as {
 			if _, ok := childrenAndStatus[cn]; ok {
 				childrenAndStatus[cn] = "subnamespace"
 			} else {
-				childrenAndStatus[cn] = "missing subnamespace"
+				childrenAndStatus[cn] = st + " subnamespace"
 			}
 		}
 		if len(childrenAndStatus) > 0 {

--- a/incubator/hnc/internal/reconcilers/hierarchy_config.go
+++ b/incubator/hnc/internal/reconcilers/hierarchy_config.go
@@ -85,16 +85,20 @@ type HierarchyConfigReconciler struct {
 
 // Reconcile sets up some basic variables and then calls the business logic.
 func (r *HierarchyConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	if config.ExcludedNamespaces[req.Namespace] {
-		return ctrl.Result{}, nil
+	ns := req.NamespacedName.Namespace
+	log := loggerWithRID(r.Log).WithValues("ns", ns)
+
+	// Always delete hierarchyconfiguration (and any other HNC CRs) in the
+	// excluded namespaces and early exit.
+	if config.ExcludedNamespaces[ns] {
+		// Since singletons in the excluded namespaces are never synced by HNC, there
+		// are no finalizers on the singletons that we can delete them without
+		// removing the finalizers first.
+		return ctrl.Result{}, r.deleteSingletonIfExists(ctx, log, ns)
 	}
 
 	stats.StartHierConfigReconcile()
 	defer stats.StopHierConfigReconcile()
-
-	ns := req.NamespacedName.Namespace
-
-	log := loggerWithRID(r.Log).WithValues("ns", ns)
 
 	return ctrl.Result{}, r.reconcile(ctx, log, ns)
 }
@@ -373,8 +377,11 @@ func (r *HierarchyConfigReconciler) syncParent(log logr.Logger, inst *api.Hierar
 
 	// Sync this namespace with its current parent.
 	curParent := r.Forest.Get(inst.Spec.Parent)
-	if curParent != nil && !curParent.Exists() {
-		log.Info("The parent doesn't appear to exist (or hasn't been synced yet)", "parent", inst.Spec.Parent)
+	if config.ExcludedNamespaces[inst.Spec.Parent] {
+		log.Info("Setting ConditionActivitiesHalted: excluded namespace set as parent", "parent", inst.Spec.Parent)
+		ns.SetCondition(api.ConditionActivitiesHalted, api.ReasonIllegalParent, fmt.Sprintf("Parent %q is an excluded namespace", inst.Spec.Parent))
+	} else if curParent != nil && !curParent.Exists() {
+		log.Info("Setting ConditionActivitiesHalted: parent doesn't exist (or hasn't been synced yet)", "parent", inst.Spec.Parent)
 		ns.SetCondition(api.ConditionActivitiesHalted, api.ReasonParentMissing, fmt.Sprintf("Parent %q does not exist", inst.Spec.Parent))
 	}
 
@@ -579,6 +586,37 @@ func (r *HierarchyConfigReconciler) writeHierarchy(ctx context.Context, log logr
 	}
 
 	return true, nil
+}
+
+// deleteSingletonIfExists deletes the singleton in the namespace if it exists.
+// Note: Make sure there's no finalizers on the singleton before calling this
+// function.
+func (r *HierarchyConfigReconciler) deleteSingletonIfExists(ctx context.Context, log logr.Logger, nm string) error {
+	inst, deletingCRD, err := r.getSingleton(ctx, nm)
+	if err != nil {
+		return err
+	}
+
+	// Early exit if the singleton doesn't exist.
+	if inst.CreationTimestamp.IsZero() {
+		return nil
+	}
+
+	// If the CRD is being deleted, we don't need to delete it separately. It will
+	// be deleted with the CRD.
+	if deletingCRD {
+		log.Info("HC in excluded namespace is already being deleted")
+		return nil
+	}
+	log.Info("Deleting illegal HC in excluded namespace")
+
+	stats.WriteHierConfig()
+	if err := r.Delete(ctx, inst); err != nil {
+		log.Error(err, "while deleting on apiserver")
+		return err
+	}
+
+	return nil
 }
 
 func (r *HierarchyConfigReconciler) writeNamespace(ctx context.Context, log logr.Logger, orig, inst *corev1.Namespace) (bool, error) {

--- a/incubator/hnc/internal/reconcilers/test_helpers_test.go
+++ b/incubator/hnc/internal/reconcilers/test_helpers_test.go
@@ -51,6 +51,17 @@ func getHierarchy(ctx context.Context, nm string) *api.HierarchyConfiguration {
 	return hier
 }
 
+func canGetHierarchy(ctx context.Context, nm string) func() bool {
+	return func() bool {
+		nnm := types.NamespacedName{Namespace: nm, Name: api.Singleton}
+		hier := &api.HierarchyConfiguration{}
+		if err := k8sClient.Get(ctx, nnm, hier); err != nil {
+			return false
+		}
+		return true
+	}
+}
+
 func updateHierarchy(ctx context.Context, h *api.HierarchyConfiguration) {
 	if h.CreationTimestamp.IsZero() {
 		ExpectWithOffset(1, k8sClient.Create(ctx, h)).Should(Succeed())


### PR DESCRIPTION
Fixes #1443

Remove any HNC CRs (hierarchyconfiguration and anchor) from the excluded
namespaces if they are successfully created bypassing the webhook.

Set `ActivitiesHalted: IllegalParent` condition if a namespace sets an
excluded namespace as a parent, e.g.
```
$ kubectl hns describe a
Hierarchy configuration for namespace a
  Parent: kube-system
  Children:
  - d (subnamespace)
  Conditions:
  - ActivitiesHalted (IllegalParent): Parent "kube-system" is an excluded namespace
```

Subnamespace anchor using an excluded namespace name would get
`Forbidden` state. Update the `kubectl hns describe` to show:
```
$ kubectl hns describe parent
Hierarchy configuration for namespace parent
  No parent
  Children:
  - d (Conflict subnamespace)
  - e (subnamespace)
  - f
  - kube-system (Forbidden subnamespace)
  No conditions
```

Tested by `make test` since there's no wehbook in the integration tests. Passed `make test-e2e`.