### PR TITLE
Add block_role_privilege_escalation benchmark

### DIFF
--- a/benchmarks/kubectl-mtb/README.md
+++ b/benchmarks/kubectl-mtb/README.md
@@ -6,7 +6,7 @@
 
 > kubectl plugin to validate multi-tenancy configuration for a Kubernetes cluster.
 
-The `mtb` kubectl plugin provides behavioral and configuration checks to help validate if a cluster is properly configured for multi-tenant use. 
+The `mtb` kubectl plugin provides behavioral and configuration checks to help validate if a cluster is properly configured for multi-tenant use.
 
 ## Demo
 
@@ -121,7 +121,7 @@ For conformance with benchmarks like `Configure namespace resource quotas`, the 
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/multi-tenancy/master/benchmarks/kubectl-mtb/test/quotas/ns_quota.yaml
 ```
 
-After applying the policies and ResourceQuota object, run the benchmarks again. All benchmarks should pass. 
+After applying the policies and ResourceQuota object, run the benchmarks again. All benchmarks should pass.
 
 <img width="570" alt="passed-tests" src="https://user-images.githubusercontent.com/21216969/89316882-42aa8300-d69a-11ea-997a-557708fa0da0.png">
 
@@ -165,14 +165,14 @@ The generated binary will create the relevant templates, needed to write the bec
 **Example :**
 
 ```bash
-./mtb-builder create block multitenant resources -p 1
+./mtb-builder create "block multitenant resources" -p 1
 ```
 
-Here,  `create block multitenant resources` is name of the benchmark and `-p` flag is used here to mention the profile level. The above command will generate a directory named `create_block_multitenant_resources` under which following files would be present.
+Here, `block multitenant resources` is name of the benchmark and `-p` flag is used here to mention the profile level. The above command will generate a directory named `block_multitenant_resources` under which following files would be present.
 
 * config.yaml
-* create_block_multitenant_resources_test.go
-* create_block_multitenant_resources.go
+* block_multitenant_resources_test.go
+* block_multitenant_resources.go
 
 
 ### Generate README
@@ -185,7 +185,7 @@ make readme
 
 ### Run unit tests
 
-* The unit tests run on a separate kind cluster. To run all the unit test you can run the command `make unit-tests` this will create a new cluster if it cannot be found on your machine. By default, the cluster is named `kubectl-mtb-suite`, after the tests are done, the cluster will be deleted. 
+* The unit tests run on a separate kind cluster. To run all the unit test you can run the command `make unit-tests` this will create a new cluster if it cannot be found on your machine. By default, the cluster is named `kubectl-mtb-suite`, after the tests are done, the cluster will be deleted.
 
 * If you want to run a particular unit test, you can checkout into the particular benchmark directory and run `go test` which will create a cluster named `kubectl-mtb` which will be deleted after the tests are completed.
 

--- a/benchmarks/kubectl-mtb/test/benchmarks/block_other_tenant_resources/README.md
+++ b/benchmarks/kubectl-mtb/test/benchmarks/block_other_tenant_resources/README.md
@@ -10,7 +10,7 @@ Configuration
 
 **Category:**
 
-Tenant Protection
+Tenant Isolation
 
 **Description:**
 
@@ -32,6 +32,7 @@ For each namespaced resource, and each verb (get, list, create, update, patch, w
 kubectl --kubeconfig tenant-a -n b1 &lt;verb&gt; &lt;resource&gt;
 ```
 Each command must return &#39;no&#39;
+
 
 
 **namespaceRequired:** 

--- a/benchmarks/kubectl-mtb/test/benchmarks/block_other_tenant_resources/config.yaml
+++ b/benchmarks/kubectl-mtb/test/benchmarks/block_other_tenant_resources/config.yaml
@@ -1,9 +1,9 @@
 id: MTB-PL1-CC-TI-2
 title: Block access to other tenant resources
 benchmarkType: Configuration
-category: Tenant Protection
+category: Tenant Isolation
 description: Access controls should be configured so that a tenant cannot view, edit, create, or delete namespaced resources belonging to another tenant.
-remediation: 
+remediation:
 profileLevel: 2
 namespaceRequired: 2
 rationale: Tenant resources should be isolated from other tenants.

--- a/benchmarks/kubectl-mtb/test/benchmarks/block_role_privilege_escalation/README.md
+++ b/benchmarks/kubectl-mtb/test/benchmarks/block_role_privilege_escalation/README.md
@@ -1,0 +1,29 @@
+# Block role privilege escalation <small>[MTB-PL2-CC-TI-1] </small>
+
+**Profile Applicability:**
+
+2
+
+**Type:**
+
+Configuration
+
+**Category:**
+
+Tenant Isolation
+
+**Description:**
+
+Tenants should not have the ability to escalate their Role beyond the permissions the administrator gives them.
+
+
+**Audit:**
+
+`kubectl auth can-i escalate role -n &lt;ns&gt;` and `kubectl auth can-i bind clusterrole/cluster-admin -n &lt;ns&gt;` should return &#34;no&#34; for each tenant.
+
+
+**Remediation:**
+
+Ensure that users can&#39;t perform the &#34;escalate&#34; verb on Roles. Ensure users can&#39;t perform the &#34;bind&#34; verb on arbitrary Roles/ClusterRoles. Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping
+
+

--- a/benchmarks/kubectl-mtb/test/benchmarks/block_role_privilege_escalation/README.md
+++ b/benchmarks/kubectl-mtb/test/benchmarks/block_role_privilege_escalation/README.md
@@ -19,7 +19,7 @@ Tenants should not have the ability to escalate their Role beyond the permission
 
 **Audit:**
 
-`kubectl auth can-i escalate role -n &lt;ns&gt;` and `kubectl auth can-i bind clusterrole/cluster-admin -n &lt;ns&gt;` should return &#34;no&#34; for each tenant.
+`kubectl auth can-i escalate role --as tenant -n namespace` and `kubectl auth can-i bind clusterrole/cluster-admin --as tenant -n namespace` should return &#34;no&#34; for each tenant.
 
 
 **Remediation:**

--- a/benchmarks/kubectl-mtb/test/benchmarks/block_role_privilege_escalation/block_role_privilege_escalation.go
+++ b/benchmarks/kubectl-mtb/test/benchmarks/block_role_privilege_escalation/block_role_privilege_escalation.go
@@ -1,0 +1,66 @@
+package blockroleprivilegeescalation
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/multi-tenancy/benchmarks/kubectl-mtb/bundle/box"
+	"sigs.k8s.io/multi-tenancy/benchmarks/kubectl-mtb/pkg/benchmark"
+	"sigs.k8s.io/multi-tenancy/benchmarks/kubectl-mtb/test"
+	"sigs.k8s.io/multi-tenancy/benchmarks/kubectl-mtb/test/utils"
+	"sigs.k8s.io/multi-tenancy/benchmarks/kubectl-mtb/types"
+)
+
+var b = &benchmark.Benchmark{
+
+	PreRun: func(options types.RunOptions) error {
+
+		return nil
+	},
+	Run: func(options types.RunOptions) error {
+		// Tenants shouldn't be allowed to "escalate" roles or "bind" to a higher-privileged role like cluster-admin.
+		// Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping
+		roleResource := utils.GroupResource{
+			APIGroup: "rbac.authorization.k8s.io",
+			APIResource: metav1.APIResource{
+				Name: "role",
+			},
+		}
+		access, msg, err := utils.RunAccessCheck(options.Tenant1Client, options.TenantNamespace, roleResource, "escalate")
+		if err != nil {
+			options.Logger.Debug(err.Error())
+			return err
+		}
+		if access {
+			return fmt.Errorf(msg)
+		}
+		// This mainly checks if tenants have been _accidentally_ given access to bind to any role, via "resourceNames: ['*']".
+		// There's still the chance they have access to bind to specific roles, but that would likely have been set explicitly by an admin.
+		crResource := utils.GroupResource{
+			APIGroup: "rbac.authorization.k8s.io",
+			APIResource: metav1.APIResource{
+				Name: "clusterrole",
+			},
+			ResourceName: "cluster-admin",
+		}
+		access, msg, err = utils.RunAccessCheck(options.Tenant1Client, options.TenantNamespace, crResource, "bind")
+		if err != nil {
+			options.Logger.Debug(err.Error())
+			return err
+		}
+		if access {
+			return fmt.Errorf(msg)
+		}
+		return nil
+	},
+}
+
+func init() {
+	// Get the []byte representation of a file, or an error if it doesn't exist:
+	err := b.ReadConfig(box.Get("block_role_privilege_escalation/config.yaml"))
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	test.BenchmarkSuite.Add(b)
+}

--- a/benchmarks/kubectl-mtb/test/benchmarks/block_role_privilege_escalation/block_role_privilege_escalation_test.go
+++ b/benchmarks/kubectl-mtb/test/benchmarks/block_role_privilege_escalation/block_role_privilege_escalation_test.go
@@ -1,0 +1,1 @@
+package blockroleprivilegeescalation

--- a/benchmarks/kubectl-mtb/test/benchmarks/block_role_privilege_escalation/config.yaml
+++ b/benchmarks/kubectl-mtb/test/benchmarks/block_role_privilege_escalation/config.yaml
@@ -1,0 +1,12 @@
+id: MTB-PL2-CC-TI-1
+title: Block role privilege escalation
+benchmarkType: Configuration
+category: Tenant Isolation
+description: |
+  Tenants should not have the ability to escalate their Role beyond the permissions the administrator gives them.
+remediation: |
+  Ensure that users can't perform the "escalate" verb on Roles. Ensure users can't perform the "bind" verb on arbitrary Roles/ClusterRoles. Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping
+
+profileLevel: 2
+audit: |
+  `kubectl auth can-i escalate role -n <ns>` and `kubectl auth can-i bind clusterrole/cluster-admin -n <ns>` should return "no" for each tenant.

--- a/benchmarks/kubectl-mtb/test/benchmarks/block_role_privilege_escalation/config.yaml
+++ b/benchmarks/kubectl-mtb/test/benchmarks/block_role_privilege_escalation/config.yaml
@@ -9,4 +9,4 @@ remediation: |
 
 profileLevel: 2
 audit: |
-  `kubectl auth can-i escalate role -n <ns>` and `kubectl auth can-i bind clusterrole/cluster-admin -n <ns>` should return "no" for each tenant.
+  `kubectl auth can-i escalate role --as tenant -n namespace` and `kubectl auth can-i bind clusterrole/cluster-admin --as tenant -n namespace` should return "no" for each tenant.


### PR DESCRIPTION
See #1518 for full details.

In short, it's very easy for administrators to accidentally grant users the undocumented ["escalate" verb](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping) on tenant Roles, which lets tenants bypass many other benchmarks, like by deleting ResourceQuotas/LimitRanges. Since it's such a pain to obtain the "true" full list of verbs when writing Roles, administrators are likely to read the "Allow self-service management of Roles" benchmark and create a role like the following:

```yaml
# don't use this role
- apiGroups: ['rbac.authorization.k8s.io']
  resources: ['*']
  verbs: ['*']
```

When instead they should enumerate all of the verbs, leaving out the "escalate" verb:

```yaml
- apiGroups: ['rbac.authorization.k8s.io']
  resources: ['*']
  verbs: ['create', 'delete', 'deletecollection', 'get', 'list', 'patch', 'update', 'watch']
```

This PR helps catch that common mistake.

Also: I updated the builder instructions in the README and updated the category on "Block access to other tenant resources" to match the real category name.



