### PR TITLE
Disable broken test

### DIFF
--- a/incubator/hnc/test/e2e/issues_test.go
+++ b/incubator/hnc/test/e2e/issues_test.go
@@ -215,7 +215,10 @@ var _ = Describe("Issues", func() {
 		MustRun("kubectl delete subns", nsChild, "-n", nsParent)
 	})
 
-	It("Should have CannotPropagateObject and CannotUpdateObject events - replacing obsolete issues #328, #605, #771", func() {
+	// Disabled due to https://github.com/kubernetes-sigs/multi-tenancy/issues/1492 - now that HNC
+	// *can* propagate cluster-admin rolebindings (see the test for #772), we need to find some new
+	// way to test what HNC does when it *can't* propagate something.
+	XIt("Should have CannotPropagateObject and CannotUpdateObject events - replacing obsolete issues #328, #605, #771", func() {
 		// Set up
 		CreateNamespace(nsParent)
 		CreateNamespace(nsChild)


### PR DESCRIPTION
This test assumed that HNC was not able to propagate cluster-admin
rolebindings, but this just changed so the test is now failing.

Issue #1492 tracks re-enabling this, but for now we'll disable.