### PR TITLE
Allow the AlwaysPullImages admission plugin to satisfy benchmark

### DIFF
--- a/benchmarks/kubectl-mtb/internal/kubectl-mtb/run.go
+++ b/benchmarks/kubectl-mtb/internal/kubectl-mtb/run.go
@@ -160,7 +160,7 @@ func validateFlags(cmd *cobra.Command) error {
 
 	_, err = benchmarkRunOptions.ClusterAdminClient.CoreV1().Namespaces().Get(context.TODO(), benchmarkRunOptions.TenantNamespace, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("invalid namespace")
+		return err
 	}
 
 	return nil

--- a/benchmarks/kubectl-mtb/test/benchmarks/require_always_pull_image/README.md
+++ b/benchmarks/kubectl-mtb/test/benchmarks/require_always_pull_image/README.md
@@ -18,7 +18,7 @@ Require that the image pull policy is always set to to `Always` so that the user
 
 **Remediation:**
 
-Enable the AlwaysPullImages admission plugin in the kube-apiserver or create dynamic admission controller that enforces/mutates the `imagePullPolicy` to be `Always` for all Pods in the cluster.
+Enable the AlwaysPullImages admission plugin in the kube-apiserver or create a dynamic admission controller that enforces/mutates the `imagePullPolicy` to be `Always` for all Pods in the cluster.
 
 
 **namespaceRequired:** 

--- a/benchmarks/kubectl-mtb/test/benchmarks/require_always_pull_image/README.md
+++ b/benchmarks/kubectl-mtb/test/benchmarks/require_always_pull_image/README.md
@@ -14,11 +14,11 @@ Data Isolation
 
 **Description:**
 
-Set the image pull policy to `Always` so that the users an be assured that their private images can only be used by those who have the credentials to pull them.
+Require that the image pull policy is always set to to `Always` so that the users an be assured that their private images can only be used by those who have the credentials to pull them.
 
 **Remediation:**
 
-Set `imagePullPolicy` to `always` for the container or enable the AlwaysPullImages admission plugin.
+Enable the AlwaysPullImages admission plugin in the kube-apiserver or create dynamic admission controller that enforces/mutates the `imagePullPolicy` to be `Always` for all Pods in the cluster.
 
 
 **namespaceRequired:** 

--- a/benchmarks/kubectl-mtb/test/benchmarks/require_always_pull_image/README.md
+++ b/benchmarks/kubectl-mtb/test/benchmarks/require_always_pull_image/README.md
@@ -18,7 +18,7 @@ Set the image pull policy to `Always` so that the users an be assured that their
 
 **Remediation:**
 
-Set `imagePullPolicy` to `always` for the container.
+Set `imagePullPolicy` to `always` for the container or enable the AlwaysPullImages admission plugin.
 
 
 **namespaceRequired:** 

--- a/benchmarks/kubectl-mtb/test/benchmarks/require_always_pull_image/config.yaml
+++ b/benchmarks/kubectl-mtb/test/benchmarks/require_always_pull_image/config.yaml
@@ -4,5 +4,5 @@ benchmarkType: Configuration Check
 category: Data Isolation
 namespaceRequired: 1
 description: Require that the image pull policy is always set to to `Always` so that the users an be assured that their private images can only be used by those who have the credentials to pull them.
-remediation: Enable the AlwaysPullImages admission plugin in the kube-apiserver or create dynamic admission controller that enforces/mutates the `imagePullPolicy` to be `Always` for all Pods in the cluster.
+remediation: Enable the AlwaysPullImages admission plugin in the kube-apiserver or create a dynamic admission controller that enforces/mutates the `imagePullPolicy` to be `Always` for all Pods in the cluster.
 profileLevel: 1

--- a/benchmarks/kubectl-mtb/test/benchmarks/require_always_pull_image/config.yaml
+++ b/benchmarks/kubectl-mtb/test/benchmarks/require_always_pull_image/config.yaml
@@ -4,5 +4,5 @@ benchmarkType: Configuration Check
 category: Data Isolation
 namespaceRequired: 1
 description: Set the image pull policy to `Always` so that the users an be assured that their private images can only be used by those who have the credentials to pull them.
-remediation: Set `imagePullPolicy` to `always` for the container.
+remediation: Set `imagePullPolicy` to `always` for the container or enable the AlwaysPullImages admission plugin.
 profileLevel: 1

--- a/benchmarks/kubectl-mtb/test/benchmarks/require_always_pull_image/config.yaml
+++ b/benchmarks/kubectl-mtb/test/benchmarks/require_always_pull_image/config.yaml
@@ -3,6 +3,6 @@ title: Require always imagePullPolicy
 benchmarkType: Configuration Check
 category: Data Isolation
 namespaceRequired: 1
-description: Set the image pull policy to `Always` so that the users an be assured that their private images can only be used by those who have the credentials to pull them.
-remediation: Set `imagePullPolicy` to `always` for the container or enable the AlwaysPullImages admission plugin.
+description: Require that the image pull policy is always set to to `Always` so that the users an be assured that their private images can only be used by those who have the credentials to pull them.
+remediation: Enable the AlwaysPullImages admission plugin in the kube-apiserver or create dynamic admission controller that enforces/mutates the `imagePullPolicy` to be `Always` for all Pods in the cluster.
 profileLevel: 1


### PR DESCRIPTION
Fixes #1516 

This PR checks the kube-apiserver pod Command to determine if the [AlwaysPullImages admission plugin](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#alwayspullimages) is enabled. If it is, that is sufficient to satisfy the require_always_pull_image benchmark.

The Admission plugin works by allowing users to create pods with whatever imagePullPolicy they want, but it just modifies the value to "Always" before the pod starts up. As a result, without this PR, the benchmark fails unless you have some other validatingwebhook like gatekeeper enforcing the policy.