### PR TITLE
Improve 'usage' and fix error handling for unknown IDs

### DIFF
--- a/benchmarks/kubectl-mtb/README.md
+++ b/benchmarks/kubectl-mtb/README.md
@@ -40,6 +40,12 @@ Run benchmarks:
 kubectl-mtb run benchmarks -n "namespace" --as "user"
 ```
 
+Run a specific benchmark by ID:
+
+```bash
+kubectl-mtb run benchmark MTB-PL2-CC-TI-1 -n "namespace" --as "user"
+```
+
 ## Complete example
 
 ### Create a namespace

--- a/benchmarks/kubectl-mtb/internal/kubectl-mtb/get.go
+++ b/benchmarks/kubectl-mtb/internal/kubectl-mtb/get.go
@@ -27,7 +27,7 @@ import (
 )
 
 var getCmd = &cobra.Command{
-	Use:   "get <resource>",
+	Use:   "get [benchmark|benchmarks] [<benchmark ID>]",
 	Short: "display one or many benchmarks.",
 
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
@@ -35,7 +35,9 @@ var getCmd = &cobra.Command{
 			return err
 		}
 
-		filterBenchmarks(cmd, args)
+		if err := filterBenchmarks(cmd, args); err != nil {
+			return err
+		}
 		return nil
 	},
 

--- a/benchmarks/kubectl-mtb/internal/kubectl-mtb/run.go
+++ b/benchmarks/kubectl-mtb/internal/kubectl-mtb/run.go
@@ -35,7 +35,7 @@ import (
 var benchmarkRunOptions = types.RunOptions{}
 
 var runCmd = &cobra.Command{
-	Use:   "run <resource>",
+	Use:   "run [benchmark|benchmarks] [<benchmark ID>]",
 	Short: "run one or more multi-tenancy benchmarks",
 
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
@@ -48,7 +48,9 @@ var runCmd = &cobra.Command{
 			return err
 		}
 
-		filterBenchmarks(cmd, args)
+		if err := filterBenchmarks(cmd, args); err != nil {
+			return err
+		}
 		return nil
 
 	},

--- a/benchmarks/kubectl-mtb/internal/kubectl-mtb/util.go
+++ b/benchmarks/kubectl-mtb/internal/kubectl-mtb/util.go
@@ -2,6 +2,7 @@ package kubectl
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/multi-tenancy/benchmarks/kubectl-mtb/pkg/benchmark"
@@ -15,7 +16,7 @@ func getResource(args []string) (string, error) {
 
 	r := args[0]
 	if !supportedResourceNames.Has(r) {
-		return "", fmt.Errorf("Please specify a valid resource")
+		return "", fmt.Errorf("Please specify one of the following resources: %v", reflect.ValueOf(supportedResourceNames).MapKeys())
 	}
 
 	return r, nil
@@ -29,14 +30,18 @@ func getBenchmarkArg(args []string) string {
 	return args[1]
 }
 
-func filterBenchmarks(cmd *cobra.Command, args []string) {
+func filterBenchmarks(cmd *cobra.Command, args []string) error {
 	profileLevel, _ := cmd.Flags().GetInt("profile-level")
 
 	id := getBenchmarkArg(args)
 	if id != "" {
 		b := test.BenchmarkSuite.ID(id)
+		if b == nil {
+			return fmt.Errorf("unknown benchmark ID: %s", id)
+		}
 		benchmarks = []*benchmark.Benchmark{b}
 	} else {
 		benchmarks = test.BenchmarkSuite.ProfileLevel(profileLevel)
 	}
+	return nil
 }


### PR DESCRIPTION
Fixes #1520 

* I had a hard time understanding what a "resource" is, since really it just has to be the word "benchmark(s)", which is optional. So I made the "usage" more explicit, and used the not-very-official POSIX specification for the args: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html 
   -  Seems like needing to specify "benchmark" may have been leftover from some plan for kubectl-mtb to run things other than benchmarks.  Should we just remove that arg all together since it's optional anyway?
* Made `filterBenchmarks` return an error if the user specified an ID that didn't exist. Without this check, you get a nil element in the variable `benchmark` which causes segfaults elsewhere in the code.