### PR TITLE
Sync object propagation on newly labeled namespaces

### DIFF
--- a/incubator/hnc/internal/forest/namespace.go
+++ b/incubator/hnc/internal/forest/namespace.go
@@ -1,6 +1,8 @@
 package forest
 
 import (
+	"reflect"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -92,12 +94,15 @@ func (ns *Namespace) GetLabels() labels.Set {
 	return labels.Set(ns.labels)
 }
 
-// Deep copy the input labels so that it'll not be changed after
-func (ns *Namespace) SetLabels(labels map[string]string) {
+// Deep copy the input labels so that it'll not be changed after. It returns
+// true if the labels are updated; returns false if there's no change.
+func (ns *Namespace) SetLabels(labels map[string]string) bool {
+	updated := !reflect.DeepEqual(ns.labels, labels)
 	ns.labels = make(map[string]string)
 	for key, val := range labels {
 		ns.labels[key] = val
 	}
+	return updated
 }
 
 // clean garbage collects this namespace if it has a zero value.

--- a/incubator/hnc/internal/reconcilers/hierarchy_config.go
+++ b/incubator/hnc/internal/reconcilers/hierarchy_config.go
@@ -144,13 +144,13 @@ func (r *HierarchyConfigReconciler) reconcile(ctx context.Context, log logr.Logg
 	r.updateFinalizers(ctx, log, inst, nsInst, anms)
 
 	// Sync the Hierarchy singleton with the in-memory forest.
-	initial := r.syncWithForest(log, nsInst, inst, deletingCRD, anms)
+	needUpdateObjects := r.syncWithForest(log, nsInst, inst, deletingCRD, anms)
 
 	// Write back if anything's changed. Early-exit if we just write back exactly what we had and this
 	// isn't the first time we're syncing.
 	updated, err := r.writeInstances(ctx, log, origHC, inst, origNS, nsInst)
-	updated = updated || initial
-	if !updated || err != nil {
+	needUpdateObjects = updated || needUpdateObjects
+	if !needUpdateObjects || err != nil {
 		return err
 	}
 
@@ -223,7 +223,8 @@ func (r *HierarchyConfigReconciler) updateFinalizers(ctx context.Context, log lo
 // guarded by the forest mutex, which means that none of the other namespaces being reconciled will
 // be able to proceed until this one is finished. While the results of the reconiliation may not be
 // fully written back to the apiserver yet, each namespace is reconciled in isolation (apart from
-// the in-memory forest) so this is fine.
+// the in-memory forest) so this is fine. Return true, if the namespace is just synced or the
+// namespace labels are changed that requires updating all objects in the namespaces.
 func (r *HierarchyConfigReconciler) syncWithForest(log logr.Logger, nsInst *corev1.Namespace, inst *api.HierarchyConfiguration, deletingCRD bool, anms []string) bool {
 	r.Forest.Lock()
 	defer r.Forest.Unlock()
@@ -257,9 +258,9 @@ func (r *HierarchyConfigReconciler) syncWithForest(log logr.Logger, nsInst *core
 	r.syncConditions(log, inst, ns, deletingCRD, hadCrit)
 
 	// Sync the tree labels. This should go last since it can depend on the conditions.
-	r.syncLabel(log, nsInst, ns)
+	nsCustomerLabelUpdated := r.syncLabel(log, nsInst, ns)
 
-	return initial
+	return initial || nsCustomerLabelUpdated
 }
 
 // syncExternalNamespace sets external tree labels to the namespace in the forest
@@ -420,10 +421,11 @@ func (r *HierarchyConfigReconciler) syncAnchors(log logr.Logger, ns *forest.Name
 	}
 }
 
-func (r *HierarchyConfigReconciler) syncLabel(log logr.Logger, nsInst *corev1.Namespace, ns *forest.Namespace) {
+// Sync namespace tree labels and other labels. Return true if the labels are updated.
+func (r *HierarchyConfigReconciler) syncLabel(log logr.Logger, nsInst *corev1.Namespace, ns *forest.Namespace) bool {
 	if ns.IsExternal() {
 		metadata.SetLabel(nsInst, nsInst.Name+api.LabelTreeDepthSuffix, "0")
-		return
+		return false
 	}
 
 	// Remove all existing depth labels.
@@ -461,7 +463,11 @@ func (r *HierarchyConfigReconciler) syncLabel(log logr.Logger, nsInst *corev1.Na
 	}
 	// Update the labels in the forest so that we can quickly access the labels and
 	// compare if they match the given selector
-	ns.SetLabels(nsInst.Labels)
+	if ns.SetLabels(nsInst.Labels) {
+		log.Info("Namespace labels have been updated.")
+		return true
+	}
+	return false
 }
 
 func (r *HierarchyConfigReconciler) syncConditions(log logr.Logger, inst *api.HierarchyConfiguration, ns *forest.Namespace, deletingCRD, hadCrit bool) {

--- a/incubator/hnc/internal/reconcilers/test_helpers_test.go
+++ b/incubator/hnc/internal/reconcilers/test_helpers_test.go
@@ -108,6 +108,22 @@ func createNSes(ctx context.Context, num int) []string {
 	return nms
 }
 
+func addNamespaceLabel(ctx context.Context, nm, k, v string) {
+	ns := getNamespace(ctx, nm)
+	l := ns.Labels
+	l[k] = v
+	ns.SetLabels(l)
+	updateNamespace(ctx, ns)
+}
+
+func removeNamespaceLabel(ctx context.Context, nm, k string) {
+	ns := getNamespace(ctx, nm)
+	l := ns.Labels
+	delete(l, k)
+	ns.SetLabels(l)
+	updateNamespace(ctx, ns)
+}
+
 func updateNamespace(ctx context.Context, ns *corev1.Namespace) {
 	ExpectWithOffset(1, k8sClient.Update(ctx, ns)).Should(Succeed())
 }


### PR DESCRIPTION
Detect namespace label changes. If the labels are updated, ensure
syncing all the objects (including non-existing yet but possible
propagated objects) in the namespace, so that we will not miss any
propagation label changes that should trigger propagation or
unpropagation.

Add integration tests in reconciler/object_test.go.

Tested manually that labeling and unlabeling a child with the propagate
label won't do anything before the fix, but triggers propagation and
unpropagation accordingly after the fix. Also tested with `make test`,
passed after the fix ant failed before the fix.