### PR TITLE
Allow HNC to propagate changes to CRD.

### DIFF
--- a/incubator/hnc/.gitignore
+++ b/incubator/hnc/.gitignore
@@ -25,3 +25,4 @@ manifests
 *.swp
 *.swo
 *~
+.vscode

--- a/incubator/hnc/internal/reconcilers/object.go
+++ b/incubator/hnc/internal/reconcilers/object.go
@@ -570,8 +570,10 @@ func (r *ObjectReconciler) writeObject(ctx context.Context, log logr.Logger, ins
 	// The object exists if CreationTimestamp is set. This flag enables us to have only 1 API call.
 	exist := inst.GetCreationTimestamp() != v1.Time{}
 	ns := inst.GetNamespace()
-	// Get current ResourceVersion, required for smooth updates.
+	// Get current ResourceVersion, required for updates for newer API objects (including custom resources).
 	rv := inst.GetResourceVersion()
+
+	// Overwrite the propagated copy with the source, then restore all essential properties of the copy.
 	inst = object.Canonical(srcInst)
 	inst.SetNamespace(ns)
 	// we should set the resourceVersion when updating the object, which is required by k8s.

--- a/incubator/hnc/internal/reconcilers/object.go
+++ b/incubator/hnc/internal/reconcilers/object.go
@@ -570,8 +570,13 @@ func (r *ObjectReconciler) writeObject(ctx context.Context, log logr.Logger, ins
 	// The object exists if CreationTimestamp is set. This flag enables us to have only 1 API call.
 	exist := inst.GetCreationTimestamp() != v1.Time{}
 	ns := inst.GetNamespace()
+	// Get current ResourceVersion, required for smooth updates.
+	rv := inst.GetResourceVersion()
 	inst = object.Canonical(srcInst)
 	inst.SetNamespace(ns)
+	// we should set the resourceVersion when updating the object, which is required by k8s.
+	// for more details see https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/53.
+	inst.SetResourceVersion(rv)
 	metadata.SetLabel(inst, api.LabelInheritedFrom, srcInst.GetNamespace())
 	log.V(1).Info("Writing", "dst", inst.GetNamespace(), "origin", srcInst.GetNamespace())
 

--- a/incubator/hnc/pkg/testutils/testutils.go
+++ b/incubator/hnc/pkg/testutils/testutils.go
@@ -210,7 +210,7 @@ func MustApplyYAML(s string) {
 	MustRun("kubectl apply -f", filename)
 }
 
-func MustNotApplyYAML(s string){
+func MustNotApplyYAML(s string) {
 	filename := writeTempFile(s)
 	defer removeFile(filename)
 	MustNotRun("kubectl apply -f", filename)
@@ -272,6 +272,19 @@ func CleanupTestNamespaces() {
 		return nil
 	}).Should(Succeed(), "while getting list of namespaces to clean up")
 	cleanupNamespaces(nses...)
+}
+
+// CleanupCRDIfExists checks whether the eetests.e2e.hnc.x-k8s.io CRD is present, if so, delete it.
+func CleanupTestCRDIfExists() {
+	crd := "eetests.e2e.hnc.x-k8s.io"
+	if err := TryRunQuietly("kubectl get crd", crd); err != nil {
+		// crd does not exist, return directly.
+		return
+	}
+
+	MustRun("kubectl delete crd", crd)
+	// make sure the crd has been deleted.
+	RunShouldNotContain(crd, 10, "kubectl get crd")
 }
 
 // cleanupNamespaces does everything it can to delete the passed-in namespaces. It also uses very

--- a/incubator/hnc/test/e2e/issues_test.go
+++ b/incubator/hnc/test/e2e/issues_test.go
@@ -27,6 +27,7 @@ var _ = Describe("Issues", func() {
 
 	AfterEach(func() {
 		CleanupTestNamespaces()
+		CleanupTestCRDIfExists()
 	})
 
 	It("Should not delete full namespace when a faulty anchor is deleted - issue #1149", func() {
@@ -270,7 +271,7 @@ var _ = Describe("Issues", func() {
 		CreateNamespace(nsParent)
 		MustRun("kubectl get ns", nsParent)
 		CreateSubnamespace(nsChild, nsParent)
-		CRD := `# a simple CRD used for e2e testing only, should be deleted after finishing(or failing) this testcase.
+		crd := `# a simple CRD used for e2e testing only, should be deleted after finishing(or failing) this testcase.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -313,8 +314,7 @@ spec:
     served: true
     storage: true`
 		// create CRD and set the propagation strategy for it.
-		MustApplyYAML(CRD)
-		defer MustRun("kubectl delete crd eetests.e2e.hnc.x-k8s.io")
+		MustApplyYAML(crd)
 		MustRun("kubectl hns config set-resource eetests --group e2e.hnc.x-k8s.io --mode Propagate --force")
 
 		eetest := `# this is an instance of CRD eetests.e2e.hnc.x-k8s.io/v1


### PR DESCRIPTION
> A PR would be great, thanks! Just a few quick pointers / requests:
> 
> * A change like this benefits from a _lot_ of comments, e.g. linking to this issue. Otherwise we'll have no idea why we added this in a few months.
> * It would be great if you could add or update a unit test to verify that the rV is being copied (e.g. [here](https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/42769da7fce8bd4c71a4ef2fd0735f43ce4710a7/internal/reconcilers/object_test.go#L367).
> * It would be _amazing_ if you could update an end-to-end test (e.g. [here](https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/master/test/e2e/issues_test.go)) to try to propagate a CRD, show that this fails without your fix, and that it passes with your fix.  [This](https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/42769da7fce8bd4c71a4ef2fd0735f43ce4710a7/test/e2e/issues_test.go#L233) test is probably a pretty good model, and you can embed yaml in the test as shown [here](https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/42769da7fce8bd4c71a4ef2fd0735f43ce4710a7/test/e2e/quickstart_test.go#L171).
>   
>   * The e2e tests assume that you've deployed HNC to a cluster, and your kubectl config is currently pointing at the cluster you want to run the tests on.
>   * Running _all_ the e2e tests takes ~30min but you only need to run the one you're writing. So you can modify your test so that the `It()` function has an `F` (for "focus") in front of it, like this: `FIt()` (note the first two letters are capitalized). This will only run _your_ test. Just remember to change it back to `It()` before you submit the PR.
> * We use one commit per PR so please squash all commits and force-update the PR branch if necessary. We also describe how we tested the change in the commit message like [this](https://github.com/kubernetes-sigs/hierarchical-namespaces/commit/0fa702a121605c7cfb3f935f95da412cbd27fb1d).

@adrianludwin PTAL, follow your pointers
- I have link the issue and add some description to the code 
- for the unit test, I have no idea about how to `verify that the rV is being copied` by now, because every resource in k8s will have a `ResourceVersion`.
- e2e test have been added and tested.
- the commit msg is detailed for how to reproduce before this pr's change.
