### PR TITLE
Update docs for upcoming v0.8

### DIFF
--- a/incubator/hnc/docs/user-guide/README.md
+++ b/incubator/hnc/docs/user-guide/README.md
@@ -1,4 +1,4 @@
-# HNC User Guide v0.7 (and v0.6)
+# HNC User Guide v0.8 (and v0.7)
 
 Authors: aludwin@google.com and other contributors from wg-multitenancy
 
@@ -12,7 +12,7 @@ This guide explains how to use hierarchical namespaces, explains some of the
 concepts behind them for a more in-depth understanding, and covers some best
 practices.
 
-**Note: this doc covers HNC v0.7.x and v0.6.x.** For older versions of HNC,
+**Note: this doc covers HNC v0.8.x and v0.7.x.** For older versions of HNC,
 see below.
 
 ## Table of contents
@@ -25,6 +25,7 @@ see below.
 
 ## Older user guides
 
+* [HNC v0.6](https://github.com/kubernetes-sigs/multi-tenancy/tree/hnc-v0.6/incubator/hnc/docs/user-guide)
 * [HNC v0.5](https://github.com/kubernetes-sigs/multi-tenancy/tree/hnc-v0.5/incubator/hnc/docs/user-guide)
 * [HNC v0.4](https://github.com/kubernetes-sigs/multi-tenancy/tree/hnc-v0.4/incubator/hnc/docs/user-guide)
 * [HNC v0.3](https://docs.google.com/document/d/1XVVv1ha4j1WUaszu3mmlACeWPUJXbJhA6zntxswrsco)

--- a/incubator/hnc/docs/user-guide/concepts.md
+++ b/incubator/hnc/docs/user-guide/concepts.md
@@ -318,8 +318,6 @@ application.
 
 ### Exceptions and propagation control
 
-***Exceptions are only available in HNC v0.7***
-
 By default, HNC propagates _all_ objects of a [specified type](how-to.md#admin-resources)
 from ancestor namespaces to descendant namespaces. However, sometimes this is
 too restrictive, and you need to create ***exceptions*** to certain policies. For example:
@@ -537,18 +535,8 @@ We are considering replacing this with the standard
 
 This label should be added to namespaces such as `kube-system` and `kube-public`
 so that HNC's validating webhook cannot accidentally prevent operations in these
-namespaces and block critical cluster operations.
-
-Before installing HNC, users can customize the excluded namespace list in the HNC
-deployment with a container arg called `excluded-namespace` in
-`config/manager/manager.yaml` and then set this label on the excluded namespaces.
-Setting this label on namespaces that are not
-listed in the HNC deployment as an `excluded-namespace` is not allowed.
-
-As of March 2021, the default excluded namespaces listed in [config/manager/manager.yaml](https://github.com/kubernetes-sigs/multi-tenancy/blob/master/incubator/hnc/config/manager/manager.yaml)
-are `kube-system`, `kube-public`, `hnc-system` and
-`kube-node-lease`. HNC adds this label to `hnc-system` namespace by default, so
-users will have to add this label to other excluded namespaces manually.
+namespaces and block critical cluster operations. See [Excluding namespaces from
+HNC](how-to.md#admin-excluded-namespaces) for more information.
 
 <a name="admin-labels-set">
 

--- a/incubator/hnc/docs/user-guide/quickstart.md
+++ b/incubator/hnc/docs/user-guide/quickstart.md
@@ -630,7 +630,7 @@ also show up in the HNC logs, and in its [metrics](how-to.md#admin-metrics).
 
 <a name="exceptions"/>
 
-## Keeping objects out of certain namespaces (v0.7 only)
+## Keeping objects out of certain namespaces
 
 _Demonstrates: exceptions_
 


### PR DESCRIPTION
Add documentation for excluded namespaces and remove references to HNC
v0.6.

Fixes #1466 

Interesting modified files include:
* [Installation instructions](https://github.com/adrianludwin/multi-tenancy/blob/docs-v08/incubator/hnc/docs/user-guide/how-to.md#prerequisite)
* [Excluded namespaces howto](https://github.com/adrianludwin/multi-tenancy/blob/docs-v08/incubator/hnc/docs/user-guide/how-to.md#admin-excluded-namespaces)
* [CLI howto](https://github.com/adrianludwin/multi-tenancy/blob/docs-v08/incubator/hnc/docs/user-guide/how-to.md#admin-cli-args)
* [Labels concepts](https://github.com/adrianludwin/multi-tenancy/blob/docs-v08/incubator/hnc/docs/user-guide/concepts.md#hncx-k8sioexcluded-namespace-label-on-namespaces)