### PR TITLE
Increase HNC release timeout to 30m (HNC v0.8 branch)

### DIFF
--- a/incubator/hnc/Makefile
+++ b/incubator/hnc/Makefile
@@ -370,7 +370,7 @@ endif
 	@echo "Starting build."
 	@echo "*********************************************"
 	@echo "*********************************************"
-	gcloud builds submit --config cloudbuild.yaml --no-source --substitutions=${HNC_GCB_SUBS}
+	gcloud builds submit --config cloudbuild.yaml --no-source --substitutions=${HNC_GCB_SUBS} --timeout=30m
 	@echo "*********************************************"
 	@echo "*********************************************"
 	@echo "Pushing ${HNC_IMG} to ${HNC_RELEASE_IMG}"


### PR DESCRIPTION
Apparently the default limit is 10m and we've now gone over that (we
were averaging around 7m, I wonder if GCB now uses a slower machine
since little has changed on our side). Anyway, 30m should be enough for
the foreseeable future.